### PR TITLE
Add ficha clínica shortcut chip to agenda cards

### DIFF
--- a/pages/funcionarios/vet-ficha-clinica.html
+++ b/pages/funcionarios/vet-ficha-clinica.html
@@ -89,9 +89,10 @@
                     <!-- Toolbar interna (Histórico/Consulta) -->
                     <div class="px-4 py-3 border-b border-gray-100 flex items-center gap-3">
                         <div class="flex items-center gap-2">
-                            <button
+                            <button id="vet-tab-historico" type="button"
                                 class="px-3 py-1.5 rounded-md text-[13px] bg-gray-100 text-gray-700">Histórico</button>
-                            <button class="px-3 py-1.5 rounded-md text-[13px] bg-sky-600 text-white">Consulta</button>
+                            <button id="vet-tab-consulta" type="button"
+                                class="px-3 py-1.5 rounded-md text-[13px] bg-sky-600 text-white">Consulta</button>
                         </div>
                         <div class="ml-auto flex items-center gap-2">
                             <button
@@ -105,8 +106,10 @@
                     <!-- Corpo com “quadro” e coluna LOG à direita -->
                     <div class="relative">
                         <div class="p-4 lg:p-6 min-h-[520px] bg-gray-50 rounded-b-xl">
-                            <!-- espaço de conteúdo da consulta -->
-                            <div class="h-[420px] rounded-lg bg-white border border-dashed border-gray-300"></div>
+                            <div id="vet-consulta-area"
+                                class="h-[420px] rounded-lg bg-white border border-dashed border-gray-300 flex flex-col items-center justify-center text-sm text-gray-500 text-center px-6">
+                                Selecione um agendamento na agenda para carregar os serviços veterinários.
+                            </div>
                         </div>
 
                         <!-- Coluna LOG (fixa dentro do card) -->

--- a/scripts/funcionarios/banhoetosa/grid.js
+++ b/scripts/funcionarios/banhoetosa/grid.js
@@ -180,6 +180,29 @@ function normalizeCategories(value) {
   return str ? [str] : [];
 }
 
+function normalizeStaffTypes(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    const arr = value
+      .map(item => {
+        if (!item) return '';
+        if (typeof item === 'object') {
+          if (item.tipo) return String(item.tipo).trim();
+          if (item.nome) return String(item.nome).trim();
+        }
+        return String(item).trim();
+      })
+      .filter(Boolean);
+    return Array.from(new Set(arr));
+  }
+  if (typeof value === 'object' && (value.tipo || value.nome)) {
+    const arr = [String(value.tipo || value.nome).trim()].filter(Boolean);
+    return Array.from(new Set(arr));
+  }
+  const str = String(value || '').trim();
+  return str ? [str] : [];
+}
+
 function normalizeServiceEntry(entry, fallbackNome = '', fallbackValor = null) {
   if (!entry) return null;
   const id = normalizeId(entry._id || entry.id || entry.servico || entry.servicoId);
@@ -199,12 +222,23 @@ function normalizeServiceEntry(entry, fallbackNome = '', fallbackValor = null) {
   const categorias = normalizeCategories(
     entry.categorias || entry.categoria || entry.category || entry.categoriaPrincipal || entry?.servico?.categorias
   );
+  const tiposPermitidos = normalizeStaffTypes(
+    entry.tiposPermitidos
+      || entry.allowedTipos
+      || entry.allowedStaffTypes
+      || entry.allowedStaff
+      || entry.grupoTiposPermitidos
+      || entry?.grupo?.tiposPermitidos
+      || entry?.servico?.tiposPermitidos
+      || entry?.servico?.grupo?.tiposPermitidos
+  );
   if (!nome && !id) return null;
   return {
     _id: id || null,
     nome,
     valor,
     categorias,
+    tiposPermitidos,
   };
 }
 
@@ -221,7 +255,10 @@ function extractAppointmentServices(appointment) {
       _id: appointment.servicoId || appointment.servico?._id || appointment.servico,
       nome: appointment.servico || appointment.servicoNome || appointment?.servico?.nome,
       valor: appointment.valor,
-      categorias: appointment?.servico?.categorias || appointment.categorias || appointment.categoria
+      categorias: appointment?.servico?.categorias || appointment.categorias || appointment.categoria,
+      tiposPermitidos: appointment?.servico?.tiposPermitidos
+        || appointment?.servico?.grupo?.tiposPermitidos
+        || appointment.tiposPermitidos
     }, appointment.servico || '', appointment.valor);
     if (fallback) services.push(fallback);
   }

