### PR TITLE
Add quick add buttons per professional in agenda

### DIFF
--- a/scripts/funcionarios/banho-e-tosa.js
+++ b/scripts/funcionarios/banho-e-tosa.js
@@ -582,11 +582,32 @@
         else {
           // >>> centraliza o nome do profissional
           cell.style.textAlign = 'center';
+          const wrapper = document.createElement('div');
+          wrapper.className = 'flex items-center justify-center gap-2';
+
           const span = document.createElement('span');
           span.className = 'agenda-head-label inline-block';
           span.textContent = label || '';
-          cell.dataset.profId = String(profs[idx - 1]._id);
-          cell.appendChild(span);
+          wrapper.appendChild(span);
+
+          const prof = profs[idx - 1];
+          if (prof && prof._id) {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'agenda-head-add inline-flex h-6 w-6 items-center justify-center rounded-full bg-sky-500 text-white transition hover:bg-sky-600 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-1';
+            btn.textContent = '+';
+            btn.setAttribute('aria-label', `Adicionar agendamento para ${label}`);
+            btn.dataset.profId = String(prof._id);
+            btn.addEventListener('click', (ev) => {
+              ev.preventDefault();
+              ev.stopPropagation();
+              openAddModal(String(prof._id));
+            });
+            wrapper.appendChild(btn);
+          }
+
+          cell.dataset.profId = prof && prof._id ? String(prof._id) : '';
+          cell.appendChild(wrapper);
         }
         header.appendChild(cell);
       });
@@ -1041,7 +1062,14 @@
   }
 
   // Modal — modo adicionar
-  function openAddModal() {
+  function openAddModal(preselectProfId) {
+    let preselectedId = '';
+    if (preselectProfId && typeof preselectProfId === 'object' && typeof preselectProfId.preventDefault === 'function') {
+      preselectProfId.preventDefault?.();
+    } else if (preselectProfId != null) {
+      preselectedId = String(preselectProfId);
+    }
+
     state.editing = null;
     if (!modal) { console.warn('Modal #modal-add-servico não encontrado'); return; }
 
@@ -1075,7 +1103,7 @@
       addStoreSelect.value = sid;
 
       // Carrega os profissionais correspondentes à empresa escolhida no modal (sem travar a abertura)
-      try { if (sid) { populateModalProfissionais(sid); } } catch(_) {}
+      try { if (sid) { populateModalProfissionais(sid, preselectedId); } } catch(_) {}
     }
 
     // Data (usa a data visível na página)
@@ -1094,6 +1122,10 @@
 
     // Status default
     if (statusSelect) statusSelect.value = 'agendado';
+
+    if (preselectedId && profSelect) {
+      try { profSelect.value = preselectedId; } catch (_) {}
+    }
 
     // Botão Excluir só em edição
     if (modalDelete) modalDelete.classList.add('hidden');

--- a/scripts/funcionarios/banhoetosa/grid.js
+++ b/scripts/funcionarios/banhoetosa/grid.js
@@ -5,6 +5,7 @@ import {
   updateHeaderLabel, localDateStr, addDays, startOfWeek, startOfMonth, startOfNextMonth,
   renderStatusBadge, statusMeta
 } from './core.js';
+import { openAddModal } from './modal.js';
 
 export function renderGrid() {
   if (!els.agendaList) return;
@@ -35,11 +36,32 @@ export function renderGrid() {
       cell.textContent = label;
     } else {
       cell.style.textAlign = 'center';
+      const wrapper = document.createElement('div');
+      wrapper.className = 'flex items-center justify-center gap-2';
+
       const span = document.createElement('span');
       span.className = 'agenda-head-label inline-block';
       span.textContent = label || '';
-      cell.dataset.profId = String(profs[idx - 1]._id);
-      cell.appendChild(span);
+      wrapper.appendChild(span);
+
+      const prof = profs[idx - 1];
+      if (prof && prof._id) {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'agenda-head-add inline-flex h-6 w-6 items-center justify-center rounded-full bg-sky-500 text-white transition hover:bg-sky-600 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-1';
+        btn.textContent = '+';
+        btn.setAttribute('aria-label', `Adicionar agendamento para ${label}`);
+        btn.dataset.profId = String(prof._id);
+        btn.addEventListener('click', (ev) => {
+          ev.preventDefault();
+          ev.stopPropagation();
+          openAddModal(String(prof._id));
+        });
+        wrapper.appendChild(btn);
+      }
+
+      cell.dataset.profId = prof && prof._id ? String(prof._id) : '';
+      cell.appendChild(wrapper);
     }
     header.appendChild(cell);
   });

