### PR TITLE
Add attachments modal and Drive upload integration

### DIFF
--- a/pages/funcionarios/vet-ficha-clinica.html
+++ b/pages/funcionarios/vet-ficha-clinica.html
@@ -266,8 +266,9 @@
                                 Vacina</span>
                         </a>
 
-                        <a
-                            class="flex items-center justify-between px-3 py-3 rounded-lg bg-gray-100 ring-1 ring-gray-200">
+                        <a id="vet-add-anexo-btn"
+                            class="flex items-center justify-between px-3 py-3 rounded-lg bg-gray-100 ring-1 ring-gray-200"
+                            href="#">
                             <span class="flex items-center gap-2 text-gray-800"><i class="fas fa-paperclip"></i>
                                 Anexo</span>
                         </a>

--- a/scripts/funcionarios/vet/ficha-clinica.js
+++ b/scripts/funcionarios/vet/ficha-clinica.js
@@ -94,6 +94,7 @@
         consultaTab: document.getElementById('vet-tab-consulta'),
         addConsultaBtn: document.getElementById('vet-add-consulta-btn'),
         addVacinaBtn: document.getElementById('vet-add-vacina-btn'),
+        addAnexoBtn: document.getElementById('vet-add-anexo-btn'),
     };
 
     const state = {
@@ -106,6 +107,9 @@
         consultasLoading: false,
         consultasLoadKey: null,
         vacinas: [],
+        anexos: [],
+        anexosLoading: false,
+        anexosLoadKey: null,
     };
 
     const consultaModal = {
@@ -142,12 +146,35 @@
         searchAbortController: null,
     };
 
+    const anexoModal = {
+        overlay: null,
+        dialog: null,
+        form: null,
+        titleEl: null,
+        submitBtn: null,
+        cancelBtn: null,
+        addBtn: null,
+        nameInput: null,
+        fileInput: null,
+        dropzone: null,
+        dropzoneText: null,
+        dropzoneHint: null,
+        filesList: null,
+        emptyState: null,
+        contextInfo: null,
+        selectedFiles: [],
+        pendingFile: null,
+        isSubmitting: false,
+        keydownHandler: null,
+    };
+
     const STORAGE_KEYS = {
         cliente: 'vetFichaSelectedCliente',
         petId: 'vetFichaSelectedPetId',
         agenda: 'vetFichaAgendaContext',
     };
     const VACINA_STORAGE_PREFIX = 'vetFichaVacinas:';
+    const ANEXO_STORAGE_PREFIX = 'vetFichaAnexos:';
     const OBJECT_ID_REGEX = /^[0-9a-fA-F]{24}$/;
 
     const CARD_TUTOR_ACTIVE_CLASSES = ['bg-sky-100', 'text-sky-700'];
@@ -163,6 +190,8 @@
         em_atendimento: 'Em atendimento',
         finalizado: 'Finalizado',
     };
+    const ANEXO_ALLOWED_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.pdf'];
+    const ANEXO_ALLOWED_MIME_TYPES = ['image/png', 'image/jpeg', 'application/pdf'];
     const PET_PLACEHOLDERS = {
         nome: 'Nome do Pet',
         tipo: '—',
@@ -822,6 +851,245 @@
         }
     }
 
