### PR TITLE
Remove duplicate servico index definition

### DIFF
--- a/servidor/models/VetConsultation.js
+++ b/servidor/models/VetConsultation.js
@@ -18,7 +18,6 @@ const VetConsultationSchema = new Schema({
     type: Schema.Types.ObjectId,
     ref: 'Service',
     required: true,
-    index: true,
   },
   appointment: {
     type: Schema.Types.ObjectId,


### PR DESCRIPTION
## Summary
- remove the redundant inline `index: true` from the vet consultation `servico` field to avoid duplicating the explicit schema index

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9e99bb6ec8323a2a3d22fd5735f56