### PR TITLE
Add Google Drive-backed vet attachment endpoints

### DIFF
--- a/servidor/models/VetAttachment.js
+++ b/servidor/models/VetAttachment.js
@@ -1,0 +1,98 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const VetAttachmentFileSchema = new Schema({
+  nome: {
+    type: String,
+    required: true,
+    trim: true,
+  },
+  originalName: {
+    type: String,
+    trim: true,
+    default: '',
+  },
+  mimeType: {
+    type: String,
+    trim: true,
+    default: '',
+  },
+  size: {
+    type: Number,
+    default: 0,
+  },
+  extension: {
+    type: String,
+    trim: true,
+    default: '',
+  },
+  url: {
+    type: String,
+    trim: true,
+    default: '',
+  },
+  driveFileId: {
+    type: String,
+    trim: true,
+    default: '',
+  },
+  driveViewLink: {
+    type: String,
+    trim: true,
+    default: '',
+  },
+  driveContentLink: {
+    type: String,
+    trim: true,
+    default: '',
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+}, { _id: true, id: false });
+
+const VetAttachmentSchema = new Schema({
+  cliente: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true,
+  },
+  pet: {
+    type: Schema.Types.ObjectId,
+    ref: 'Pet',
+    required: true,
+    index: true,
+  },
+  appointment: {
+    type: Schema.Types.ObjectId,
+    ref: 'Appointment',
+    default: null,
+  },
+  observacao: {
+    type: String,
+    default: '',
+    trim: true,
+  },
+  arquivos: {
+    type: [VetAttachmentFileSchema],
+    default: [],
+  },
+  createdBy: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    default: null,
+  },
+  updatedBy: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    default: null,
+  },
+}, { timestamps: true });
+
+VetAttachmentSchema.index({ cliente: 1, pet: 1, createdAt: -1 });
+VetAttachmentSchema.index({ appointment: 1 });
+
+module.exports = mongoose.model('VetAttachment', VetAttachmentSchema);

--- a/servidor/routes/funcVet.js
+++ b/servidor/routes/funcVet.js
@@ -1,5 +1,7 @@
 const express = require('express');
 const mongoose = require('mongoose');
+const path = require('path');
+const multer = require('multer');
 
 const authMiddleware = require('../middlewares/authMiddleware');
 const authorizeRoles = require('../middlewares/authorizeRoles');
@@ -7,9 +9,47 @@ const Pet = require('../models/Pet');
 const Service = require('../models/Service');
 const Appointment = require('../models/Appointment');
 const VetConsultation = require('../models/VetConsultation');
+const VetAttachment = require('../models/VetAttachment');
+const {
+  isDriveConfigured,
+  getDriveFolderId,
+  uploadBufferToDrive,
+  deleteFile,
+} = require('../utils/googleDrive');
 
 const router = express.Router();
 const requireStaff = authorizeRoles('funcionario', 'admin', 'admin_master');