+    function generateAnexoId() {
+        return `anx-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    }
+
+    function generateAnexoFileId() {
+        return `anx-file-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    }
+
+    function getFileExtension(filename) {
+        if (!filename) return '';
+        const lower = String(filename).toLowerCase();
+        const dotIndex = lower.lastIndexOf('.');
+        if (dotIndex < 0) return '';
+        return lower.slice(dotIndex);
+    }
+
+    function formatFileSize(bytes) {
+        const size = Number(bytes);
+        if (!Number.isFinite(size) || size < 0) return '';
+        if (size === 0) return '0 B';
+        const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        const exponent = Math.min(Math.floor(Math.log(size) / Math.log(1024)), units.length - 1);
+        const value = size / Math.pow(1024, exponent);
+        const formatted = value >= 10 || exponent === 0 ? value.toFixed(0) : value.toFixed(1);
+        return `${formatted} ${units[exponent]}`;
+    }
+
+    function isAllowedAnexoFile(file) {
+        if (!file) return false;
+        const extension = getFileExtension(file.name);
+        if (extension && ANEXO_ALLOWED_EXTENSIONS.includes(extension)) return true;
+        const mime = String(file.type || '').toLowerCase();
+        if (mime && ANEXO_ALLOWED_MIME_TYPES.some((type) => mime === type)) return true;
+        return false;
+    }
+
+    function normalizeAnexoFileRecord(raw, fallback = {}) {
+        const source = raw && typeof raw === 'object' ? raw : {};
+        const fallbackSource = fallback && typeof fallback === 'object' ? fallback : {};
+        const id = normalizeId(source.id || source._id || fallbackSource.id || fallbackSource._id) || generateAnexoFileId();
+        const nome = pickFirst(
+            source.nome,
+            source.name,
+            fallbackSource.nome,
+            fallbackSource.name,
+            fallbackSource.displayName,
+        );
+        const originalName = pickFirst(
+            source.originalName,
+            source.arquivoNomeOriginal,
+            source.fileName,
+            source.filename,
+            fallbackSource.originalName,
+        );
+        const mimeType = pickFirst(source.mimeType, source.contentType, source.tipo, fallbackSource.mimeType);
+        const sizeCandidate = Number(source.tamanho ?? source.size ?? source.bytes ?? fallbackSource.size);
+        const size = Number.isFinite(sizeCandidate) && sizeCandidate >= 0 ? sizeCandidate : 0;
+        const url = pickFirst(source.url, source.link, source.downloadUrl, source.webViewLink, fallbackSource.url);
+        let extension = pickFirst(source.extensao, source.extension, fallbackSource.extension);
+        if (!extension && (originalName || nome)) {
+            extension = getFileExtension(originalName || nome);
+        }
+        if (extension) {
+            extension = String(extension).toLowerCase();
+            if (extension && !extension.startsWith('.')) extension = `.${extension}`;
+        }
+        const createdAt = toIsoOrNull(source.createdAt || source.uploadedAt || fallbackSource.createdAt);
+
+        return {
+            id,
+            _id: id,
+            nome: nome || originalName || 'Arquivo',
+            originalName: originalName || nome || '',
+            mimeType: mimeType || '',
+            size,
+            url: url || '',
+            extension: extension || '',
+            createdAt,
+        };
+    }
+
+    function mergeAnexoFiles(existing = [], incoming = []) {
+        const list = [];
+        const map = new Map();
+        const push = (item) => {
+            const normalized = normalizeAnexoFileRecord(item);
+            if (!normalized) return;
+            const key = normalizeId(normalized.id || normalized._id) || `${normalized.nome}|${normalized.originalName}|${normalized.url}`;
+            const previous = map.get(key);
+            if (previous) {
+                const merged = {
+                    ...previous,
+                    ...normalized,
+                };
+                if (!merged.url && normalized.url) merged.url = normalized.url;
+                if (!merged.mimeType && normalized.mimeType) merged.mimeType = normalized.mimeType;
+                if (!merged.size && normalized.size) merged.size = normalized.size;
+                if (!merged.extension && normalized.extension) merged.extension = normalized.extension;
+                if (!merged.createdAt) merged.createdAt = normalized.createdAt;
+                map.set(key, merged);
+            } else {
+                map.set(key, normalized);
+            }
+        };
+        (Array.isArray(existing) ? existing : []).forEach(push);
+        (Array.isArray(incoming) ? incoming : []).forEach(push);
+        map.forEach((value) => list.push(value));
+        list.sort((a, b) => {
+            const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+            const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+            return bTime - aTime;
+        });
+        return list;
+    }
+
+    function normalizeAnexoRecord(raw, fallbackFiles = []) {
+        if (!raw && (!fallbackFiles || !fallbackFiles.length)) return null;
+        const source = raw && typeof raw === 'object' ? raw : {};
+        const arquivosRaw = Array.isArray(source.arquivos)
+            ? source.arquivos
+            : (Array.isArray(source.files) ? source.files : (Array.isArray(source.anexos) ? source.anexos : []));
+        const fallbackList = Array.isArray(fallbackFiles) ? fallbackFiles : [];
+        const arquivos = mergeAnexoFiles(arquivosRaw, fallbackList);
+        if (!arquivos.length && !fallbackList.length) return null;
+
+        const id = normalizeId(source.id || source._id || source.uid || source.key) || generateAnexoId();
+        const createdAt = toIsoOrNull(source.createdAt || source.criadoEm || source.dataCriacao) || new Date().toISOString();
+        const updatedAt = toIsoOrNull(source.updatedAt || source.atualizadoEm || source.dataAtualizacao) || createdAt;
+
+        return {
+            id,
+            _id: id,
+            clienteId: normalizeId(source.clienteId || source.cliente),
+            petId: normalizeId(source.petId || source.pet),
+            appointmentId: normalizeId(source.appointmentId || source.appointment),
+            observacao: typeof source.observacao === 'string' ? source.observacao.trim() : '',
+            createdAt,
+            updatedAt,
+            arquivos,
+        };
+    }
+
+    function getAnexoStorageKey(clienteId, petId) {
+        const base = getConsultasKey(clienteId, petId);
+        return base ? `${ANEXO_STORAGE_PREFIX}${base}` : null;
+    }
+
+    function persistAnexosForSelection() {
+        const key = getAnexoStorageKey(state.selectedCliente?._id, state.selectedPetId);
+        if (!key) return;
+        try {
+            if (Array.isArray(state.anexos) && state.anexos.length) {
+                localStorage.setItem(key, JSON.stringify(state.anexos));
+            } else {
+                localStorage.removeItem(key);
+            }
+        } catch { }
+    }
+
+    function loadAnexosForSelection() {
+        const key = getAnexoStorageKey(state.selectedCliente?._id, state.selectedPetId);
+        if (!key) {
+            state.anexos = [];
+            return;
+        }
+        try {
+            const raw = localStorage.getItem(key);
+            if (!raw) {
+                state.anexos = [];
+                return;
+            }
+            const parsed = JSON.parse(raw);
+            if (!Array.isArray(parsed)) {
+                state.anexos = [];
+                return;
+            }
+            const normalized = parsed.map((item) => normalizeAnexoRecord(item)).filter(Boolean);
+            normalized.sort((a, b) => {
+                const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+                const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+                return bTime - aTime;
+            });
+            state.anexos = normalized;
+        } catch {
+            state.anexos = [];
+        }
+    }
+
+    function upsertAnexoInState(record, fallbackFiles = []) {
+        const normalized = normalizeAnexoRecord(record, fallbackFiles);
+        if (!normalized) return null;
+        const id = normalizeId(normalized.id || normalized._id);
+        if (!id) return null;
+
+        const next = Array.isArray(state.anexos) ? [...state.anexos] : [];
+        const idx = next.findIndex((item) => normalizeId(item?.id || item?._id) === id);
+        const incomingFiles = Array.isArray(normalized.arquivos) ? mergeAnexoFiles([], normalized.arquivos) : [];
+        const payload = {
+            ...normalized,
+            id,
+            _id: id,
+            createdAt: toIsoOrNull(normalized.createdAt) || new Date().toISOString(),
+            arquivos: incomingFiles,
+        };
+
+        if (idx >= 0) {
+            const existing = next[idx];
+            payload.arquivos = mergeAnexoFiles(existing?.arquivos, incomingFiles);
+            next[idx] = { ...existing, ...payload };
+        } else {
+            next.unshift(payload);
+        }
+
+        const deduped = [];
+        const seen = new Set();
+        next.forEach((item) => {
+            const itemId = normalizeId(item?.id || item?._id);
+            if (!itemId || seen.has(itemId)) return;
+            seen.add(itemId);
+            const createdAt = toIsoOrNull(item.createdAt) || new Date().toISOString();
+            deduped.push({
+                ...item,
+                id: itemId,
+                _id: itemId,
+                createdAt,
+                arquivos: mergeAnexoFiles([], item.arquivos || []),
+            });
+        });
+
+        deduped.sort((a, b) => {
+            const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+            const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+            return bTime - aTime;
+        });
+
+        state.anexos = deduped;
+        return deduped.find((item) => normalizeId(item?.id || item?._id) === id) || payload;
+    }
+
     function getCurrentAgendaService() {
         const context = state.agendaContext || null;
         if (!context) return null;
@@ -999,6 +1267,60 @@
         }
     }
 