--- a/scripts/funcionarios/vet/ficha-clinica.js
+++ b/scripts/funcionarios/vet/ficha-clinica.js
@@ -70,7 +70,10 @@
         petMicrochip: document.getElementById('vet-pet-microchip'),
         toggleTutor: document.getElementById('vet-card-show-tutor'),
         togglePet: document.getElementById('vet-card-show-pet'),
-        pageContent: document.getElementById('vet-ficha-content')
+        pageContent: document.getElementById('vet-ficha-content'),
+        consultaArea: document.getElementById('vet-consulta-area'),
+        historicoTab: document.getElementById('vet-tab-historico'),
+        consultaTab: document.getElementById('vet-tab-consulta')
     };
 
     const state = {
@@ -78,17 +81,28 @@
         selectedPetId: null,
         petsById: {},
         currentCardMode: 'tutor',
+        agendaContext: null,
     };
 
     const STORAGE_KEYS = {
         cliente: 'vetFichaSelectedCliente',
         petId: 'vetFichaSelectedPetId',
+        agenda: 'vetFichaAgendaContext',
     };
 
     const CARD_TUTOR_ACTIVE_CLASSES = ['bg-sky-100', 'text-sky-700'];
     const CARD_PET_ACTIVE_CLASSES = ['bg-emerald-100', 'text-emerald-700'];
     const CARD_BUTTON_INACTIVE_CLASSES = ['bg-gray-100', 'text-gray-600'];
     const CARD_BUTTON_DISABLED_CLASSES = ['opacity-50', 'cursor-not-allowed'];
+    const CONSULTA_PLACEHOLDER_CLASSNAMES = 'h-[420px] rounded-lg bg-white border border-dashed border-gray-300 flex flex-col items-center justify-center text-sm text-gray-500 text-center px-6';
+    const CONSULTA_CARD_CLASSNAMES = 'h-[420px] rounded-lg bg-white border border-gray-200 shadow-sm overflow-hidden';
+    const CONSULTA_PLACEHOLDER_TEXT = 'Selecione um agendamento na agenda para carregar os serviços veterinários.';
+    const STATUS_LABELS = {
+        agendado: 'Agendado',
+        em_espera: 'Em espera',
+        em_atendimento: 'Em atendimento',
+        finalizado: 'Finalizado',
+    };
     const PET_PLACEHOLDERS = {
         nome: 'Nome do Pet',
         tipo: '—',
@@ -115,6 +129,16 @@
                 .toLowerCase();
         }
         return str.toLowerCase();
+    }
+
+    function normalizeId(value) {
+        if (value === null || value === undefined) return '';
+        if (typeof value === 'object') {
+            if (value._id) return String(value._id).trim();
+            if (value.id) return String(value.id).trim();
+        }
+        if (typeof value === 'number') return String(value);
+        return String(value).trim();
     }
 
     function capitalize(value) {
@@ -216,7 +240,17 @@
             }
         } catch { }
         const petId = localStorage.getItem(STORAGE_KEYS.petId) || null;
-        return { cliente, petId };
+        let agendaContext = null;
+        try {
+            const rawAgenda = localStorage.getItem(STORAGE_KEYS.agenda);
+            if (rawAgenda) {
+                const parsedAgenda = JSON.parse(rawAgenda);
+                if (parsedAgenda && typeof parsedAgenda === 'object') {
+                    agendaContext = parsedAgenda;
+                }
+            }
+        } catch { }
+        return { cliente, petId, agendaContext };
     }
 
     function updatePageVisibility() {
@@ -241,6 +275,21 @@
         }
     }
 
