### PR TITLE
Implement consultation modal for vet ficha clinica

### DIFF
--- a/pages/funcionarios/vet-ficha-clinica.html
+++ b/pages/funcionarios/vet-ficha-clinica.html
@@ -253,8 +253,9 @@
                 <div class="bg-white rounded-xl shadow-sm ring-1 ring-black/5 p-4">
                     <h4 class="font-semibold text-gray-800 mb-3">Ações rápidas</h4>
                     <div class="grid grid-cols-2 gap-3">
-                        <a
-                            class="flex items-center justify-between px-3 py-3 rounded-lg bg-amber-50 ring-1 ring-amber-100">
+                        <a id="vet-add-consulta-btn"
+                            class="flex items-center justify-between px-3 py-3 rounded-lg bg-amber-50 ring-1 ring-amber-100"
+                            href="#">
                             <span class="flex items-center gap-2 text-gray-800"><i class="fas fa-briefcase-medical"></i>
                                 Consulta</span>
                         </a>

--- a/servidor/models/VetConsultation.js
+++ b/servidor/models/VetConsultation.js
@@ -1,0 +1,53 @@
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const VetConsultationSchema = new Schema({
+  cliente: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true,
+  },
+  pet: {
+    type: Schema.Types.ObjectId,
+    ref: 'Pet',
+    required: true,
+    index: true,
+  },
+  servico: {
+    type: Schema.Types.ObjectId,
+    ref: 'Service',
+    required: true,
+    index: true,
+  },
+  appointment: {
+    type: Schema.Types.ObjectId,
+    ref: 'Appointment',
+  },
+  anamnese: {
+    type: String,
+    default: '',
+  },
+  exameFisico: {
+    type: String,
+    default: '',
+  },
+  diagnostico: {
+    type: String,
+    default: '',
+  },
+  createdBy: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+  },
+  updatedBy: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+  },
+}, { timestamps: true });
+
+VetConsultationSchema.index({ cliente: 1, pet: 1, createdAt: -1 });
+VetConsultationSchema.index({ appointment: 1 });
+VetConsultationSchema.index({ servico: 1 });
+
+module.exports = mongoose.model('VetConsultation', VetConsultationSchema);