+    async function loadAnexosFromServer(options = {}) {
+        const { force = false } = options || {};
+        const clienteId = normalizeId(state.selectedCliente?._id);
+        const petId = normalizeId(state.selectedPetId);
+
+        if (!(clienteId && petId)) {
+            state.anexos = [];
+            state.anexosLoadKey = null;
+            state.anexosLoading = false;
+            updateConsultaAgendaCard();
+            return;
+        }
+
+        const key = getConsultasKey(clienteId, petId);
+        if (!force && key && state.anexosLoadKey === key) return;
+
+        state.anexosLoading = true;
+        updateConsultaAgendaCard();
+
+        try {
+            const params = new URLSearchParams({ clienteId, petId });
+            const appointmentId = normalizeId(state.agendaContext?.appointmentId);
+            if (appointmentId) params.set('appointmentId', appointmentId);
+
+            const resp = await api(`/func/vet/anexos?${params.toString()}`);
+            const payload = await resp.json().catch(() => (resp.ok ? [] : {}));
+            if (!resp.ok) {
+                const message = typeof payload?.message === 'string' ? payload.message : 'Erro ao carregar anexos.';
+                throw new Error(message);
+            }
+
+            const list = Array.isArray(payload?.anexos)
+                ? payload.anexos
+                : (Array.isArray(payload) ? payload : []);
+            const normalized = list.map((item) => normalizeAnexoRecord(item)).filter(Boolean);
+            normalized.sort((a, b) => {
+                const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+                const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+                return bTime - aTime;
+            });
+
+            state.anexos = normalized;
+            state.anexosLoadKey = key;
+            persistAnexosForSelection();
+        } catch (error) {
+            console.error('loadAnexosFromServer', error);
+            state.anexosLoadKey = null;
+            notify(error.message || 'Erro ao carregar anexos.', 'error');
+        } finally {
+            state.anexosLoading = false;
+            updateConsultaAgendaCard();
+        }
+    }
+
     function createConsultaFieldSection(label, value) {
         const wrapper = document.createElement('div');
         wrapper.className = 'space-y-1';
@@ -1089,6 +1411,138 @@
             if (event.key === 'Enter' || event.key === ' ') {
                 event.preventDefault();
                 openForEdit(event);
+            }
+        });
+
+        return card;
+    }
+
+    function getAnexoFileIconClass(file) {
+        const ext = String(file?.extension || '').toLowerCase();
+        if (ext === '.pdf') return 'fas fa-file-pdf';
+        if (ext === '.png' || ext === '.jpg' || ext === '.jpeg') return 'fas fa-file-image';
+        return 'fas fa-file';
+    }
+
+    function createAnexoCard(anexo) {
+        if (!anexo) return null;
+        const arquivos = Array.isArray(anexo.arquivos) ? anexo.arquivos.filter(Boolean) : [];
+        if (!arquivos.length) return null;
+
+        const card = document.createElement('article');
+        card.className = 'rounded-xl border border-indigo-200 bg-white p-4 shadow-sm';
+
+        const header = document.createElement('div');
+        header.className = 'flex items-start gap-3';
+        card.appendChild(header);
+
+        const icon = document.createElement('div');
+        icon.className = 'flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-indigo-100 text-indigo-600';
+        icon.innerHTML = '<i class="fas fa-paperclip"></i>';
+        header.appendChild(icon);
+
+        const headerText = document.createElement('div');
+        headerText.className = 'flex-1';
+        header.appendChild(headerText);
+
+        const title = document.createElement('h3');
+        title.className = 'text-sm font-semibold text-indigo-700';
+        title.textContent = 'Anexos';
+        headerText.appendChild(title);
+
+        const fileCount = arquivos.length;
+        if (fileCount > 0) {
+            const badge = document.createElement('span');
+            badge.className = 'mt-1 inline-flex items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-medium text-indigo-700';
+            const badgeIcon = document.createElement('i');
+            badgeIcon.className = 'fas fa-files text-[10px]';
+            badge.appendChild(badgeIcon);
+            const badgeText = document.createElement('span');
+            badgeText.className = 'leading-none';
+            badgeText.textContent = `${fileCount} arquivo${fileCount === 1 ? '' : 's'}`;
+            badge.appendChild(badgeText);
+            headerText.appendChild(badge);
+        }
+
+        const metaParts = [];
+        if (anexo.createdAt) {
+            const created = formatDateTimeDisplay(anexo.createdAt);
+            if (created) metaParts.push(`Registrado em ${created}`);
+        }
+        if (anexo.updatedAt && anexo.updatedAt !== anexo.createdAt) {
+            const updated = formatDateTimeDisplay(anexo.updatedAt);
+            if (updated) metaParts.push(`Atualizado em ${updated}`);
+        }
+        if (metaParts.length) {
+            const meta = document.createElement('p');
+            meta.className = 'mt-0.5 text-xs text-gray-500';
+            meta.textContent = metaParts.join(' · ');
+            headerText.appendChild(meta);
+        }
+
+        const list = document.createElement('div');
+        list.className = 'mt-4 space-y-3';
+        card.appendChild(list);
+
+        arquivos.forEach((file) => {
+            const item = document.createElement('div');
+            item.className = 'flex flex-col gap-2 rounded-lg border border-indigo-100 bg-indigo-50/70 px-3 py-3 shadow-sm sm:flex-row sm:items-center sm:justify-between';
+            list.appendChild(item);
+
+            const info = document.createElement('div');
+            info.className = 'flex items-start gap-3 text-sm text-indigo-700';
+            item.appendChild(info);
+
+            const iconWrapper = document.createElement('div');
+            iconWrapper.className = 'flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-indigo-200 bg-white text-indigo-600';
+            const fileIcon = document.createElement('i');
+            fileIcon.className = getAnexoFileIconClass(file);
+            iconWrapper.appendChild(fileIcon);
+            info.appendChild(iconWrapper);
+
+            const textWrap = document.createElement('div');
+            textWrap.className = 'min-w-0';
+            info.appendChild(textWrap);
+
+            const nameEl = document.createElement('p');
+            nameEl.className = 'font-semibold leading-tight text-indigo-700 break-words';
+            nameEl.textContent = file.nome || file.originalName || 'Arquivo';
+            textWrap.appendChild(nameEl);
+
+            const meta = document.createElement('p');
+            meta.className = 'text-xs text-indigo-600';
+            const metaPieces = [];
+            if (file.originalName && file.originalName !== file.nome) metaPieces.push(file.originalName);
+            const extension = String(file.extension || '').replace('.', '').toUpperCase();
+            if (extension) metaPieces.push(extension);
+            if (file.size) metaPieces.push(formatFileSize(file.size));
+            meta.textContent = metaPieces.length ? metaPieces.join(' · ') : '—';
+            textWrap.appendChild(meta);
+
+            const actions = document.createElement('div');
+            actions.className = 'flex items-center gap-2';
+            let hasAction = false;
+            if (file.url) {
+                const link = document.createElement('a');
+                link.href = file.url;
+                link.target = '_blank';
+                link.rel = 'noopener noreferrer';
+                link.className = 'inline-flex items-center gap-2 rounded-md border border-indigo-300 bg-white px-3 py-1 text-xs font-semibold text-indigo-600 transition hover:bg-indigo-600 hover:text-white';
+                link.innerHTML = '<i class="fas fa-arrow-up-right-from-square text-[10px]"></i><span>Abrir</span>';
+                if (file.originalName) {
+                    link.download = file.originalName;
+                }
+                actions.appendChild(link);
+                hasAction = true;
+            } else {
+                const pending = document.createElement('span');
+                pending.className = 'text-xs text-indigo-500';
+                pending.textContent = 'Link disponível após sincronização.';
+                actions.appendChild(pending);
+                hasAction = true;
+            }
+            if (hasAction) {
+                item.appendChild(actions);
             }
         });
 
@@ -2115,6 +2569,574 @@
         }
     }
 