+    function formatDateTimeDisplay(value) {
+        if (!value) return '';
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return '';
+        try {
+            const dateStr = new Intl.DateTimeFormat('pt-BR', { day: '2-digit', month: '2-digit', year: 'numeric' }).format(date);
+            const timeStr = new Intl.DateTimeFormat('pt-BR', { hour: '2-digit', minute: '2-digit' }).format(date);
+            return `${dateStr} às ${timeStr}`;
+        } catch {
+            const dateStr = date.toLocaleDateString('pt-BR');
+            const timeStr = date.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
+            return `${dateStr} às ${timeStr}`;
+        }
+    }
+
     function formatPetWeight(value) {
         if (value === null || value === undefined || value === '') return '';
         const num = Number(value);
@@ -250,6 +299,70 @@
         const str = String(value).trim();
         if (!str) return '';
         return /kg$/i.test(str) ? str : `${str} Kg`;
+    }
+
+    function formatMoney(value) {
+        const num = Number(value || 0);
+        if (Number.isNaN(num)) return 'R$ 0,00';
+        try {
+            return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(num);
+        } catch {
+            return `R$ ${num.toFixed(2).replace('.', ',')}`;
+        }
+    }
+
+    function isVetCategory(value) {
+        const norm = normalizeForCompare(value);
+        if (!norm) return false;
+        return norm.replace(/[^a-z]/g, '').includes('veterinario');
+    }
+
+    function isVetService(service) {
+        if (!service) return false;
+        const categories = [];
+        if (Array.isArray(service.categorias)) categories.push(...service.categorias);
+        if (Array.isArray(service.category)) categories.push(...service.category);
+        if (service.categoria) categories.push(service.categoria);
+        if (Array.isArray(service?.servico?.categorias)) categories.push(...service.servico.categorias);
+        if (service.grupoNome) categories.push(service.grupoNome);
+        if (service.grupo && service.grupo.nome) categories.push(service.grupo.nome);
+        if (categories.some(isVetCategory)) return true;
+        const nomeNorm = normalizeForCompare(service.nome || service.descricao || service.titulo || '');
+        if (nomeNorm.includes('veterin')) return true;
+        return false;
+    }
+
+    function mapServiceForDisplay(service) {
+        if (!service) return null;
+        const nome = pickFirst(
+            service.nome,
+            service.descricao,
+            service.titulo,
+            typeof service === 'string' ? service : ''
+        );
+        return {
+            _id: normalizeId(service._id || service.id || service.servico || service.servicoId),
+            nome: nome || '—',
+            valor: Number(service.valor || 0),
+        };
+    }
+
+    function getVetServices(list) {
+        if (!Array.isArray(list)) return [];
+        return list
+            .filter(isVetService)
+            .map(mapServiceForDisplay)
+            .filter(Boolean);
+    }
+
+    function getStatusKey(status) {
+        if (!status) return '';
+        return String(status).trim().toLowerCase().replace(/\s+/g, '_');
+    }
+
+    function getStatusLabel(status) {
+        const key = getStatusKey(status);
+        return STATUS_LABELS[key] || (status ? capitalize(status) : '');
     }
 
     function getSelectedPet() {
@@ -326,6 +439,159 @@
         }
     }
 