--- a/servidor/routes/funcVet.js
+++ b/servidor/routes/funcVet.js
@@ -1,0 +1,311 @@
+const express = require('express');
+const mongoose = require('mongoose');
+
+const authMiddleware = require('../middlewares/authMiddleware');
+const authorizeRoles = require('../middlewares/authorizeRoles');
+const Pet = require('../models/Pet');
+const Service = require('../models/Service');
+const Appointment = require('../models/Appointment');
+const VetConsultation = require('../models/VetConsultation');
+
+const router = express.Router();
+const requireStaff = authorizeRoles('funcionario', 'admin', 'admin_master');
+
+function normalizeObjectId(value) {
+  if (!value) return null;
+  const str = String(value).trim();
+  if (!str) return null;
+  if (!mongoose.Types.ObjectId.isValid(str)) return null;
+  return str;
+}
+
+function toStringSafe(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') return String(value);
+  if (typeof value === 'object' && typeof value.toString === 'function') {
+    return value.toString();
+  }
+  try {
+    return String(value);
+  } catch (_) {
+    return null;
+  }
+}
+
+function isVetService(serviceDoc = {}) {
+  const raw = Array.isArray(serviceDoc.categorias)
+    ? serviceDoc.categorias
+    : (serviceDoc.categorias ? [serviceDoc.categorias] : []);
+  return raw.some((cat) => String(cat || '').trim().toLowerCase() === 'veterinario');
+}
+
+async function ensurePetBelongsToCliente(petId, clienteId) {
+  const pet = await Pet.findById(petId).select('owner').lean();
+  if (!pet) {
+    return { ok: false, status: 404, message: 'Pet não encontrado.' };
+  }
+  if (clienteId && toStringSafe(pet.owner) !== clienteId) {
+    return { ok: false, status: 400, message: 'Pet não pertence ao tutor informado.' };
+  }
+  return { ok: true };
+}
+
+async function fetchVetService(servicoId) {
+  const service = await Service.findById(servicoId).select('categorias nome').lean();
+  if (!service) {
+    return { ok: false, status: 404, message: 'Serviço não encontrado.' };
+  }
+  if (!isVetService(service)) {
+    return { ok: false, status: 400, message: 'Serviço informado não é veterinário.' };
+  }
+  return { ok: true, service };
+}
+
+async function ensureAppointmentLink(appointmentId, clienteId, petId, servicoId) {
+  if (!appointmentId) {
+    return { ok: true, appointment: null };
+  }
+  const appointment = await Appointment.findById(appointmentId)
+    .select('cliente pet servico itens')
+    .lean();
+  if (!appointment) {
+    return { ok: false, status: 404, message: 'Agendamento não encontrado.' };
+  }
+  if (clienteId && toStringSafe(appointment.cliente) !== clienteId) {
+    return { ok: false, status: 400, message: 'Agendamento não pertence ao tutor informado.' };
+  }
+  if (petId && toStringSafe(appointment.pet) !== petId) {
+    return { ok: false, status: 400, message: 'Agendamento não pertence ao pet informado.' };
+  }
+  if (servicoId) {
+    const allowed = new Set();
+    if (appointment.servico) {
+      allowed.add(toStringSafe(appointment.servico));
+    }
+    if (Array.isArray(appointment.itens)) {
+      appointment.itens.forEach((item) => {
+        if (item && item.servico) {
+          allowed.add(toStringSafe(item.servico));
+        }
+      });
+    }
+    if (allowed.size && !allowed.has(servicoId)) {
+      return { ok: false, status: 400, message: 'Serviço informado não pertence ao agendamento selecionado.' };
+    }
+  }
+  return { ok: true, appointment };
+}
+
+function formatConsultation(doc) {
+  if (!doc) return null;
+  const createdAt = doc.createdAt instanceof Date ? doc.createdAt.toISOString() : doc.createdAt || null;
+  const updatedAt = doc.updatedAt instanceof Date ? doc.updatedAt.toISOString() : doc.updatedAt || createdAt;
+  return {
+    _id: toStringSafe(doc._id),
+    clienteId: toStringSafe(doc.cliente),
+    petId: toStringSafe(doc.pet),
+    servicoId: toStringSafe(doc.servico?._id || doc.servico),
+    servicoNome: doc.servico?.nome || null,
+    appointmentId: toStringSafe(doc.appointment),
+    anamnese: doc.anamnese || '',
+    exameFisico: doc.exameFisico || '',
+    diagnostico: doc.diagnostico || '',
+    createdAt,
+    updatedAt,
+  };
+}
+
+router.get('/vet/consultas', authMiddleware, requireStaff, async (req, res) => {
+  try {
+    const clienteId = normalizeObjectId(req.query.clienteId);
+    const petId = normalizeObjectId(req.query.petId);
+    const appointmentId = normalizeObjectId(req.query.appointmentId);
+
+    if (!clienteId || !petId) {
+      return res.status(400).json({ message: 'clienteId e petId são obrigatórios.' });
+    }
+
+    const filter = { cliente: clienteId, pet: petId };
+    if (appointmentId) {
+      filter.appointment = appointmentId;
+    }
+
+    const docs = await VetConsultation.find(filter)
+      .sort({ createdAt: -1 })
+      .populate('servico', 'nome categorias')
+      .lean();
+
+    return res.json(docs.map(formatConsultation));
+  } catch (error) {
+    console.error('GET /func/vet/consultas', error);
+    res.status(500).json({ message: 'Erro ao listar consultas.' });
+  }
+});
+
+router.get('/vet/consultas/:id', authMiddleware, requireStaff, async (req, res) => {
+  try {
+    const id = normalizeObjectId(req.params.id);
+    if (!id) {
+      return res.status(400).json({ message: 'ID inválido.' });
+    }
+    const doc = await VetConsultation.findById(id)
+      .populate('servico', 'nome categorias')
+      .lean();
+    if (!doc) {
+      return res.status(404).json({ message: 'Consulta não encontrada.' });
+    }
+    return res.json(formatConsultation(doc));
+  } catch (error) {
+    console.error('GET /func/vet/consultas/:id', error);
+    res.status(500).json({ message: 'Erro ao buscar consulta.' });
+  }
+});
+
+router.post('/vet/consultas', authMiddleware, requireStaff, async (req, res) => {
+  try {
+    const {
+      clienteId,
+      petId,
+      servicoId,
+      appointmentId,
+      anamnese,
+      exameFisico,
+      diagnostico,
+    } = req.body || {};
+
+    const cliente = normalizeObjectId(clienteId);
+    const pet = normalizeObjectId(petId);
+    const servico = normalizeObjectId(servicoId);
+    const appointment = normalizeObjectId(appointmentId);
+
+    if (!cliente || !pet || !servico) {
+      return res.status(400).json({ message: 'clienteId, petId e servicoId são obrigatórios.' });
+    }
+
+    const petCheck = await ensurePetBelongsToCliente(pet, cliente);
+    if (!petCheck.ok) {
+      return res.status(petCheck.status).json({ message: petCheck.message });
+    }
+
+    const serviceCheck = await fetchVetService(servico);
+    if (!serviceCheck.ok) {
+      return res.status(serviceCheck.status).json({ message: serviceCheck.message });
+    }
+
+    const appointmentCheck = await ensureAppointmentLink(appointment, cliente, pet, servico);
+    if (!appointmentCheck.ok) {
+      return res.status(appointmentCheck.status).json({ message: appointmentCheck.message });
+    }
+
+    const nowUserId = normalizeObjectId(req.user?.id);
+
+    const doc = await VetConsultation.create({
+      cliente,
+      pet,
+      servico,
+      appointment: appointment || undefined,
+      anamnese: typeof anamnese === 'string' ? anamnese : '',
+      exameFisico: typeof exameFisico === 'string' ? exameFisico : '',
+      diagnostico: typeof diagnostico === 'string' ? diagnostico : '',
+      createdBy: nowUserId || undefined,
+      updatedBy: nowUserId || undefined,
+    });
+
+    const full = await VetConsultation.findById(doc._id)
+      .populate('servico', 'nome categorias')
+      .lean();
+
+    return res.status(201).json(formatConsultation(full));
+  } catch (error) {
+    console.error('POST /func/vet/consultas', error);
+    res.status(500).json({ message: 'Erro ao salvar consulta.' });
+  }
+});
+
+router.put('/vet/consultas/:id', authMiddleware, requireStaff, async (req, res) => {
+  try {
+    const id = normalizeObjectId(req.params.id);
+    if (!id) {
+      return res.status(400).json({ message: 'ID inválido.' });
+    }
+
+    const existing = await VetConsultation.findById(id).lean();
+    if (!existing) {
+      return res.status(404).json({ message: 'Consulta não encontrada.' });
+    }
+
+    const cliente = toStringSafe(existing.cliente);
+    const pet = toStringSafe(existing.pet);
+
+    const {
+      anamnese,
+      exameFisico,
+      diagnostico,
+      servicoId,
+      appointmentId,
+      clienteId,
+      petId,
+    } = req.body || {};
+
+    const bodyClienteId = normalizeObjectId(clienteId);
+    if (bodyClienteId && bodyClienteId !== cliente) {
+      return res.status(400).json({ message: 'Consulta pertence a outro tutor.' });
+    }
+    const bodyPetId = normalizeObjectId(petId);
+    if (bodyPetId && bodyPetId !== pet) {
+      return res.status(400).json({ message: 'Consulta pertence a outro pet.' });
+    }
+
+    const updates = {};
+    if (typeof anamnese !== 'undefined') updates.anamnese = String(anamnese || '');
+    if (typeof exameFisico !== 'undefined') updates.exameFisico = String(exameFisico || '');
+    if (typeof diagnostico !== 'undefined') updates.diagnostico = String(diagnostico || '');
+
+    const nextServicoId = normalizeObjectId(servicoId) || toStringSafe(existing.servico);
+    if (!nextServicoId) {
+      return res.status(400).json({ message: 'Serviço inválido.' });
+    }
+    const serviceCheck = await fetchVetService(nextServicoId);
+    if (!serviceCheck.ok) {
+      return res.status(serviceCheck.status).json({ message: serviceCheck.message });
+    }
+    if (normalizeObjectId(servicoId)) {
+      updates.servico = nextServicoId;
+    }
+
+    const nextAppointmentId = typeof appointmentId !== 'undefined'
+      ? normalizeObjectId(appointmentId)
+      : toStringSafe(existing.appointment);
+
+    const appointmentCheck = await ensureAppointmentLink(nextAppointmentId, cliente, pet, nextServicoId);
+    if (!appointmentCheck.ok) {
+      return res.status(appointmentCheck.status).json({ message: appointmentCheck.message });
+    }
+
+    if (typeof appointmentId !== 'undefined') {
+      updates.appointment = nextAppointmentId || undefined;
+    }
+
+    const updater = normalizeObjectId(req.user?.id);
+    if (updater) {
+      updates.updatedBy = updater;
+    }
+    updates.updatedAt = new Date();
+
+    const full = await VetConsultation.findByIdAndUpdate(id, { $set: updates }, { new: true })
+      .populate('servico', 'nome categorias')
+      .lean();
+
+    if (!full) {
+      return res.status(404).json({ message: 'Consulta não encontrada.' });
+    }
+
+    return res.json(formatConsultation(full));
+  } catch (error) {
+    console.error('PUT /func/vet/consultas/:id', error);
+    res.status(500).json({ message: 'Erro ao atualizar consulta.' });
+  }
+});
+
+module.exports = router;