+    function updateAnexoDropzoneText() {
+        if (!anexoModal.dropzoneText || !anexoModal.dropzoneHint) return;
+        if (anexoModal.pendingFile) {
+            anexoModal.dropzoneText.textContent = anexoModal.pendingFile.name;
+            const details = [];
+            const extension = getFileExtension(anexoModal.pendingFile.name).replace('.', '').toUpperCase();
+            if (extension) details.push(extension);
+            const size = formatFileSize(anexoModal.pendingFile.size);
+            if (size) details.push(size);
+            anexoModal.dropzoneHint.textContent = details.length ? details.join(' · ') : '';
+        } else {
+            anexoModal.dropzoneText.textContent = 'Arraste o arquivo aqui ou clique para selecionar';
+            anexoModal.dropzoneHint.textContent = 'Formatos aceitos: PNG, JPG, JPEG ou PDF.';
+        }
+    }
+
+    function refreshAnexoModalControls() {
+        const hasPendingFile = !!anexoModal.pendingFile;
+        const nameValue = (anexoModal.nameInput?.value || '').trim();
+        const canAdd = hasPendingFile && !!nameValue && !anexoModal.isSubmitting;
+        if (anexoModal.addBtn) {
+            anexoModal.addBtn.disabled = !canAdd;
+            anexoModal.addBtn.classList.toggle('opacity-50', anexoModal.addBtn.disabled);
+            anexoModal.addBtn.classList.toggle('cursor-not-allowed', anexoModal.addBtn.disabled);
+        }
+        const hasSelected = Array.isArray(anexoModal.selectedFiles) && anexoModal.selectedFiles.length > 0;
+        const submitDisabled = anexoModal.isSubmitting || !hasSelected;
+        if (anexoModal.submitBtn) {
+            anexoModal.submitBtn.disabled = submitDisabled;
+            anexoModal.submitBtn.classList.toggle('opacity-60', anexoModal.isSubmitting);
+            anexoModal.submitBtn.classList.toggle('cursor-not-allowed', submitDisabled);
+            anexoModal.submitBtn.textContent = anexoModal.isSubmitting ? 'Salvando...' : 'Salvar';
+        }
+        if (anexoModal.cancelBtn) {
+            anexoModal.cancelBtn.disabled = anexoModal.isSubmitting;
+            anexoModal.cancelBtn.classList.toggle('opacity-50', anexoModal.isSubmitting);
+            anexoModal.cancelBtn.classList.toggle('cursor-not-allowed', anexoModal.isSubmitting);
+        }
+        if (anexoModal.nameInput) anexoModal.nameInput.disabled = anexoModal.isSubmitting;
+        if (anexoModal.fileInput) anexoModal.fileInput.disabled = anexoModal.isSubmitting;
+    }
+
+    function setAnexoModalSubmitting(isSubmitting) {
+        anexoModal.isSubmitting = !!isSubmitting;
+        refreshAnexoModalControls();
+    }
+
+    function setAnexoPendingFile(file) {
+        anexoModal.pendingFile = file || null;
+        if (!file && anexoModal.fileInput) {
+            anexoModal.fileInput.value = '';
+        }
+        if (file && anexoModal.nameInput) {
+            const current = anexoModal.nameInput.value.trim();
+            if (!current) {
+                const ext = getFileExtension(file.name);
+                const base = ext ? file.name.slice(0, -ext.length) : file.name;
+                anexoModal.nameInput.value = base || file.name;
+            }
+        }
+        updateAnexoDropzoneText();
+        refreshAnexoModalControls();
+    }
+
+    function updateAnexoFilesGrid() {
+        const list = anexoModal.filesList;
+        const empty = anexoModal.emptyState;
+        if (!list) return;
+        list.innerHTML = '';
+        const files = Array.isArray(anexoModal.selectedFiles) ? anexoModal.selectedFiles : [];
+        if (!files.length) {
+            if (empty) empty.classList.remove('hidden');
+            refreshAnexoModalControls();
+            return;
+        }
+        if (empty) empty.classList.add('hidden');
+
+        files.forEach((entry) => {
+            const row = document.createElement('div');
+            row.className = 'flex flex-col gap-2 rounded-lg border border-indigo-100 bg-white px-3 py-3 shadow-sm sm:flex-row sm:items-center sm:justify-between';
+            list.appendChild(row);
+
+            const info = document.createElement('div');
+            info.className = 'flex items-start gap-3 text-sm text-indigo-700';
+            row.appendChild(info);
+
+            const icon = document.createElement('div');
+            icon.className = 'flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-indigo-200 bg-indigo-50 text-indigo-600';
+            icon.innerHTML = '<i class="fas fa-file"></i>';
+            info.appendChild(icon);
+
+            const textWrap = document.createElement('div');
+            textWrap.className = 'min-w-0';
+            info.appendChild(textWrap);
+
+            const nameEl = document.createElement('p');
+            nameEl.className = 'font-semibold leading-tight text-indigo-700 break-words';
+            nameEl.textContent = entry.name;
+            textWrap.appendChild(nameEl);
+
+            const meta = document.createElement('p');
+            meta.className = 'text-xs text-indigo-500';
+            const parts = [];
+            if (entry.originalName && entry.originalName !== entry.name) parts.push(entry.originalName);
+            if (entry.extension) parts.push(entry.extension.replace('.', '').toUpperCase());
+            if (entry.size) parts.push(formatFileSize(entry.size));
+            meta.textContent = parts.length ? parts.join(' · ') : '—';
+            textWrap.appendChild(meta);
+
+            const actions = document.createElement('div');
+            actions.className = 'flex items-center gap-2';
+            row.appendChild(actions);
+
+            const removeBtn = document.createElement('button');
+            removeBtn.type = 'button';
+            removeBtn.className = 'inline-flex items-center gap-1 rounded-md border border-transparent px-3 py-1 text-xs font-semibold text-rose-600 hover:bg-rose-50';
+            removeBtn.innerHTML = '<i class="fas fa-trash-can"></i><span>Remover</span>';
+            removeBtn.addEventListener('click', (event) => {
+                event.preventDefault();
+                anexoModal.selectedFiles = anexoModal.selectedFiles.filter((file) => file.id !== entry.id);
+                updateAnexoFilesGrid();
+                refreshAnexoModalControls();
+            });
+            actions.appendChild(removeBtn);
+        });
+
+        refreshAnexoModalControls();
+    }
+
+    function ensureAnexoModal() {
+        if (anexoModal.overlay) return anexoModal;
+
+        const overlay = document.createElement('div');
+        overlay.id = 'vet-anexo-modal';
+        overlay.className = 'hidden fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4';
+        overlay.setAttribute('aria-hidden', 'true');
+
+        const dialog = document.createElement('div');
+        dialog.className = 'w-full max-w-3xl rounded-xl bg-white shadow-xl focus:outline-none';
+        dialog.tabIndex = -1;
+        dialog.setAttribute('role', 'dialog');
+        dialog.setAttribute('aria-modal', 'true');
+        overlay.appendChild(dialog);
+
+        const form = document.createElement('form');
+        form.className = 'flex flex-col gap-6 p-6';
+        dialog.appendChild(form);
+
+        const header = document.createElement('div');
+        header.className = 'flex items-start justify-between gap-3';
+        form.appendChild(header);
+
+        const title = document.createElement('h2');
+        title.className = 'text-lg font-semibold text-gray-800';
+        title.textContent = 'Novo anexo';
+        header.appendChild(title);
+
+        const closeBtn = document.createElement('button');
+        closeBtn.type = 'button';
+        closeBtn.className = 'text-gray-400 transition hover:text-gray-600';
+        closeBtn.innerHTML = '<i class="fas fa-xmark"></i>';
+        closeBtn.addEventListener('click', (event) => {
+            event.preventDefault();
+            closeAnexoModal();
+        });
+        header.appendChild(closeBtn);
+
+        const fieldsWrapper = document.createElement('div');
+        fieldsWrapper.className = 'grid gap-4';
+        form.appendChild(fieldsWrapper);
+
+        const contextInfo = document.createElement('div');
+        contextInfo.className = 'hidden rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-2 text-sm text-indigo-700';
+        fieldsWrapper.appendChild(contextInfo);
+
+        const row = document.createElement('div');
+        row.className = 'grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]';
+        fieldsWrapper.appendChild(row);
+
+        const nameWrapper = document.createElement('div');
+        nameWrapper.className = 'flex flex-col gap-2';
+        row.appendChild(nameWrapper);
+
+        const nameLabel = document.createElement('label');
+        nameLabel.className = 'text-sm font-medium text-gray-700';
+        nameLabel.textContent = 'Nome do arquivo';
+        nameWrapper.appendChild(nameLabel);
+
+        const nameInput = document.createElement('input');
+        nameInput.type = 'text';
+        nameInput.placeholder = 'Digite um nome para o arquivo';
+        nameInput.className = 'w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-800 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200';
+        nameWrapper.appendChild(nameInput);
+
+        const fileWrapper = document.createElement('div');
+        fileWrapper.className = 'flex flex-col gap-2';
+        row.appendChild(fileWrapper);
+
+        const fileLabel = document.createElement('span');
+        fileLabel.className = 'text-sm font-medium text-gray-700';
+        fileLabel.textContent = 'Arquivo';
+        fileWrapper.appendChild(fileLabel);
+
+        const dropzone = document.createElement('div');
+        dropzone.className = 'flex min-h-[120px] flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-gray-300 bg-white px-4 py-4 text-center text-sm text-gray-500 transition hover:border-indigo-400 hover:text-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-200 cursor-pointer';
+        dropzone.tabIndex = 0;
+        fileWrapper.appendChild(dropzone);
+
+        const dropzoneIcon = document.createElement('div');
+        dropzoneIcon.className = 'text-2xl text-indigo-400';
+        dropzoneIcon.innerHTML = '<i class="fas fa-cloud-arrow-up"></i>';
+        dropzone.appendChild(dropzoneIcon);
+
+        const dropzoneText = document.createElement('p');
+        dropzoneText.className = 'text-sm font-medium text-gray-700';
+        dropzone.appendChild(dropzoneText);
+
+        const dropzoneHint = document.createElement('p');
+        dropzoneHint.className = 'text-xs text-gray-500';
+        dropzone.appendChild(dropzoneHint);
+
+        const fileInput = document.createElement('input');
+        fileInput.type = 'file';
+        fileInput.accept = ANEXO_ALLOWED_EXTENSIONS.join(',');
+        fileInput.className = 'hidden';
+        fileWrapper.appendChild(fileInput);
+
+        const addWrapper = document.createElement('div');
+        addWrapper.className = 'flex items-end';
+        row.appendChild(addWrapper);
+
+        const addBtn = document.createElement('button');
+        addBtn.type = 'button';
+        addBtn.className = 'w-full rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50';
+        addBtn.textContent = 'Adicionar';
+        addWrapper.appendChild(addBtn);
+
+        const filesContainer = document.createElement('div');
+        filesContainer.className = 'rounded-lg border border-dashed border-indigo-200 bg-indigo-50/60 p-4';
+        fieldsWrapper.appendChild(filesContainer);
+
+        const emptyState = document.createElement('p');
+        emptyState.className = 'text-sm text-indigo-600';
+        emptyState.textContent = 'Nenhum arquivo adicionado. Preencha as informações acima e clique em “Adicionar”.';
+        filesContainer.appendChild(emptyState);
+
+        const filesList = document.createElement('div');
+        filesList.className = 'mt-3 space-y-3';
+        filesContainer.appendChild(filesList);
+
+        const footer = document.createElement('div');
+        footer.className = 'flex flex-col-reverse gap-2 pt-2 sm:flex-row sm:items-center sm:justify-end sm:gap-3';
+        form.appendChild(footer);
+
+        const cancelBtn = document.createElement('button');
+        cancelBtn.type = 'button';
+        cancelBtn.className = 'w-full rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 sm:w-auto';
+        cancelBtn.textContent = 'Cancelar';
+        footer.appendChild(cancelBtn);
+
+        const submitBtn = document.createElement('button');
+        submitBtn.type = 'submit';
+        submitBtn.className = 'w-full rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-400 sm:w-auto disabled:cursor-not-allowed disabled:opacity-60';
+        submitBtn.textContent = 'Salvar';
+        footer.appendChild(submitBtn);
+
+        form.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            await handleAnexoSubmit();
+        });
+
+        cancelBtn.addEventListener('click', (event) => {
+            event.preventDefault();
+            closeAnexoModal();
+        });
+
+        addBtn.addEventListener('click', (event) => {
+            event.preventDefault();
+            handleAnexoAdd();
+        });
+
+        dropzone.addEventListener('click', () => {
+            if (!anexoModal.isSubmitting && anexoModal.fileInput) {
+                anexoModal.fileInput.click();
+            }
+        });
+        dropzone.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                if (!anexoModal.isSubmitting && anexoModal.fileInput) {
+                    anexoModal.fileInput.click();
+                }
+            }
+        });
+        dropzone.addEventListener('dragover', (event) => {
+            event.preventDefault();
+            if (anexoModal.isSubmitting) return;
+            dropzone.classList.add('border-indigo-400', 'bg-indigo-50', 'text-indigo-600');
+        });
+        dropzone.addEventListener('dragleave', (event) => {
+            event.preventDefault();
+            dropzone.classList.remove('border-indigo-400', 'bg-indigo-50', 'text-indigo-600');
+        });
+        dropzone.addEventListener('drop', (event) => {
+            event.preventDefault();
+            dropzone.classList.remove('border-indigo-400', 'bg-indigo-50', 'text-indigo-600');
+            if (anexoModal.isSubmitting) return;
+            const file = event.dataTransfer?.files?.[0];
+            if (file) {
+                handleAnexoFileSelection(file);
+            }
+        });
+
+        fileInput.addEventListener('change', (event) => {
+            if (anexoModal.isSubmitting) return;
+            const file = event.target.files && event.target.files[0];
+            if (file) {
+                handleAnexoFileSelection(file);
+            }
+        });
+
+        nameInput.addEventListener('input', () => {
+            refreshAnexoModalControls();
+        });
+
+        overlay.addEventListener('click', (event) => {
+            if (event.target === overlay) {
+                event.preventDefault();
+                closeAnexoModal();
+            }
+        });
+
+        document.body.appendChild(overlay);
+
+        anexoModal.overlay = overlay;
+        anexoModal.dialog = dialog;
+        anexoModal.form = form;
+        anexoModal.titleEl = title;
+        anexoModal.submitBtn = submitBtn;
+        anexoModal.cancelBtn = cancelBtn;
+        anexoModal.addBtn = addBtn;
+        anexoModal.nameInput = nameInput;
+        anexoModal.fileInput = fileInput;
+        anexoModal.dropzone = dropzone;
+        anexoModal.dropzoneText = dropzoneText;
+        anexoModal.dropzoneHint = dropzoneHint;
+        anexoModal.filesList = filesList;
+        anexoModal.emptyState = emptyState;
+        anexoModal.contextInfo = contextInfo;
+        anexoModal.selectedFiles = [];
+        anexoModal.pendingFile = null;
+
+        updateAnexoDropzoneText();
+        refreshAnexoModalControls();
+
+        return anexoModal;
+    }
+
+    function closeAnexoModal() {
+        if (!anexoModal.overlay) return;
+        anexoModal.overlay.classList.add('hidden');
+        anexoModal.overlay.setAttribute('aria-hidden', 'true');
+        if (anexoModal.form) anexoModal.form.reset();
+        anexoModal.selectedFiles = [];
+        anexoModal.pendingFile = null;
+        if (anexoModal.filesList) anexoModal.filesList.innerHTML = '';
+        if (anexoModal.emptyState) anexoModal.emptyState.classList.remove('hidden');
+        updateAnexoDropzoneText();
+        setAnexoModalSubmitting(false);
+        if (anexoModal.contextInfo) {
+            anexoModal.contextInfo.textContent = '';
+            anexoModal.contextInfo.classList.add('hidden');
+        }
+        if (anexoModal.keydownHandler) {
+            document.removeEventListener('keydown', anexoModal.keydownHandler);
+            anexoModal.keydownHandler = null;
+        }
+        refreshAnexoModalControls();
+    }
+
+    function openAnexoModal() {
+        if (!ensureTutorAndPetSelected()) {
+            return;
+        }
+
+        const modal = ensureAnexoModal();
+        modal.selectedFiles = [];
+        modal.pendingFile = null;
+        if (modal.form) modal.form.reset();
+        updateAnexoFilesGrid();
+        updateAnexoDropzoneText();
+        setAnexoModalSubmitting(false);
+        if (modal.overlay) {
+            modal.overlay.classList.remove('hidden');
+            modal.overlay.removeAttribute('aria-hidden');
+        }
+        if (modal.dialog) {
+            modal.dialog.focus();
+        }
+        if (modal.contextInfo) {
+            const tutorNome = pickFirst(
+                state.selectedCliente?.nome,
+                state.selectedCliente?.nomeCompleto,
+                state.selectedCliente?.nomeContato,
+                state.selectedCliente?.razaoSocial,
+            );
+            const pet = getSelectedPet();
+            const petNome = pickFirst(pet?.nome, pet?.name);
+            const contextParts = [];
+            if (tutorNome) contextParts.push(`Tutor: ${tutorNome}`);
+            if (petNome) contextParts.push(`Pet: ${petNome}`);
+            modal.contextInfo.textContent = contextParts.join(' · ');
+            modal.contextInfo.classList.toggle('hidden', contextParts.length === 0);
+        }
+        if (modal.keydownHandler) {
+            document.removeEventListener('keydown', modal.keydownHandler);
+        }
+        modal.keydownHandler = (event) => {
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                closeAnexoModal();
+            }
+        };
+        document.addEventListener('keydown', modal.keydownHandler);
+        setTimeout(() => {
+            if (modal.nameInput) modal.nameInput.focus();
+        }, 50);
+        refreshAnexoModalControls();
+    }
+
+    function handleAnexoFileSelection(file) {
+        if (!file) return;
+        if (!isAllowedAnexoFile(file)) {
+            notify('Formato de arquivo inválido. Utilize arquivos PNG, JPG, JPEG ou PDF.', 'warning');
+            return;
+        }
+        setAnexoPendingFile(file);
+    }
+
+    function handleAnexoAdd() {
+        const modal = ensureAnexoModal();
+        if (modal.isSubmitting) return;
+
+        const file = modal.pendingFile;
+        const nameValue = (modal.nameInput?.value || '').trim();
+        if (!file) {
+            notify('Selecione um arquivo para adicionar.', 'warning');
+            return;
+        }
+        if (!isAllowedAnexoFile(file)) {
+            notify('Formato de arquivo inválido. Utilize arquivos PNG, JPG, JPEG ou PDF.', 'warning');
+            setAnexoPendingFile(null);
+            return;
+        }
+        if (!nameValue) {
+            notify('Informe um nome para o arquivo.', 'warning');
+            if (modal.nameInput) modal.nameInput.focus();
+            return;
+        }
+
+        const entry = {
+            id: `tmp-anx-file-${Date.now()}-${Math.floor(Math.random() * 1e5)}`,
+            name: nameValue,
+            originalName: file.name,
+            size: Number(file.size || 0),
+            mimeType: file.type || '',
+            extension: getFileExtension(file.name),
+            file,
+        };
+        if (!Array.isArray(modal.selectedFiles)) modal.selectedFiles = [];
+        modal.selectedFiles.push(entry);
+        updateAnexoFilesGrid();
+        if (modal.nameInput) modal.nameInput.value = '';
+        setAnexoPendingFile(null);
+        if (modal.fileInput) modal.fileInput.value = '';
+        if (modal.nameInput) modal.nameInput.focus();
+    }
+
+    async function handleAnexoSubmit() {
+        const modal = ensureAnexoModal();
+        if (modal.isSubmitting) return;
+
+        if (!ensureTutorAndPetSelected()) {
+            return;
+        }
+
+        const files = Array.isArray(modal.selectedFiles) ? modal.selectedFiles : [];
+        if (!files.length) {
+            notify('Adicione pelo menos um arquivo antes de salvar.', 'warning');
+            return;
+        }
+
+        const clienteId = normalizeId(state.selectedCliente?._id);
+        const petId = normalizeId(state.selectedPetId);
+        if (!(clienteId && petId)) {
+            notify('Selecione um tutor e um pet para registrar anexos.', 'warning');
+            return;
+        }
+
+        const appointmentId = normalizeId(state.agendaContext?.appointmentId);
+
+        const formData = new FormData();
+        formData.append('clienteId', clienteId);
+        formData.append('petId', petId);
+        if (appointmentId) formData.append('appointmentId', appointmentId);
+
+        const fallbackFiles = [];
+
+        files.forEach((entry) => {
+            const file = entry.file;
+            if (!file) return;
+            const displayName = (entry.name || file.name || '').trim();
+            formData.append('arquivos', file, file.name);
+            formData.append('nomes[]', displayName || file.name);
+            fallbackFiles.push({
+                nome: displayName || file.name,
+                originalName: entry.originalName || file.name,
+                size: Number(entry.size || file.size || 0),
+                mimeType: entry.mimeType || file.type || '',
+                extension: entry.extension || getFileExtension(file.name),
+            });
+        });
+
+        setAnexoModalSubmitting(true);
+
+        try {
+            const response = await fetch(`${API_CONFIG.BASE_URL}/func/vet/anexos`, {
+                method: 'POST',
+                headers: {
+                    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+                },
+                body: formData,
+            });
+            const data = await response.json().catch(() => (response.ok ? {} : {}));
+            if (!response.ok) {
+                const message = typeof data?.message === 'string' ? data.message : 'Erro ao salvar anexos.';
+                throw new Error(message);
+            }
+
+            let record = null;
+            if (Array.isArray(data?.anexos)) {
+                record = data.anexos.map((item) => normalizeAnexoRecord(item, fallbackFiles)).find(Boolean) || null;
+            } else if (Array.isArray(data)) {
+                record = data.map((item) => normalizeAnexoRecord(item, fallbackFiles)).find(Boolean) || null;
+            } else {
+                record = normalizeAnexoRecord(data, fallbackFiles);
+            }
+            if (!record && fallbackFiles.length) {
+                record = normalizeAnexoRecord({ arquivos: fallbackFiles }, fallbackFiles);
+            }
+
+            const saved = upsertAnexoInState(record, fallbackFiles);
+            if (!saved && fallbackFiles.length) {
+                upsertAnexoInState({ arquivos: fallbackFiles }, fallbackFiles);
+            }
+            persistAnexosForSelection();
+            updateConsultaAgendaCard();
+            closeAnexoModal();
+            notify('Anexos salvos com sucesso.', 'success');
+            await loadAnexosFromServer({ force: true });
+        } catch (error) {
+            console.error('handleAnexoSubmit', error);
+            notify(error.message || 'Erro ao salvar anexos.', 'error');
+        } finally {
+            setAnexoModalSubmitting(false);
+        }
+    }
+
     function getSelectedPet() {
         const petId = state.selectedPetId;
         if (!petId) return null;
@@ -2211,6 +3233,9 @@
         const isLoadingConsultas = !!state.consultasLoading;
         const vacinas = Array.isArray(state.vacinas) ? state.vacinas : [];
         const hasVacinas = vacinas.length > 0;
+        const anexos = Array.isArray(state.anexos) ? state.anexos : [];
+        const hasAnexos = anexos.length > 0;
+        const isLoadingAnexos = !!state.anexosLoading;
         const context = state.agendaContext;
         const selectedPetId = normalizeId(state.selectedPetId);
         const selectedTutorId = normalizeId(state.selectedCliente?._id);
@@ -2341,13 +3366,14 @@
             }
         }
 