+    function setConsultaTabActive() {
+        if (els.consultaTab) {
+            els.consultaTab.classList.remove('bg-gray-100', 'text-gray-700', 'hover:bg-gray-50');
+            els.consultaTab.classList.add('bg-sky-600', 'text-white');
+        }
+        if (els.historicoTab) {
+            els.historicoTab.classList.remove('bg-sky-600', 'text-white');
+            els.historicoTab.classList.add('bg-gray-100', 'text-gray-700', 'hover:bg-gray-50');
+        }
+    }
+
+    function updateConsultaAgendaCard() {
+        const area = els.consultaArea;
+        if (!area) return;
+        setConsultaTabActive();
+
+        const applyPlaceholder = (message = CONSULTA_PLACEHOLDER_TEXT) => {
+            area.className = CONSULTA_PLACEHOLDER_CLASSNAMES;
+            area.innerHTML = '';
+            const paragraph = document.createElement('p');
+            paragraph.textContent = message;
+            area.appendChild(paragraph);
+        };
+
+        const context = state.agendaContext;
+        const selectedPetId = normalizeId(state.selectedPetId);
+        const selectedTutorId = normalizeId(state.selectedCliente?._id);
+        const contextPetId = normalizeId(context?.petId);
+        const contextTutorId = normalizeId(context?.tutorId);
+
+        if (!context || !selectedPetId || !selectedTutorId || !contextPetId || !contextTutorId || contextPetId !== selectedPetId || contextTutorId !== selectedTutorId) {
+            applyPlaceholder();
+            return;
+        }
+
+        const allServices = Array.isArray(context.servicos) ? context.servicos : [];
+        const vetServices = getVetServices(allServices);
+        const filteredOut = Math.max(allServices.length - vetServices.length, 0);
+
+        if (!vetServices.length) {
+            area.className = `${CONSULTA_CARD_CLASSNAMES} flex flex-col items-center justify-center p-5`;
+            area.innerHTML = '';
+            const emptyBox = document.createElement('div');
+            emptyBox.className = 'w-full rounded-xl border border-dashed border-slate-300 bg-slate-50 px-6 py-8 text-center text-sm text-slate-600';
+            emptyBox.textContent = 'Nenhum serviço veterinário encontrado para este agendamento.';
+            area.appendChild(emptyBox);
+            if (filteredOut > 0) {
+                const note = document.createElement('p');
+                note.className = 'mt-3 text-xs text-slate-500 text-center';
+                note.textContent = `${filteredOut} serviço(s) de outras categorias foram ocultados.`;
+                area.appendChild(note);
+            }
+            return;
+        }
+
+        area.className = CONSULTA_CARD_CLASSNAMES;
+        area.innerHTML = '';
+        const scroll = document.createElement('div');
+        scroll.className = 'h-full w-full overflow-y-auto p-5';
+        area.appendChild(scroll);
+
+        const card = document.createElement('div');
+        card.className = 'bg-white border border-gray-200 rounded-xl shadow-sm p-4 space-y-4';
+        scroll.appendChild(card);
+
+        const header = document.createElement('div');
+        header.className = 'flex flex-wrap items-start justify-between gap-3';
+        card.appendChild(header);
+
+        const info = document.createElement('div');
+        header.appendChild(info);
+
+        const title = document.createElement('h3');
+        title.className = 'text-base font-semibold text-gray-800';
+        title.textContent = 'Serviços veterinários agendados';
+        info.appendChild(title);
+
+        const metaList = document.createElement('div');
+        metaList.className = 'mt-1 space-y-1 text-sm text-gray-600';
+        const when = formatDateTimeDisplay(context.scheduledAt);
+        if (when) {
+            const whenEl = document.createElement('div');
+            whenEl.textContent = `Atendimento em ${when}`;
+            metaList.appendChild(whenEl);
+        }
+        if (context.profissionalNome) {
+            const profEl = document.createElement('div');
+            profEl.textContent = `Profissional: ${context.profissionalNome}`;
+            metaList.appendChild(profEl);
+        }
+        if (metaList.children.length) info.appendChild(metaList);
+
+        if (context.status) {
+            const statusEl = document.createElement('span');
+            statusEl.className = 'inline-flex items-center rounded-full border border-slate-200 bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700';
+            statusEl.textContent = getStatusLabel(context.status);
+            header.appendChild(statusEl);
+        }
+
+        const list = document.createElement('div');
+        list.className = 'rounded-lg border border-gray-200 overflow-hidden';
+        card.appendChild(list);
+
+        let total = 0;
+        vetServices.forEach((service, idx) => {
+            const row = document.createElement('div');
+            row.className = 'flex items-center justify-between px-4 py-2 text-sm text-gray-700 bg-white';
+            if (idx > 0) row.classList.add('border-t', 'border-gray-200');
+            const nameEl = document.createElement('span');
+            nameEl.className = 'pr-3';
+            nameEl.textContent = service.nome || '—';
+            const valueEl = document.createElement('span');
+            valueEl.className = 'font-semibold text-gray-900';
+            valueEl.textContent = formatMoney(service.valor);
+            row.appendChild(nameEl);
+            row.appendChild(valueEl);
+            list.appendChild(row);
+            total += Number(service.valor || 0);
+        });
+
+        const totalRow = document.createElement('div');
+        totalRow.className = 'flex items-center justify-between rounded-lg bg-slate-50 px-4 py-3 text-sm font-semibold text-gray-800 border border-gray-200';
+        const totalLabel = document.createElement('span');
+        totalLabel.textContent = 'Total dos serviços';
+        const totalValue = document.createElement('span');
+        totalValue.textContent = formatMoney(total);
+        totalRow.appendChild(totalLabel);
+        totalRow.appendChild(totalValue);
+        card.appendChild(totalRow);
+
+        if (filteredOut > 0) {
+            const note = document.createElement('p');
+            note.className = 'text-xs text-gray-500';
+            note.textContent = `${filteredOut} serviço(s) de outras categorias foram ocultados.`;
+            card.appendChild(note);
+        }
+
+        if (context.observacoes) {
+            const obsWrap = document.createElement('div');
+            obsWrap.className = 'rounded-lg border border-gray-200 bg-slate-50 p-3';
+            const obsTitle = document.createElement('div');
+            obsTitle.className = 'text-xs font-semibold uppercase tracking-wide text-gray-500';
+            obsTitle.textContent = 'Observações';
+            const obsText = document.createElement('p');
+            obsText.className = 'mt-1 text-sm text-gray-700';
+            obsText.style.whiteSpace = 'pre-line';
+            obsText.textContent = context.observacoes;
+            obsWrap.appendChild(obsTitle);
+            obsWrap.appendChild(obsText);
+            card.appendChild(obsWrap);
+        }
+    }
+
     function updateCardDisplay() {
         const pet = getSelectedPet();
         const hasPet = !!pet;
@@ -349,6 +615,7 @@
             els.cardIconSymbol.className = `fas ${showPet ? 'fa-paw' : 'fa-user'} text-xl`;
         }
         updateToggleButtons(showPet, hasPet);