--- a/servidor/server.js
+++ b/servidor/server.js
@@ -54,6 +54,7 @@ const routes = [
 
 // Registrar rotas adicionais (Agenda - funcionários)
 routes.push({ path: '/api/func', file: './routes/funcAgenda' });
+routes.push({ path: '/api/func', file: './routes/funcVet' });
 
 // Carrega cada rota
 routes.forEach(r => app.use(r.path, require(r.file)));

--- a/src/output.css
+++ b/src/output.css
@@ -46,6 +46,7 @@
     --color-sky-50: oklch(97.7% 0.013 236.62);
     --color-sky-100: oklch(95.1% 0.026 236.824);
     --color-sky-200: oklch(90.1% 0.058 230.902);
+    --color-sky-300: oklch(82.8% 0.111 230.318);
     --color-sky-400: oklch(74.6% 0.16 232.661);
     --color-sky-500: oklch(68.5% 0.169 237.323);
     --color-sky-600: oklch(58.8% 0.158 241.966);
@@ -744,6 +745,9 @@
   .min-h-\[64px\] {
     min-height: 64px;
   }
+  .min-h-\[120px\] {
+    min-height: 120px;
+  }
   .min-h-\[140px\] {
     min-height: 140px;
   }
@@ -1027,6 +1031,9 @@
   }
   .flex-col {
     flex-direction: column;
+  }
+  .flex-col-reverse {
+    flex-direction: column-reverse;
   }
   .flex-wrap {
     flex-wrap: wrap;
@@ -1832,6 +1839,9 @@
   .whitespace-pre-line {
     white-space: pre-line;
   }
+  .whitespace-pre-wrap {
+    white-space: pre-wrap;
+  }
   .text-amber-700 {
     color: var(--color-amber-700);
   }
@@ -1903,6 +1913,9 @@
   }
   .text-red-700 {
     color: var(--color-red-700);
+  }
+  .text-sky-600 {
+    color: var(--color-sky-600);
   }
   .text-sky-700 {
     color: var(--color-sky-700);
@@ -2336,6 +2349,13 @@
       }
     }
   }