-        const shouldShowPlaceholder = !hasManualConsultas && !hasAgendaContent && !hasVacinas;
+        const hasAnyContent = hasManualConsultas || hasAgendaContent || hasVacinas || hasAnexos;
+        const shouldShowPlaceholder = !hasAnyContent;
 
-        if (isLoadingConsultas && !hasManualConsultas && !hasAgendaContent && !hasVacinas) {
+        if ((isLoadingConsultas || isLoadingAnexos) && !hasAnyContent) {
             area.className = CONSULTA_PLACEHOLDER_CLASSNAMES;
             area.innerHTML = '';
             const paragraph = document.createElement('p');
-            paragraph.textContent = 'Carregando consultas...';
+            paragraph.textContent = 'Carregando registros...';
             area.appendChild(paragraph);
             return;
         }
@@ -2367,6 +3393,19 @@
         const scroll = document.createElement('div');
         scroll.className = 'h-full w-full overflow-y-auto p-5 space-y-4';
         area.appendChild(scroll);
+
+        if (hasAnexos) {
+            const orderedAnexos = [...anexos];
+            orderedAnexos.sort((a, b) => {
+                const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+                const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+                return bTime - aTime;
+            });
+            orderedAnexos.forEach((anexo) => {
+                const card = createAnexoCard(anexo);
+                if (card) scroll.appendChild(card);
+            });
+        }
 
         if (hasVacinas) {
             const orderedVacinas = [...vacinas];
@@ -2518,6 +3557,9 @@
         state.consultasLoadKey = null;
         state.consultasLoading = false;
         state.vacinas = [];
+        state.anexos = [];
+        state.anexosLoadKey = null;
+        state.anexosLoading = false;
         const tutorId = normalizeId(state.selectedCliente?._id);
         if (state.agendaContext) {
             const contextTutorId = normalizeId(state.agendaContext.tutorId);
@@ -2609,14 +3651,21 @@
         state.consultas = [];
         state.consultasLoadKey = null;
         state.consultasLoading = false;
+        state.anexos = [];
+        state.anexosLoadKey = null;
+        state.anexosLoading = false;
         loadVacinasForSelection();
+        loadAnexosForSelection();
         updateCardDisplay();
         updatePageVisibility();
         if (!state.selectedPetId) {
             updateConsultaAgendaCard();
             return;
         }
-        await loadConsultasFromServer({ force: true });
+        await Promise.all([
+            loadConsultasFromServer({ force: true }),
+            loadAnexosFromServer({ force: true }),
+        ]);
     }
 
     function clearCliente() {
@@ -2628,6 +3677,9 @@
         state.consultasLoadKey = null;
         state.consultasLoading = false;
         state.vacinas = [];
+        state.anexos = [];
+        state.anexosLoadKey = null;
+        state.anexosLoading = false;
         persistAgendaContext(null);
         if (els.cliInput) els.cliInput.value = '';
         hideSugestoes();
@@ -2652,6 +3704,9 @@
         state.consultasLoadKey = null;
         state.consultasLoading = false;
         state.vacinas = [];
+        state.anexos = [];
+        state.anexosLoadKey = null;
+        state.anexosLoading = false;
         updateCardDisplay();
         updatePageVisibility();
     }
@@ -2733,6 +3788,12 @@
         els.addVacinaBtn.addEventListener('click', (e) => {
             e.preventDefault();
             openVacinaModal();
+        });
+    }
+    if (els.addAnexoBtn) {
+        els.addAnexoBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            openAnexoModal();
         });
     }
     updateCardDisplay();