+
+const ALLOWED_ANEXO_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.pdf']);
+const ALLOWED_ANEXO_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'application/pdf']);
+const MAX_ANEXO_FILE_SIZE = 20 * 1024 * 1024; // 20MB
+const MAX_ANEXO_FILE_COUNT = 10;
+
+const uploadAnexoMiddleware = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: MAX_ANEXO_FILE_SIZE,
+    files: MAX_ANEXO_FILE_COUNT,
+  },
+});
+
+function handleAnexoUpload(req, res, next) {
+  uploadAnexoMiddleware.array('arquivos', MAX_ANEXO_FILE_COUNT)(req, res, (err) => {
+    if (err instanceof multer.MulterError) {
+      if (err.code === 'LIMIT_FILE_SIZE') {
+        return res.status(400).json({ message: 'Cada arquivo deve ter no máximo 20MB.' });
+      }
+      if (err.code === 'LIMIT_FILE_COUNT') {
+        return res.status(400).json({ message: `Envie no máximo ${MAX_ANEXO_FILE_COUNT} arquivos por vez.` });
+      }
+      return res.status(400).json({ message: 'Falha ao processar os arquivos enviados.' });
+    }
+    if (err) {
+      return res.status(400).json({ message: 'Falha ao processar os arquivos enviados.' });
+    }
+    return next();
+  });
+}
 
 function normalizeObjectId(value) {
   if (!value) return null;
@@ -31,6 +71,41 @@ function toStringSafe(value) {
   } catch (_) {
     return null;
   }
+}
+
+function toIsoDate(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function sanitizeFileName(name) {
+  if (!name) return '';
+  return String(name)
+    .replace(/[\\/:*?"<>|]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function ensureFileNameWithExtension(name, extension) {
+  if (!extension) return name || '';
+  const ext = extension.startsWith('.') ? extension : `.${extension}`;
+  const lower = (name || '').toLowerCase();
+  if (lower.endsWith(ext.toLowerCase())) {
+    return name || '';
+  }
+  return `${name || ''}${ext}`;
+}
+
+function inferExtensionFromFile(file) {
+  const original = path.extname(file?.originalname || '').toLowerCase();
+  if (original) return original;
+  const mime = String(file?.mimetype || '').toLowerCase();
+  if (mime === 'image/png') return '.png';
+  if (mime === 'image/jpeg') return '.jpg';
+  if (mime === 'application/pdf') return '.pdf';
+  return '';
 }
 
 function isVetService(serviceDoc = {}) {
@@ -116,6 +191,90 @@ function formatConsultation(doc) {
   };
 }
 
+function formatAttachment(doc) {
+  if (!doc) return null;
+  const createdAt = toIsoDate(doc.createdAt);
+  const updatedAt = toIsoDate(doc.updatedAt) || createdAt;
+  const arquivosRaw = Array.isArray(doc.arquivos) ? doc.arquivos : [];
+  const arquivos = arquivosRaw
+    .map((file) => {
+      if (!file) return null;
+      const fileId = toStringSafe(file._id || file.id);
+      const extension = typeof file.extension === 'string' ? file.extension : '';
+      return {
+        id: fileId || undefined,
+        _id: fileId || undefined,
+        nome: file.nome || file.originalName || 'Arquivo',
+        originalName: file.originalName || '',
+        mimeType: file.mimeType || '',
+        size: Number(file.size || 0),
+        extension: extension || '',
+        url: file.url || file.driveViewLink || file.driveContentLink || '',
+        driveFileId: file.driveFileId || '',
+        createdAt: toIsoDate(file.createdAt) || createdAt,
+      };
+    })
+    .filter(Boolean);
+
+  arquivos.sort((a, b) => {
+    const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return bTime - aTime;
+  });
+
+  return {
+    id: toStringSafe(doc._id),
+    _id: toStringSafe(doc._id),
+    clienteId: toStringSafe(doc.cliente),
+    petId: toStringSafe(doc.pet),
+    appointmentId: toStringSafe(doc.appointment),
+    observacao: typeof doc.observacao === 'string' ? doc.observacao : '',
+    createdAt,
+    updatedAt,
+    arquivos,
+  };
+}
+
+router.get('/vet/anexos', authMiddleware, requireStaff, async (req, res) => {
+  try {
+    const clienteId = normalizeObjectId(req.query.clienteId);
+    const petId = normalizeObjectId(req.query.petId);
+    const appointmentId = normalizeObjectId(req.query.appointmentId);
+
+    if (!(clienteId && petId)) {
+      return res.status(400).json({ message: 'clienteId e petId são obrigatórios.' });
+    }
+
+    const petCheck = await ensurePetBelongsToCliente(petId, clienteId);
+    if (!petCheck.ok) {
+      return res.status(petCheck.status).json({ message: petCheck.message });
+    }
+
+    const query = {
+      cliente: clienteId,
+      pet: petId,
+    };
+
+    if (appointmentId) {
+      query.$or = [
+        { appointment: appointmentId },
+        { appointment: { $exists: false } },
+        { appointment: null },
+      ];
+    }
+
+    const docs = await VetAttachment.find(query)
+      .sort({ createdAt: -1 })
+      .lean();
+
+    const formatted = docs.map(formatAttachment).filter(Boolean);
+    return res.json(formatted);
+  } catch (error) {
+    console.error('GET /func/vet/anexos', error);
+    return res.status(500).json({ message: 'Erro ao carregar anexos.' });
+  }
+});
+
 router.get('/vet/consultas', authMiddleware, requireStaff, async (req, res) => {
   try {
     const clienteId = normalizeObjectId(req.query.clienteId);
@@ -159,6 +318,138 @@ router.get('/vet/consultas/:id', authMiddleware, requireStaff, async (req, res) 
   } catch (error) {
     console.error('GET /func/vet/consultas/:id', error);
     res.status(500).json({ message: 'Erro ao buscar consulta.' });
+  }
+});
+
+router.post('/vet/anexos', authMiddleware, requireStaff, handleAnexoUpload, async (req, res) => {
+  const uploadedDriveIds = [];
+  try {
+    if (!isDriveConfigured()) {
+      return res.status(500).json({ message: 'Integração com o Google Drive não está configurada.' });
+    }
+
+    const cliente = normalizeObjectId(req.body.clienteId);
+    const pet = normalizeObjectId(req.body.petId);
+    const appointment = normalizeObjectId(req.body.appointmentId);
+
+    if (!(cliente && pet)) {
+      return res.status(400).json({ message: 'clienteId e petId são obrigatórios.' });
+    }
+
+    const files = Array.isArray(req.files) ? req.files : [];
+    if (!files.length) {
+      return res.status(400).json({ message: 'Envie ao menos um arquivo.' });
+    }
+
+    const invalidFile = files.find((file) => {
+      const extension = inferExtensionFromFile(file).toLowerCase();
+      const mime = String(file?.mimetype || '').toLowerCase();
+      return !(
+        (extension && ALLOWED_ANEXO_EXTENSIONS.has(extension)) ||
+        ALLOWED_ANEXO_MIME_TYPES.has(mime)
+      );
+    });
+
+    if (invalidFile) {
+      return res.status(400).json({
+        message: `Formato de arquivo não suportado: ${invalidFile.originalname || 'arquivo'}. Permitido: PNG, JPG, JPEG ou PDF.`,
+      });
+    }
+
+    const petCheck = await ensurePetBelongsToCliente(pet, cliente);
+    if (!petCheck.ok) {
+      return res.status(petCheck.status).json({ message: petCheck.message });
+    }
+
+    const appointmentCheck = await ensureAppointmentLink(appointment, cliente, pet, null);
+    if (!appointmentCheck.ok) {
+      return res.status(appointmentCheck.status).json({ message: appointmentCheck.message });
+    }
+
+    const rawNames = req.body['nomes[]'];
+    const providedNames = Array.isArray(rawNames)
+      ? rawNames
+      : (typeof rawNames === 'string' ? [rawNames] : []);
+
+    const folderId = getDriveFolderId();
+    const uploadedFiles = [];
+
+    for (let index = 0; index < files.length; index += 1) {
+      const file = files[index];
+      const providedName = typeof providedNames[index] === 'string' ? providedNames[index] : '';
+      const sanitizedProvided = sanitizeFileName(providedName);
+      const fallbackName = sanitizeFileName(file.originalname) || `Arquivo ${index + 1}`;
+      const displayName = sanitizedProvided || fallbackName || `Arquivo ${index + 1}`;
+      const extension = inferExtensionFromFile(file).toLowerCase();
+
+      let driveBaseName = sanitizeFileName(displayName) || `arquivo-${Date.now()}-${index + 1}`;
+      let driveFileName = ensureFileNameWithExtension(driveBaseName, extension || inferExtensionFromFile(file));
+      driveFileName = sanitizeFileName(driveFileName);
+      if (!driveFileName) {
+        driveFileName = `arquivo-${Date.now()}-${index + 1}${extension || ''}`;
+      } else if (extension && !driveFileName.toLowerCase().endsWith(extension)) {
+        driveFileName = `${driveFileName}${extension}`;
+      }
+
+      const uploadResult = await uploadBufferToDrive(file.buffer, {
+        mimeType: file.mimetype || 'application/octet-stream',
+        name: driveFileName,
+        folderId,
+      });
+
+      if (uploadResult?.id) {
+        uploadedDriveIds.push(uploadResult.id);
+      }
+
+      uploadedFiles.push({
+        nome: displayName,
+        originalName: file.originalname || '',
+        mimeType: uploadResult?.mimeType || file.mimetype || '',
+        size: Number(uploadResult?.size) || Number(file.size || 0),
+        extension: extension || '',
+        url: uploadResult?.webViewLink || uploadResult?.webContentLink || '',
+        driveFileId: uploadResult?.id || '',
+        driveViewLink: uploadResult?.webViewLink || '',
+        driveContentLink: uploadResult?.webContentLink || '',
+        createdAt: new Date(),
+      });
+    }
+
+    const nowUserId = normalizeObjectId(req.user?.id);
+    const doc = await VetAttachment.create({
+      cliente,
+      pet,
+      appointment: appointment || undefined,
+      observacao: typeof req.body.observacao === 'string' ? req.body.observacao.trim() : '',
+      arquivos: uploadedFiles,
+      createdBy: nowUserId || undefined,
+      updatedBy: nowUserId || undefined,
+    });
+
+    const full = await VetAttachment.findById(doc._id).lean();
+    return res.status(201).json(formatAttachment(full));
+  } catch (error) {
+    if (uploadedDriveIds.length) {
+      await Promise.allSettled(uploadedDriveIds.map((id) => deleteFile(id)));
+    }
+    console.error('POST /func/vet/anexos', error);
+    let message = 'Erro ao salvar anexos.';
+    if (error?.body) {
+      try {
+        const parsed = JSON.parse(error.body.toString('utf8'));
+        if (parsed?.error?.message) {
+          message = `Google Drive: ${parsed.error.message}`;
+        } else if (parsed?.error_description) {
+          message = `Google Drive: ${parsed.error_description}`;
+        }
+      } catch (_) {
+        // ignore parsing issues
+      }
+    }
+    if (message === 'Erro ao salvar anexos.' && error?.message) {
+      message = error.message;
+    }
+    return res.status(500).json({ message });
   }
 });
 

--- a/servidor/utils/googleDrive.js
+++ b/servidor/utils/googleDrive.js
@@ -3,7 +3,7 @@ const { URL } = require('url');
 const jwt = require('jsonwebtoken');
 
 const TOKEN_URI = 'https://oauth2.googleapis.com/token';
-const UPLOAD_URI = 'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,name,mimeType,size,webViewLink,webContentLink';
+const UPLOAD_URI = 'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&supportsAllDrives=true&fields=id,name,mimeType,size,webViewLink,webContentLink';
 const FILES_URI = 'https://www.googleapis.com/drive/v3/files';
 const DRIVE_SCOPE = 'https://www.googleapis.com/auth/drive.file';
 
@@ -190,7 +190,7 @@ async function ensureFileIsPublic(fileId, token) {
 
   try {
     await requestGoogle({
-      url: `${FILES_URI}/${fileId}/permissions`,
+      url: `${FILES_URI}/${fileId}/permissions?supportsAllDrives=true`,
       method: 'POST',
       headers,
       body: Buffer.from(body, 'utf8'),
@@ -206,7 +206,7 @@ async function getFileMetadata(fileId, token) {
     Authorization: `Bearer ${token}`,
   };
   const response = await requestGoogle({
-    url: `${FILES_URI}/${fileId}?fields=id,name,mimeType,size,webViewLink,webContentLink`,
+    url: `${FILES_URI}/${fileId}?supportsAllDrives=true&fields=id,name,mimeType,size,webViewLink,webContentLink`,
     method: 'GET',
     headers,
   });
@@ -288,7 +288,7 @@ async function deleteFile(fileId) {
   try {
     const token = await fetchAccessToken();
     await requestGoogle({
-      url: `${FILES_URI}/${fileId}`,
+      url: `${FILES_URI}/${fileId}?supportsAllDrives=true`,
       method: 'DELETE',
       headers: {
         Authorization: `Bearer ${token}`,

--- a/servidor/utils/googleDrive.js
+++ b/servidor/utils/googleDrive.js
@@ -1,0 +1,308 @@
+const https = require('https');
+const { URL } = require('url');
+const jwt = require('jsonwebtoken');
+
+const TOKEN_URI = 'https://oauth2.googleapis.com/token';
+const UPLOAD_URI = 'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,name,mimeType,size,webViewLink,webContentLink';
+const FILES_URI = 'https://www.googleapis.com/drive/v3/files';
+const DRIVE_SCOPE = 'https://www.googleapis.com/auth/drive.file';
+
+let cachedCredentials = null;
+let cachedAccessToken = null;
+let cachedAccessTokenExpiry = 0;
+let pendingTokenPromise = null;
+
+function cleanEnvValue(value) {
+  if (typeof value !== 'string') return '';
+  let cleaned = value.trim();
+  if (
+    (cleaned.startsWith('"') && cleaned.endsWith('"')) ||
+    (cleaned.startsWith("'") && cleaned.endsWith("'"))
+  ) {
+    cleaned = cleaned.slice(1, -1);
+  }
+  return cleaned.trim();
+}
+
+function getCredentials() {
+  if (cachedCredentials) {
+    return cachedCredentials;
+  }
+
+  const clientEmail = cleanEnvValue(process.env.GOOGLE_DRIVE_CLIENT_EMAIL || '');
+  let privateKey = cleanEnvValue(process.env.GOOGLE_DRIVE_PRIVATE_KEY || '');
+  if (privateKey.includes('\\n')) {
+    privateKey = privateKey.replace(/\\n/g, '\n');
+  }
+  if (privateKey.includes('\\r')) {
+    privateKey = privateKey.replace(/\\r/g, '\r');
+  }
+
+  if (!(clientEmail && privateKey)) {
+    return null;
+  }
+
+  const folderId = cleanEnvValue(process.env.GOOGLE_DRIVE_FOLDER_ID || '') || null;
+
+  cachedCredentials = { clientEmail, privateKey, folderId };
+  return cachedCredentials;
+}
+
+function resetCredentialsCache() {
+  cachedCredentials = null;
+  cachedAccessToken = null;
+  cachedAccessTokenExpiry = 0;
+  pendingTokenPromise = null;
+}
+
+function isDriveConfigured() {
+  return !!getCredentials();
+}
+
+function getDriveFolderId() {
+  const creds = getCredentials();
+  return creds?.folderId || null;
+}
+
+function requestGoogle({ url, method = 'GET', headers = {}, body = null }) {
+  return new Promise((resolve, reject) => {
+    try {
+      const parsed = new URL(url);
+      const options = {
+        method,
+        hostname: parsed.hostname,
+        path: parsed.pathname + parsed.search,
+        headers,
+      };
+
+      const req = https.request(options, (res) => {
+        const chunks = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          const buffer = Buffer.concat(chunks);
+          if (res.statusCode >= 200 && res.statusCode < 300) {
+            resolve({ status: res.statusCode, headers: res.headers, body: buffer });
+            return;
+          }
+          const error = new Error(`Request failed with status ${res.statusCode}`);
+          error.status = res.statusCode;
+          error.headers = res.headers;
+          error.body = buffer;
+          reject(error);
+        });
+      });
+
+      req.on('error', reject);
+
+      if (body) {
+        req.write(body);
+      }
+
+      req.end();
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+async function fetchAccessToken() {
+  const credentials = getCredentials();
+  if (!credentials) {
+    throw new Error('Credenciais do Google Drive não configuradas.');
+  }
+
+  if (cachedAccessToken && cachedAccessTokenExpiry > Date.now() + 60000) {
+    return cachedAccessToken;
+  }
+
+  if (pendingTokenPromise) {
+    return pendingTokenPromise;
+  }
+
+  pendingTokenPromise = (async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const payload = {
+      iss: credentials.clientEmail,
+      scope: DRIVE_SCOPE,
+      aud: TOKEN_URI,
+      iat: now,
+      exp: now + 3600,
+    };
+
+    const assertion = jwt.sign(payload, credentials.privateKey, { algorithm: 'RS256' });
+    const params = new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion,
+    });
+    const bodyString = params.toString();
+    const headers = {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Length': Buffer.byteLength(bodyString),
+    };
+
+    const response = await requestGoogle({
+      url: TOKEN_URI,
+      method: 'POST',
+      headers,
+      body: Buffer.from(bodyString, 'utf8'),
+    });
+
+    let data;
+    try {
+      data = JSON.parse(response.body.toString('utf8'));
+    } catch (error) {
+      throw new Error('Resposta inválida ao obter token do Google Drive.');
+    }
+
+    const accessToken = data?.access_token;
+    if (!accessToken) {
+      throw new Error('Token de acesso não recebido do Google Drive.');
+    }
+
+    const expiresIn = Number(data.expires_in) || 3600;
+    cachedAccessToken = accessToken;
+    cachedAccessTokenExpiry = Date.now() + (expiresIn - 120) * 1000;
+    pendingTokenPromise = null;
+
+    return accessToken;
+  })();
+
+  try {
+    const token = await pendingTokenPromise;
+    pendingTokenPromise = null;
+    return token;
+  } catch (error) {
+    pendingTokenPromise = null;
+    cachedAccessToken = null;
+    cachedAccessTokenExpiry = 0;
+    throw error;
+  }
+}
+
+async function ensureFileIsPublic(fileId, token) {
+  if (!fileId) return;
+  const body = JSON.stringify({ role: 'reader', type: 'anyone' });
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(body),
+  };
+
+  try {
+    await requestGoogle({
+      url: `${FILES_URI}/${fileId}/permissions`,
+      method: 'POST',
+      headers,
+      body: Buffer.from(body, 'utf8'),
+    });
+  } catch (error) {
+    // Apenas registra o erro e segue.
+    console.error('googleDrive.ensureFileIsPublic', error?.status || '', error?.body?.toString('utf8') || error?.message);
+  }
+}
+
+async function getFileMetadata(fileId, token) {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+  };
+  const response = await requestGoogle({
+    url: `${FILES_URI}/${fileId}?fields=id,name,mimeType,size,webViewLink,webContentLink`,
+    method: 'GET',
+    headers,
+  });
+  try {
+    return JSON.parse(response.body.toString('utf8'));
+  } catch (error) {
+    return null;
+  }
+}
+
+async function uploadBufferToDrive(buffer, options = {}) {
+  if (!Buffer.isBuffer(buffer)) {
+    throw new Error('Buffer inválido para upload.');
+  }
+
+  const credentials = getCredentials();
+  if (!credentials) {
+    throw new Error('Credenciais do Google Drive não configuradas.');
+  }
+
+  const token = await fetchAccessToken();
+  const boundary = `gc_boundary_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  const mimeType = options.mimeType || 'application/octet-stream';
+  const parents = Array.isArray(options.parents) ? options.parents.filter(Boolean) : [];
+  const folderId = options.folderId || credentials.folderId;
+  if (folderId) {
+    parents.push(folderId);
+  }
+
+  const metadata = {
+    name: options.name || `arquivo-${Date.now()}`,
+  };
+  if (parents.length) {
+    metadata.parents = parents;
+  }
+
+  const metaString = JSON.stringify(metadata);
+  const preamble = Buffer.from(`--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${metaString}\r\n`);
+  const header = Buffer.from(`--${boundary}\r\nContent-Type: ${mimeType}\r\n\r\n`);
+  const closing = Buffer.from(`\r\n--${boundary}--\r\n`);
+  const multipartBody = Buffer.concat([preamble, header, buffer, closing]);
+
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': `multipart/related; boundary=${boundary}`,
+    'Content-Length': multipartBody.length,
+  };
+
+  const response = await requestGoogle({
+    url: UPLOAD_URI,
+    method: 'POST',
+    headers,
+    body: multipartBody,
+  });
+
+  let fileData = {};
+  try {
+    fileData = JSON.parse(response.body.toString('utf8'));
+  } catch (error) {
+    fileData = {};
+  }
+
+  const fileId = fileData?.id;
+  if (!fileId) {
+    throw new Error('Falha ao criar arquivo no Google Drive.');
+  }
+
+  await ensureFileIsPublic(fileId, token);
+  const metadataResponse = await getFileMetadata(fileId, token);
+  if (metadataResponse) {
+    return metadataResponse;
+  }
+
+  return fileData;
+}
+
+async function deleteFile(fileId) {
+  if (!fileId) return;
+  try {
+    const token = await fetchAccessToken();
+    await requestGoogle({
+      url: `${FILES_URI}/${fileId}`,
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  } catch (error) {
+    console.error('googleDrive.deleteFile', error?.status || '', error?.body?.toString('utf8') || error?.message);
+  }
+}
+
+module.exports = {
+  isDriveConfigured,
+  getDriveFolderId,
+  uploadBufferToDrive,
+  deleteFile,
+  resetCredentialsCache,
+};


### PR DESCRIPTION
## Summary
- add a VetAttachment model to persist metadata for files linked to tutor and pet records
- integrate a Google Drive utility for service-account uploads, token caching, and cleanup helpers
- expose /func/vet/anexos GET/POST endpoints that validate files, push them to Drive, and return normalized attachment data

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cb18c6f1ec8323845f0fa07f5fb52c