### PR TITLE
Atualiza rótulo de profissional conforme tipo selecionado

### DIFF
--- a/pages/funcionarios/banho-e-tosa.html
+++ b/pages/funcionarios/banho-e-tosa.html
@@ -152,7 +152,7 @@
             <input id="add-hora" type="time" class="w-full rounded-lg border-gray-300 focus:ring-primary focus:border-primary"/>
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Profissional (esteticista)</label>
+            <label id="add-prof-label" for="add-prof-select" class="block text-sm font-medium text-gray-700 mb-1">Profissional (esteticista)</label>
             <select id="add-prof-select" class="w-full rounded-lg border-gray-300 focus:ring-primary focus:border-primary"></select>
           </div>
         </div>

--- a/scripts/funcionarios/banhoetosa/core.js
+++ b/scripts/funcionarios/banhoetosa/core.js
@@ -63,6 +63,7 @@ export const els = {
   obsInput: document.getElementById('add-observacoes'),
   horaInput: document.getElementById('add-hora'),
   profSelect: document.getElementById('add-prof-select'),
+  profLabel: document.getElementById('add-prof-label'),
 };
 
 // ----- State -----

--- a/scripts/funcionarios/banhoetosa/modal.js
+++ b/scripts/funcionarios/banhoetosa/modal.js
@@ -1,5 +1,5 @@
 ﻿import { api, els, state, money, debounce, todayStr, pad, buildLocalDateTime, isPrivilegedRole } from './core.js';
-import { populateModalProfissionais } from './profissionais.js';
+import { populateModalProfissionais, updateModalProfissionalLabel } from './profissionais.js';
 import { loadAgendamentos } from './agendamentos.js';
 import { renderKpis, renderFilters } from './filters.js';
 import { renderGrid } from './grid.js';