--- a/src/output.css
+++ b/src/output.css
@@ -40,6 +40,7 @@
     --color-emerald-50: oklch(97.9% 0.021 166.113);
     --color-emerald-100: oklch(95% 0.052 163.051);
     --color-emerald-200: oklch(90.5% 0.093 164.15);
+    --color-emerald-400: oklch(76.5% 0.177 163.223);
     --color-emerald-500: oklch(69.6% 0.17 162.48);
     --color-emerald-600: oklch(59.6% 0.145 163.225);
     --color-emerald-700: oklch(50.8% 0.118 165.612);
@@ -59,8 +60,17 @@
     --color-blue-600: oklch(54.6% 0.245 262.881);
     --color-blue-700: oklch(48.8% 0.243 264.376);
     --color-blue-800: oklch(42.4% 0.199 265.638);
+    --color-indigo-50: oklch(96.2% 0.018 272.314);
+    --color-indigo-100: oklch(93% 0.034 272.788);
+    --color-indigo-200: oklch(87% 0.065 274.039);
+    --color-indigo-300: oklch(78.5% 0.115 274.713);
+    --color-indigo-400: oklch(67.3% 0.182 276.935);
+    --color-indigo-500: oklch(58.5% 0.233 277.117);
+    --color-indigo-600: oklch(51.1% 0.262 276.966);
+    --color-indigo-700: oklch(45.7% 0.24 277.023);
     --color-rose-50: oklch(96.9% 0.015 12.422);
     --color-rose-100: oklch(94.1% 0.03 12.58);