+        updateConsultaAgendaCard();
     }
 
     function setCardMode(mode) {
@@ -404,6 +671,13 @@
         state.selectedPetId = null;
         state.petsById = {};
         state.currentCardMode = 'tutor';
+        const tutorId = normalizeId(cli?._id);
+        if (state.agendaContext) {
+            const contextTutorId = normalizeId(state.agendaContext.tutorId);
+            if (!tutorId || !contextTutorId || contextTutorId !== tutorId) {
+                state.agendaContext = null;
+            }
+        }
         if (!skipPersistCliente) {
             persistCliente(state.selectedCliente);
         }
@@ -411,6 +685,7 @@
             persistPetId(null);
         }
         updatePageVisibility();
+        updateConsultaAgendaCard();
         if (els.cliInput) els.cliInput.value = cli?.nome || '';
         hideSugestoes();
 
@@ -482,6 +757,8 @@
         state.selectedCliente = null;
         state.petsById = {};
         state.currentCardMode = 'tutor';
+        state.agendaContext = null;
+        try { localStorage.removeItem(STORAGE_KEYS.agenda); } catch { }
         if (els.cliInput) els.cliInput.value = '';
         hideSugestoes();
         if (els.petSelect) {
@@ -493,6 +770,7 @@
         // não forçamos limpar telefone se a UI já tiver valor útil
         persistCliente(null);
         updatePageVisibility();
+        updateConsultaAgendaCard();
     }
 
     function clearPet() {
@@ -505,7 +783,18 @@
     }
 
     function restorePersistedSelection() {
-        const { cliente, petId } = getPersistedState();
+        const { cliente, petId, agendaContext } = getPersistedState();
+        state.agendaContext = agendaContext || null;
+        if (state.agendaContext && cliente) {
+            const contextTutorId = normalizeId(state.agendaContext.tutorId);
+            const clienteId = normalizeId(cliente._id);
+            if (!contextTutorId || !clienteId || contextTutorId !== clienteId) {
+                state.agendaContext = null;
+            }
+        } else if (state.agendaContext && !cliente) {
+            state.agendaContext = null;
+        }
+        updateConsultaAgendaCard();
         if (cliente) {
             onSelectCliente(cliente, {
                 clearPersistedPet: false,

--- a/scripts/funcionarios/vet/ficha-clinica.js
+++ b/scripts/funcionarios/vet/ficha-clinica.js
@@ -326,6 +326,17 @@
         if (Array.isArray(service?.servico?.categorias)) categories.push(...service.servico.categorias);
         if (service.grupoNome) categories.push(service.grupoNome);
         if (service.grupo && service.grupo.nome) categories.push(service.grupo.nome);
+        if (Array.isArray(service.tiposPermitidos)) categories.push(...service.tiposPermitidos);
+        if (Array.isArray(service.allowedTipos)) categories.push(...service.allowedTipos);
+        if (Array.isArray(service.allowedStaffTypes)) categories.push(...service.allowedStaffTypes);
+        if (Array.isArray(service.allowedStaff)) categories.push(...service.allowedStaff);
+        if (Array.isArray(service.grupoTiposPermitidos)) categories.push(...service.grupoTiposPermitidos);
+        if (Array.isArray(service?.grupo?.tiposPermitidos)) categories.push(...service.grupo.tiposPermitidos);
+        if (Array.isArray(service?.servico?.tiposPermitidos)) categories.push(...service.servico.tiposPermitidos);
+        if (Array.isArray(service?.servico?.grupo?.tiposPermitidos)) categories.push(...service.servico.grupo.tiposPermitidos);
+        if (service.tipoPermitido) categories.push(service.tipoPermitido);
+        if (service.staffTipo) categories.push(service.staffTipo);
+        if (service.tipo) categories.push(service.tipo);
         if (categories.some(isVetCategory)) return true;
         const nomeNorm = normalizeForCompare(service.nome || service.descricao || service.titulo || '');
         if (nomeNorm.includes('veterin')) return true;

--- a/servidor/routes/funcAgenda.js
+++ b/servidor/routes/funcAgenda.js
@@ -668,13 +668,21 @@ router.get('/clientes/:id', authMiddleware, requireStaff, async (req, res) => {
       return res.status(400).json({ message: 'ID inválido.' });
     }
     const u = await User.findById(id)
-      .select('_id nomeCompleto nomeContato razaoSocial email')
+      .select('_id nomeCompleto nomeContato razaoSocial email celular telefone')
       .lean();
     if (!u) {
       return res.status(404).json({ message: 'Cliente não encontrado.' });
     }
     const nome = u.nomeCompleto || u.nomeContato || u.razaoSocial || u.email || '';
-    res.json({ _id: u._id, nome });
+    const celular = u.celular || u.telefone || '';
+    const telefone = u.telefone || '';
+    res.json({
+      _id: u._id,
+      nome,
+      email: u.email || '',
+      celular,
+      telefone,
+    });
   } catch (e) {
     console.error('GET /func/clientes/:id', e);
     res.status(500).json({ message: 'Erro ao buscar cliente.' });

--- a/servidor/routes/funcAgenda.js
+++ b/servidor/routes/funcAgenda.js
@@ -117,8 +117,8 @@ router.put('/agendamentos/:id', authMiddleware, requireStaff, async (req, res) =
     const full = await Appointment.findByIdAndUpdate(id, { $set: set }, { new: true })
       .select('_id store cliente pet servico itens profissional scheduledAt valor pago codigoVenda status observacoes')
       .populate('pet', 'nome')
-      .populate('servico', 'nome')
-      .populate('itens.servico', 'nome')
+      .populate('servico', 'nome categorias')
+      .populate('itens.servico', 'nome categorias')
       .populate('profissional', 'nomeCompleto nomeContato razaoSocial')
       .lean();
 
@@ -126,7 +126,24 @@ router.put('/agendamentos/:id', authMiddleware, requireStaff, async (req, res) =
       return res.status(404).json({ message: 'Agendamento não encontrado.' });
     }
 
-    const servicosList = (full.itens || []).map(it => ({ _id: it.servico?._id || it.servico, nome: it.servico?.nome || '—', valor: Number(it.valor || 0) }));
+    const servicosList = (full.itens || []).map(it => ({
+      _id: it.servico?._id || it.servico,
+      nome: it.servico?.nome || '—',
+      valor: Number(it.valor || 0),
+      categorias: Array.isArray(it.servico?.categorias)
+        ? it.servico.categorias.filter(Boolean)
+        : []
+    }));
+    if (!servicosList.length && full.servico) {
+      servicosList.push({
+        _id: full.servico?._id || full.servico,
+        nome: full.servico?.nome || '—',
+        valor: Number(full.valor || 0),
+        categorias: Array.isArray(full.servico?.categorias)
+          ? full.servico.categorias.filter(Boolean)
+          : []
+      });
+    }
     const servicosStr = servicosList.map(s => s.nome).join(', ');
 
     return res.json({
@@ -383,8 +400,8 @@ router.get('/agendamentos', authMiddleware, requireStaff, async (req, res) => {
       .select('_id store cliente pet servico itens profissional scheduledAt valor pago codigoVenda status observacoes')
       .populate('cliente', 'nomeCompleto nomeContato razaoSocial email')
       .populate('pet', 'nome')
-      .populate('servico', 'nome')
-      .populate('itens.servico', 'nome')
+      .populate('servico', 'nome categorias')
+      .populate('itens.servico', 'nome categorias')
       .populate('profissional', 'nomeCompleto nomeContato razaoSocial')
       .sort({ scheduledAt: 1 })
       .lean();
@@ -394,8 +411,22 @@ router.get('/agendamentos', authMiddleware, requireStaff, async (req, res) => {
 
       const itens = Array.isArray(a.itens) ? a.itens : [];
       const servicosList = itens.length
-        ? itens.map(it => ({ _id: it.servico?._id || it.servico || null, nome: it.servico?.nome || '—', valor: Number(it.valor || 0) }))
-        : (a.servico ? [{ _id: a.servico?._id || a.servico, nome: a.servico?.nome || '—', valor: Number(a.valor || 0) }] : []);
+        ? itens.map(it => ({
+          _id: it.servico?._id || it.servico || null,
+          nome: it.servico?.nome || '—',
+          valor: Number(it.valor || 0),
+          categorias: Array.isArray(it.servico?.categorias)
+            ? it.servico.categorias.filter(Boolean)
+            : []
+        }))
+        : (a.servico ? [{
+          _id: a.servico?._id || a.servico,
+          nome: a.servico?.nome || '—',
+          valor: Number(a.valor || 0),
+          categorias: Array.isArray(a.servico?.categorias)
+            ? a.servico.categorias.filter(Boolean)
+            : []
+        }] : []);
       const servicosStr = servicosList.map(s => s.nome).join(', ');
       const valorTotal = (servicosList.reduce((s, x) => s + Number(x.valor || 0), 0)) || Number(a.valor || 0) || 0;
 
@@ -445,14 +476,31 @@ router.get('/agendamentos/range', authMiddleware, requireStaff, async (req, res)
       .select('_id store cliente pet servico itens profissional scheduledAt valor pago codigoVenda status observacoes')
       .populate('cliente', 'nomeCompleto nomeContato razaoSocial email')
       .populate('pet', 'nome')
-      .populate('servico', 'nome')
-      .populate('itens.servico', 'nome')
+      .populate('servico', 'nome categorias')
+      .populate('itens.servico', 'nome categorias')
       .populate('profissional', 'nomeCompleto nomeContato razaoSocial')
       .sort({ scheduledAt: 1 })
       .lean();
 
     const map = (list || []).map(a => {
-      const servicosList = (a.itens || []).map(it => ({ _id: it.servico?._id, nome: it.servico?.nome || '—', valor: Number(it.valor || 0) }));
+      const servicosList = (a.itens || []).map(it => ({
+        _id: it.servico?._id,
+        nome: it.servico?.nome || '—',
+        valor: Number(it.valor || 0),
+        categorias: Array.isArray(it.servico?.categorias)
+          ? it.servico.categorias.filter(Boolean)
+          : []
+      }));
+      if (!servicosList.length && a.servico) {
+        servicosList.push({
+          _id: a.servico?._id || a.servico,
+          nome: a.servico?.nome || '—',
+          valor: Number(a.valor || 0),
+          categorias: Array.isArray(a.servico?.categorias)
+            ? a.servico.categorias.filter(Boolean)
+            : []
+        });
+      }
       const valorTotal = servicosList.reduce((acc, s) => acc + Number(s.valor || 0), 0) || Number(a.valor || 0) || 0;
       const tutorNome = a.cliente
         ? (a.cliente.nomeCompleto || a.cliente.nomeContato || a.cliente.razaoSocial || '')

--- a/src/output.css
+++ b/src/output.css
@@ -2336,6 +2336,13 @@
       }
     }
   }
+  .hover\:border-slate-300 {
+    &:hover {
+      @media (hover: hover) {
+        border-color: var(--color-slate-300);
+      }
+    }
+  }
   .hover\:bg-blue-500\/10 {
     &:hover {
       @media (hover: hover) {
@@ -2505,6 +2512,13 @@
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-slate-50);
+      }
+    }
+  }
+  .hover\:bg-slate-200 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-slate-200);
       }
     }
   }


### PR DESCRIPTION
## Summary
- add persistence helpers and render a Ficha Clínica chip beside each agenda value that redirects with tutor/pet context
- regenerate Tailwind output so the new hover utility classes are available for the chip styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9bfb4502883239ee8d05d8a6c2f77