+  .hover\:border-sky-300 {
+    &:hover {
+      @media (hover: hover) {
+        border-color: var(--color-sky-300);
+      }
+    }
+  }
   .hover\:border-slate-300 {
     &:hover {
       @media (hover: hover) {
@@ -2505,6 +2525,13 @@
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-sky-600);
+      }
+    }
+  }
+  .hover\:bg-sky-700 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-sky-700);
       }
     }
   }
@@ -2702,6 +2729,11 @@
       border-color: var(--color-primary);
     }
   }
+  .focus\:border-sky-500 {
+    &:focus {
+      border-color: var(--color-sky-500);
+    }
+  }
   .focus\:border-transparent {
     &:focus {
       border-color: transparent;
@@ -2735,6 +2767,11 @@
       @supports (color: color-mix(in lab, red, red)) {
         --tw-ring-color: color-mix(in oklab, var(--color-primary) 40%, transparent);
       }
+    }
+  }
+  .focus\:ring-sky-200 {
+    &:focus {
+      --tw-ring-color: var(--color-sky-200);
     }
   }
   .focus\:ring-sky-400 {
@@ -2810,6 +2847,11 @@
       width: calc(var(--spacing) * 64);
     }
   }
+  .sm\:w-auto {
+    @media (width >= 40rem) {
+      width: auto;
+    }
+  }
   .sm\:grid-cols-2 {
     @media (width >= 40rem) {
       grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -2825,14 +2867,34 @@
       grid-template-columns: repeat(4, minmax(0, 1fr));
     }
   }
+  .sm\:flex-row {
+    @media (width >= 40rem) {
+      flex-direction: row;
+    }
+  }
+  .sm\:items-center {
+    @media (width >= 40rem) {
+      align-items: center;
+    }
+  }
   .sm\:justify-between {
     @media (width >= 40rem) {
       justify-content: space-between;
     }
   }
+  .sm\:justify-end {
+    @media (width >= 40rem) {
+      justify-content: flex-end;
+    }
+  }
   .sm\:justify-start {
     @media (width >= 40rem) {
       justify-content: flex-start;
+    }
+  }
+  .sm\:gap-3 {
+    @media (width >= 40rem) {
+      gap: calc(var(--spacing) * 3);
     }
   }
   .sm\:text-sm {


### PR DESCRIPTION
## Summary
- add an ID to the quick action consultation button so it can trigger a modal workflow
- implement the consultation modal, state management, and handlers to create or edit consultation records
- render manual consultation cards above the scheduled services card and wire the quick action to open the modal

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9d79d51b4832395788f5cef15d31c