+    --color-rose-600: oklch(58.6% 0.253 17.585);
     --color-slate-50: oklch(98.4% 0.003 247.858);
     --color-slate-100: oklch(96.8% 0.007 247.896);
     --color-slate-200: oklch(92.9% 0.013 255.508);
@@ -1345,6 +1355,18 @@
   .border-green-500 {
     border-color: var(--color-green-500);
   }
+  .border-indigo-100 {
+    border-color: var(--color-indigo-100);
+  }
+  .border-indigo-200 {
+    border-color: var(--color-indigo-200);
+  }
+  .border-indigo-300 {
+    border-color: var(--color-indigo-300);
+  }
+  .border-indigo-400 {
+    border-color: var(--color-indigo-400);
+  }
   .border-primary {
     border-color: var(--color-primary);
   }
@@ -1452,6 +1474,27 @@
   }
   .bg-green-600 {
     background-color: var(--color-green-600);
+  }
+  .bg-indigo-50 {
+    background-color: var(--color-indigo-50);
+  }
+  .bg-indigo-50\/60 {
+    background-color: color-mix(in srgb, oklch(96.2% 0.018 272.314) 60%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-indigo-50) 60%, transparent);
+    }
+  }
+  .bg-indigo-50\/70 {
+    background-color: color-mix(in srgb, oklch(96.2% 0.018 272.314) 70%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-indigo-50) 70%, transparent);
+    }
+  }
+  .bg-indigo-100 {
+    background-color: var(--color-indigo-100);
+  }
+  .bg-indigo-600 {
+    background-color: var(--color-indigo-600);
   }
   .bg-light {
     background-color: var(--color-light);
@@ -1902,6 +1945,18 @@
   .text-green-800 {
     color: var(--color-green-800);
   }
+  .text-indigo-400 {
+    color: var(--color-indigo-400);
+  }
+  .text-indigo-500 {
+    color: var(--color-indigo-500);
+  }
+  .text-indigo-600 {
+    color: var(--color-indigo-600);
+  }
+  .text-indigo-700 {
+    color: var(--color-indigo-700);
+  }
   .text-primary {
     color: var(--color-primary);
   }
@@ -1913,6 +1968,9 @@
   }
   .text-red-700 {
     color: var(--color-red-700);
+  }
+  .text-rose-600 {
+    color: var(--color-rose-600);
   }
   .text-sky-600 {
     color: var(--color-sky-600);
@@ -2022,6 +2080,10 @@
   }
   .shadow-xl {
     --tw-shadow: 0 20px 25px -5px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 8px 10px -6px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .ring {
+    --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
   .ring-1 {
@@ -2332,6 +2394,13 @@
       }
     }
   }