@@ -172,6 +172,7 @@ export function openAddModal(preselectProfId) {
   if (els.statusSelect) els.statusSelect.value = 'agendado';
   if (preselectedId && els.profSelect) {
     try { els.profSelect.value = preselectedId; } catch {}
+    updateModalProfissionalLabel(preselectedId);
   }
   if (els.modalDelete) els.modalDelete.classList.add('hidden');
   els.modal.classList.remove('hidden');
@@ -230,7 +231,10 @@ export function openEditModal(a) {
     const match = state.profissionais.find(p => String(p.nome || '').trim().toLowerCase() === key);
     if (match) profId = String(match._id);
   }
-  if (els.profSelect && profId) els.profSelect.value = profId;
+  if (els.profSelect && profId) {
+    els.profSelect.value = profId;
+    updateModalProfissionalLabel(profId);
+  }
   try {
     const sid = els.addStoreSelect?.value || a.storeId || '';
     if (sid) { populateModalProfissionais(sid, profId); }
@@ -561,7 +565,14 @@ export function bindModalAndActionsEvents() {
   els.valorInput?.addEventListener('input', () => { try { els.valorInput.classList.remove('border-red-500'); const e=els.valorInput.parentElement.querySelector('.form-err'); if(e) e.remove(); } catch{} });
   els.addStoreSelect?.addEventListener('change', () => { try { els.addStoreSelect.classList.remove('border-red-500'); const e=els.addStoreSelect.parentElement.querySelector('.form-err'); if(e) e.remove(); } catch{} });
   els.horaInput?.addEventListener('input', () => { try { els.horaInput.classList.remove('border-red-500'); const e=els.horaInput.parentElement.querySelector('.form-err'); if(e) e.remove(); } catch{} });
-  els.profSelect?.addEventListener('change', () => { try { els.profSelect.classList.remove('border-red-500'); const e=els.profSelect.parentElement.querySelector('.form-err'); if(e) e.remove(); } catch{} });
+  els.profSelect?.addEventListener('change', () => {
+    try {
+      els.profSelect.classList.remove('border-red-500');
+      const e = els.profSelect.parentElement.querySelector('.form-err');
+      if (e) e.remove();
+    } catch {}
+    updateModalProfissionalLabel();
+  });
   els.addServAddBtn?.addEventListener('click', (e) => {
     e.preventDefault();
     const s = state.selectedServico;

--- a/scripts/funcionarios/banhoetosa/profissionais.js
+++ b/scripts/funcionarios/banhoetosa/profissionais.js
@@ -1,33 +1,103 @@
-﻿import { api, state, els } from './core.js';
+import { api, state, els } from './core.js';
+
+const DEFAULT_PROF_TYPE = 'esteticista';
+const TYPE_LABELS = {
+  esteticista: 'esteticista',
+  veterinario: 'veterinário',
+  banhista: 'banhista',
+  tosador: 'tosador',
+};
+
+let modalProfissionais = [];
+
+function normalizeProfissionais(list) {
+  return (Array.isArray(list) ? list : []).map((p) => {
+    const id = p && p._id != null ? String(p._id) : '';
+    const rawTipo = p && p.tipo != null ? String(p.tipo) : '';
+    const tipo = rawTipo.trim() ? rawTipo : DEFAULT_PROF_TYPE;
+    return { ...p, _id: id, tipo };
+  });
+}
+
+function renderProfOptions(list) {
+  if (!els.profSelect) return;
+  els.profSelect.innerHTML = list
+    .map((p) => `<option value="${p._id || ''}">${p.nome || ''}</option>`)
+    .join('');
+}
+
+function labelForTipo(tipo) {
+  const key = String(tipo || '').trim().toLowerCase();
+  if (!key) return TYPE_LABELS[DEFAULT_PROF_TYPE];
+  return TYPE_LABELS[key] || key;
+}
+
+export function updateModalProfissionalLabel(preferredId) {
+  if (!els.profLabel) return;
+  const arr = modalProfissionais || [];
+  const currentId = preferredId != null ? String(preferredId) : (els.profSelect?.value || '');
+  let tipo = '';
+  if (currentId) {
+    const match = arr.find((p) => String(p._id) === currentId);
+    if (match) tipo = match.tipo || '';
+  }
+  if (!tipo && arr.length) {
+    tipo = arr[0].tipo || '';
+  }
+  const label = labelForTipo(tipo);
+  els.profLabel.textContent = `Profissional (${label})`;
+}
+
+function applyModalProfissionais(list, preselectId) {
+  modalProfissionais = normalizeProfissionais(list);
+  renderProfOptions(modalProfissionais);
+  const pid = preselectId != null ? String(preselectId) : '';
+  if (els.profSelect) {
+    if (pid && modalProfissionais.some((p) => String(p._id) === pid)) {
+      els.profSelect.value = pid;
+    } else if (modalProfissionais[0] && modalProfissionais[0]._id) {
+      els.profSelect.value = modalProfissionais[0]._id;
+    } else if (els.profSelect.options.length) {
+      els.profSelect.selectedIndex = 0;
+    }
+  }
+  updateModalProfissionalLabel(preselectId);
+}
 
 export async function populateModalProfissionais(storeId, preselectId) {
   try {
-    if (!storeId || !els.profSelect) return;
+    if (!storeId || !els.profSelect) {
+      updateModalProfissionalLabel(preselectId);
+      return;
+    }
     const resp = await api(`/func/profissionais?storeId=${storeId}`);
     const list = await resp.json().catch(() => []);
-    const arr = Array.isArray(list) ? list : [];
-    els.profSelect.innerHTML = arr.map(p => `<option value="${p._id}">${p.nome}</option>`).join('');
-    const pid = preselectId ? String(preselectId) : '';
-    if (pid && arr.some(p => String(p._id) === pid)) {
-      els.profSelect.value = pid;
-    } else if (arr[0]) {
-      els.profSelect.value = String(arr[0]._id);
-    }
-  } catch {}
+    applyModalProfissionais(list, preselectId);
+  } catch {
+    updateModalProfissionalLabel(preselectId);
+  }
 }
 
 export async function loadProfissionais() {
   if (!state.selectedStoreId) {
     state.profissionais = [];
+    modalProfissionais = [];
     if (els.profSelect) els.profSelect.innerHTML = '';
+    updateModalProfissionalLabel();
     return;
   }
   const resp = await api(`/func/profissionais?storeId=${state.selectedStoreId}`);
   const list = await resp.json().catch(() => []);
-  state.profissionais = (Array.isArray(list) ? list : []).map(p => ({ ...p, tipo: p.tipo || 'esteticista' }));
+  state.profissionais = normalizeProfissionais(list);
+  modalProfissionais = state.profissionais.slice();
   if (els.profSelect) {
-    els.profSelect.innerHTML = state.profissionais
-      .map(p => `<option value="${p._id}">${p.nome}</option>`)
-      .join('');
+    const prevValue = els.profSelect.value;
+    renderProfOptions(state.profissionais);
+    if (prevValue && state.profissionais.some((p) => String(p._id) === prevValue)) {
+      els.profSelect.value = prevValue;
+    } else if (els.profSelect.options.length) {
+      els.profSelect.selectedIndex = 0;
+    }
   }
+  updateModalProfissionalLabel();
 }


### PR DESCRIPTION
## Summary
- altera o rótulo do campo de profissional para refletir o tipo do profissional selecionado no modal da agenda
- ajusta os carregamentos e eventos do modal para manter o texto atualizado quando a lista ou a seleção de profissionais muda

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c97414a87c8323bb6b1cfbff8e7b64