--- a/scripts/funcionarios/banhoetosa/grid.js
+++ b/scripts/funcionarios/banhoetosa/grid.js
@@ -48,8 +48,12 @@ export function renderGrid() {
       if (prof && prof._id) {
         const btn = document.createElement('button');
         btn.type = 'button';
-        btn.className = 'agenda-head-add inline-flex h-6 w-6 items-center justify-center rounded-full bg-sky-500 text-white transition hover:bg-sky-600 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-1';
-        btn.textContent = '+';
+        btn.className = 'agenda-head-add inline-flex h-7 w-7 items-center justify-center rounded-md border shadow-sm transition';
+        btn.innerHTML = `
+          <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" focusable="false">
+            <path fill-rule="evenodd" d="M10 3a.75.75 0 0 1 .75.75v5.5h5.5a.75.75 0 0 1 0 1.5h-5.5v5.5a.75.75 0 0 1-1.5 0v-5.5h-5.5a.75.75 0 0 1 0-1.5h5.5v-5.5A.75.75 0 0 1 10 3Z" clip-rule="evenodd" />
+          </svg>
+        `;
         btn.setAttribute('aria-label', `Adicionar agendamento para ${label}`);
         btn.dataset.profId = String(prof._id);
         btn.addEventListener('click', (ev) => {

--- a/scripts/funcionarios/banhoetosa/modal.js
+++ b/scripts/funcionarios/banhoetosa/modal.js
@@ -127,7 +127,15 @@ window.closeVendaModal = closeVendaModal;
 window.__openEditFromUI = (item) => openEditModal(item);
 window.__updateStatusQuick = (id, status) => updateStatusQuick(id, status);
 
-export function openAddModal() {
+export function openAddModal(preselectProfId) {
+  let preselectedId = '';
+  if (preselectProfId && typeof preselectProfId === 'object') {
+    if (typeof preselectProfId.preventDefault === 'function') {
+      try { preselectProfId.preventDefault(); } catch {}
+    }
+  } else if (preselectProfId != null) {
+    preselectedId = String(preselectProfId);
+  }
   state.editing = null;
   if (!els.modal) { console.warn('Modal #modal-add-servico nÃ£o encontrado'); return; }
   state.tempServicos = [];
@@ -151,7 +159,7 @@ export function openAddModal() {
     }
     const sid = state.selectedStoreId || els.storeSelect?.value || '';
     els.addStoreSelect.value = sid;
-    try { if (sid) { populateModalProfissionais(sid); } } catch{}
+    try { if (sid) { populateModalProfissionais(sid, preselectedId); } } catch{}
   }
   if (els.addDateInput) {
     const date = (els.dateInput?.value) || todayStr();
@@ -162,6 +170,9 @@ export function openAddModal() {
   if (els.horaInput) els.horaInput.value = hh;
   if (els.obsInput) { els.obsInput.value = ''; }
   if (els.statusSelect) els.statusSelect.value = 'agendado';
+  if (preselectedId && els.profSelect) {
+    try { els.profSelect.value = preselectedId; } catch {}
+  }
   if (els.modalDelete) els.modalDelete.classList.add('hidden');
   els.modal.classList.remove('hidden');
   els.modal.classList.add('flex');

--- a/src/input.css
+++ b/src/input.css
@@ -453,6 +453,36 @@
     overflow: hidden;
   }
 
+  /* Botão rápido no cabeçalho da agenda */
+  .agenda-head-add {
+    background: #ffffff;
+    color: var(--color-sky-600, #0284c7);
+    border-color: var(--color-sky-500, #0ea5e9);
+    box-shadow: 0 4px 10px -6px rgba(14, 165, 233, 0.55);
+    transition: background-color .18s ease, color .18s ease, transform .18s ease, box-shadow .18s ease;
+  }
+
+  .agenda-head-add svg {
+    display: block;
+  }
+
+  .agenda-head-add:hover {
+    background: var(--color-sky-500, #0ea5e9);
+    color: #ffffff;
+    transform: translateY(-1px);
+    box-shadow: 0 10px 18px -12px rgba(14, 165, 233, 0.9);
+  }
+
+  .agenda-head-add:active {
+    transform: translateY(0);
+    box-shadow: 0 6px 14px -10px rgba(14, 165, 233, 0.75);
+  }
+
+  .agenda-head-add:focus-visible {
+    outline: 2px solid rgba(14, 165, 233, 0.6);
+    outline-offset: 2px;
+  }
+
   /* Chips */
   .chip {
     display:inline-flex; align-items:center; gap:.35rem;

--- a/src/output.css
+++ b/src/output.css
@@ -46,6 +46,7 @@
     --color-sky-50: oklch(97.7% 0.013 236.62);
     --color-sky-100: oklch(95.1% 0.026 236.824);
     --color-sky-200: oklch(90.1% 0.058 230.902);
+    --color-sky-400: oklch(74.6% 0.16 232.661);
     --color-sky-500: oklch(68.5% 0.169 237.323);
     --color-sky-600: oklch(58.8% 0.158 241.966);
     --color-sky-700: oklch(50% 0.134 242.749);
@@ -866,9 +867,6 @@
   .max-w-3xl {
     max-width: var(--container-3xl);
   }
-  .max-w-\[10rem\] {
-    max-width: 10rem;
-  }
   .max-w-\[180px\] {
     max-width: 180px;
   }
@@ -1108,13 +1106,6 @@
       --tw-space-y-reverse: 0;
       margin-block-start: calc(calc(var(--spacing) * 6) * var(--tw-space-y-reverse));
       margin-block-end: calc(calc(var(--spacing) * 6) * calc(1 - var(--tw-space-y-reverse)));
-    }
-  }
-  .space-y-8 {
-    :where(& > :not(:last-child)) {
-      --tw-space-y-reverse: 0;
-      margin-block-start: calc(calc(var(--spacing) * 8) * var(--tw-space-y-reverse));
-      margin-block-end: calc(calc(var(--spacing) * 8) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
   .space-y-10 {
@@ -1493,6 +1484,9 @@
   }
   .bg-sky-100 {
     background-color: var(--color-sky-100);
+  }
+  .bg-sky-500 {
+    background-color: var(--color-sky-500);
   }
   .bg-sky-600 {
     background-color: var(--color-sky-600);
@@ -2500,6 +2494,13 @@
       }
     }
   }
+  .hover\:bg-sky-600 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-sky-600);
+      }
+    }
+  }
   .hover\:bg-slate-50 {
     &:hover {
       @media (hover: hover) {
@@ -2720,6 +2721,17 @@
       @supports (color: color-mix(in lab, red, red)) {
         --tw-ring-color: color-mix(in oklab, var(--color-primary) 40%, transparent);
       }
+    }
+  }
+  .focus\:ring-sky-400 {
+    &:focus {
+      --tw-ring-color: var(--color-sky-400);
+    }
+  }
+  .focus\:ring-offset-1 {
+    &:focus {
+      --tw-ring-offset-width: 1px;
+      --tw-ring-offset-shadow: var(--tw-ring-inset,) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
     }
   }
   .focus\:outline-none {
@@ -2968,9 +2980,29 @@
       grid-column: span 1 / span 1;
     }
   }
+  .lg\:col-span-2 {
+    @media (width >= 64rem) {
+      grid-column: span 2 / span 2;
+    }
+  }
   .lg\:col-span-3 {
     @media (width >= 64rem) {
       grid-column: span 3 / span 3;
+    }
+  }
+  .lg\:col-span-5 {
+    @media (width >= 64rem) {
+      grid-column: span 5 / span 5;
+    }
+  }
+  .lg\:col-span-6 {
+    @media (width >= 64rem) {
+      grid-column: span 6 / span 6;
+    }
+  }
+  .lg\:col-span-7 {
+    @media (width >= 64rem) {
+      grid-column: span 7 / span 7;
     }
   }
   .lg\:col-span-9 {
@@ -3003,6 +3035,16 @@
       grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
+  .lg\:grid-cols-4 {
+    @media (width >= 64rem) {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+  }
+  .lg\:grid-cols-12 {
+    @media (width >= 64rem) {
+      grid-template-columns: repeat(12, minmax(0, 1fr));
+    }
+  }
   .lg\:flex-row {
     @media (width >= 64rem) {
       flex-direction: row;
@@ -3021,6 +3063,31 @@
   .lg\:p-6 {
     @media (width >= 64rem) {
       padding: calc(var(--spacing) * 6);
+    }
+  }
+  .xl\:col-span-2 {
+    @media (width >= 80rem) {
+      grid-column: span 2 / span 2;
+    }
+  }
+  .xl\:col-span-3 {
+    @media (width >= 80rem) {
+      grid-column: span 3 / span 3;
+    }
+  }
+  .xl\:col-span-4 {
+    @media (width >= 80rem) {
+      grid-column: span 4 / span 4;
+    }
+  }
+  .xl\:col-span-7 {
+    @media (width >= 80rem) {
+      grid-column: span 7 / span 7;
+    }
+  }
+  .xl\:col-span-8 {
+    @media (width >= 80rem) {
+      grid-column: span 8 / span 8;
     }
   }
   .xl\:grid-cols-3 {
@@ -3461,6 +3528,30 @@
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
+  }
+  .agenda-head-add {
+    background: #ffffff;
+    color: var(--color-sky-600, #0284c7);
+    border-color: var(--color-sky-500, #0ea5e9);
+    box-shadow: 0 4px 10px -6px rgba(14, 165, 233, 0.55);
+    transition: background-color .18s ease, color .18s ease, transform .18s ease, box-shadow .18s ease;
+  }
+  .agenda-head-add svg {
+    display: block;
+  }
+  .agenda-head-add:hover {
+    background: var(--color-sky-500, #0ea5e9);
+    color: #ffffff;
+    transform: translateY(-1px);
+    box-shadow: 0 10px 18px -12px rgba(14, 165, 233, 0.9);
+  }
+  .agenda-head-add:active {
+    transform: translateY(0);
+    box-shadow: 0 6px 14px -10px rgba(14, 165, 233, 0.75);
+  }
+  .agenda-head-add:focus-visible {
+    outline: 2px solid rgba(14, 165, 233, 0.6);
+    outline-offset: 2px;
   }
   .chip {
     display: inline-flex;


### PR DESCRIPTION
## Summary
- add a quick "+" button next to each professional in the agenda header
- preselect the corresponding professional when opening the add service modal via the new button

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c8943382008323b39e21dbafb7b683