+  .hover\:border-indigo-400 {
+    &:hover {
+      @media (hover: hover) {
+        border-color: var(--color-indigo-400);
+      }
+    }
+  }
   .hover\:border-primary {
     &:hover {
       @media (hover: hover) {
@@ -2436,6 +2505,20 @@
       }
     }
   }
+  .hover\:bg-indigo-600 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-indigo-600);
+      }
+    }
+  }
+  .hover\:bg-indigo-700 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-indigo-700);
+      }
+    }
+  }
   .hover\:bg-primary {
     &:hover {
       @media (hover: hover) {
@@ -2511,6 +2594,13 @@
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-red-700);
+      }
+    }
+  }
+  .hover\:bg-rose-50 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-rose-50);
       }
     }
   }
@@ -2602,6 +2692,13 @@
     &:hover {
       @media (hover: hover) {
         color: var(--color-green-800);
+      }
+    }
+  }
+  .hover\:text-indigo-600 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-indigo-600);
       }
     }
   }
@@ -2724,6 +2821,16 @@
       }
     }
   }
+  .focus\:border-emerald-500 {
+    &:focus {
+      border-color: var(--color-emerald-500);
+    }
+  }
+  .focus\:border-indigo-500 {
+    &:focus {
+      border-color: var(--color-indigo-500);
+    }
+  }
   .focus\:border-primary {
     &:focus {
       border-color: var(--color-primary);
@@ -2751,9 +2858,29 @@
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
   }
+  .focus\:ring-emerald-200 {
+    &:focus {
+      --tw-ring-color: var(--color-emerald-200);
+    }
+  }
+  .focus\:ring-emerald-400 {
+    &:focus {
+      --tw-ring-color: var(--color-emerald-400);
+    }
+  }
   .focus\:ring-emerald-500 {
     &:focus {
       --tw-ring-color: var(--color-emerald-500);
+    }
+  }
+  .focus\:ring-indigo-200 {
+    &:focus {
+      --tw-ring-color: var(--color-indigo-200);
+    }
+  }
+  .focus\:ring-indigo-400 {
+    &:focus {
+      --tw-ring-color: var(--color-indigo-400);
     }
   }
   .focus\:ring-primary {
@@ -2804,6 +2931,11 @@
   .disabled\:opacity-50 {
     &:disabled {
       opacity: 50%;
+    }
+  }
+  .disabled\:opacity-60 {
+    &:disabled {
+      opacity: 60%;
     }
   }
   .disabled\:opacity-75 {
@@ -2865,6 +2997,11 @@
   .sm\:grid-cols-4 {
     @media (width >= 40rem) {
       grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+  }
+  .sm\:grid-cols-\[minmax\(0\,1fr\)_minmax\(0\,1fr\)_auto\] {
+    @media (width >= 40rem) {
+      grid-template-columns: minmax(0,1fr) minmax(0,1fr) auto;
     }
   }
   .sm\:flex-row {


### PR DESCRIPTION
## Summary
- hook up the "Anexo" ação rápida button to a new attachments modal with drag-and-drop support and validation
- persist anexos per tutor/pet, upload files through the existing API (for Google Drive) and render saved items as cards alongside consultas e vacinas
- refresh Tailwind output so the new modal and cards share consistent styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cafe5094848323b66a9b5ccab87aab