### PR TITLE
Oculta conteúdo da ficha clínica sem tutor e pet

### DIFF
--- a/pages/funcionarios/vet-ficha-clinica.html
+++ b/pages/funcionarios/vet-ficha-clinica.html
@@ -82,7 +82,7 @@
         </section>
 
         <!-- GRID principal: esquerda (prancha) + direita (cards do cliente e ações) -->
-        <div class="grid grid-cols-12 gap-6">
+        <div id="vet-ficha-content" class="grid grid-cols-12 gap-6 hidden">
             <!-- ESQUERDA -->
             <section class="col-span-12 lg:col-span-9">
                 <div class="bg-white rounded-xl shadow-sm ring-1 ring-black/5">

--- a/scripts/funcionarios/vet/ficha-clinica.js
+++ b/scripts/funcionarios/vet/ficha-clinica.js
@@ -44,13 +44,25 @@
         petClear: document.getElementById('vet-pet-clear'),
         tutorNome: document.getElementById('vet-tutor-nome'),
         tutorEmail: document.getElementById('vet-tutor-email'),
-        tutorTelefone: document.getElementById('vet-tutor-telefone')
+        tutorTelefone: document.getElementById('vet-tutor-telefone'),
+        pageContent: document.getElementById('vet-ficha-content')
     };
 
     const state = {
         selectedCliente: null,
         selectedPetId: null,
     };
+
+    function updatePageVisibility() {
+        if (!els.pageContent) return;
+        const hasTutor = !!(state.selectedCliente && state.selectedCliente._id);
+        const hasPet = !!state.selectedPetId;
+        if (hasTutor && hasPet) {
+            els.pageContent.classList.remove('hidden');
+        } else {
+            els.pageContent.classList.add('hidden');
+        }
+    }
 
     // --- busca clientes (igual fluxo da Agenda) ---
     async function searchClientes(term) {
@@ -92,6 +104,8 @@
 
     async function onSelectCliente(cli) {
         state.selectedCliente = cli || null;
+        state.selectedPetId = null;
+        updatePageVisibility();
         if (els.cliInput) els.cliInput.value = cli?.nome || '';
         hideSugestoes();
 
@@ -124,12 +138,14 @@
                 }
             }
         } catch { }
+        updatePageVisibility();
     }
 
     function onSelectPet(petId) {
         state.selectedPetId = petId || null;
         // aqui poderemos preencher outros campos específicos do pet, caso a página venha a ter (ex.: raça/porte).
         // por enquanto, mantemos o comportamento: seleção do pet no topo + tutor no card.
+        updatePageVisibility();
     }
 
     function clearCliente() {
@@ -139,14 +155,17 @@
         if (els.petSelect) {
             els.petSelect.innerHTML = `<option value="">Selecione o tutor para listar os pets</option>`;
         }
+        clearPet();
         if (els.tutorNome) els.tutorNome.textContent = 'Nome Tutor';
         if (els.tutorEmail) els.tutorEmail.textContent = '—';
         // não forçamos limpar telefone se a UI já tiver valor útil
+        updatePageVisibility();
     }
 
     function clearPet() {
         state.selectedPetId = null;
         if (els.petSelect) els.petSelect.value = '';
+        updatePageVisibility();
     }
 
     // --- eventos ---
@@ -168,4 +187,6 @@
     if (els.petClear) {
         els.petClear.addEventListener('click', (e) => { e.preventDefault(); clearPet(); });
     }
+
+    updatePageVisibility();
 })();


### PR DESCRIPTION
## Summary
- oculta o conteúdo principal da ficha clínica até que tutor e pet sejam selecionados
- adiciona lógica para alternar automaticamente a visibilidade do layout conforme seleção ou limpeza dos campos

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c845d0cc008323ba07c016a0a8bd25