### PR TITLE
Refatorar integração do Google Drive para OAuth 2.0

### DIFF
--- a/scripts/funcionarios/vet/ficha-clinica/consultas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/consultas.js
@@ -351,6 +351,10 @@ function createAnexoCard(anexo) {
 
   const card = document.createElement('article');
   card.className = 'rounded-xl border border-indigo-200 bg-white p-4 shadow-sm';
+  const anexoId = normalizeId(anexo.id || anexo._id);
+  if (anexoId) {
+    card.dataset.anexoId = anexoId;
+  }
 
   const header = document.createElement('div');
   header.className = 'flex items-start gap-3';
@@ -364,6 +368,51 @@ function createAnexoCard(anexo) {
   const headerText = document.createElement('div');
   headerText.className = 'flex-1';
   header.appendChild(headerText);
+
+  const headerActions = document.createElement('div');
+  headerActions.className = 'ml-auto flex items-start';
+  header.appendChild(headerActions);
+
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.className = 'inline-flex items-center gap-1 rounded-full border border-rose-200 bg-rose-50 px-2 py-1 text-[11px] font-medium text-rose-600 transition hover:bg-rose-600 hover:text-white focus:outline-none focus:ring-2 focus:ring-rose-200';
+  removeBtn.innerHTML = '<i class="fas fa-trash-can text-[10px]"></i><span>Remover</span>';
+  removeBtn.title = 'Remover anexo';
+
+  const toggleRemoveDisabled = (disabled) => {
+    removeBtn.disabled = !!disabled;
+    removeBtn.classList.toggle('opacity-60', !!disabled);
+    removeBtn.classList.toggle('cursor-not-allowed', !!disabled);
+  };
+
+  removeBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const handler = state?.deleteAnexo;
+    if (typeof handler !== 'function') {
+      notify('Não foi possível remover o anexo agora. Recarregue a página e tente novamente.', 'error');
+      return;
+    }
+
+    toggleRemoveDisabled(true);
+    let result;
+    try {
+      result = handler(anexo);
+    } catch (error) {
+      console.error('removeAnexo handler', error);
+      toggleRemoveDisabled(false);
+      return;
+    }
+
+    Promise.resolve(result)
+      .catch(() => {})
+      .finally(() => {
+        toggleRemoveDisabled(false);
+      });
+  });
+
+  headerActions.appendChild(removeBtn);
 
   const title = document.createElement('h3');
   title.className = 'text-sm font-semibold text-indigo-700';

--- a/servidor/utils/googleDrive.js
+++ b/servidor/utils/googleDrive.js
@@ -1,11 +1,8 @@
 const https = require('https');
 const { URL } = require('url');
-const jwt = require('jsonwebtoken');
-
 const TOKEN_URI = 'https://oauth2.googleapis.com/token';
 const UPLOAD_URI = 'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&supportsAllDrives=true&fields=id,name,mimeType,size,webViewLink,webContentLink';
 const FILES_URI = 'https://www.googleapis.com/drive/v3/files';
-const DRIVE_SCOPE = 'https://www.googleapis.com/auth/drive.file';
 
 let cachedCredentials = null;
 let cachedAccessToken = null;
@@ -29,22 +26,17 @@ function getCredentials() {
     return cachedCredentials;
   }
 
-  const clientEmail = cleanEnvValue(process.env.GOOGLE_DRIVE_CLIENT_EMAIL || '');
-  let privateKey = cleanEnvValue(process.env.GOOGLE_DRIVE_PRIVATE_KEY || '');
-  if (privateKey.includes('\\n')) {
-    privateKey = privateKey.replace(/\\n/g, '\n');
-  }
-  if (privateKey.includes('\\r')) {
-    privateKey = privateKey.replace(/\\r/g, '\r');
-  }
+  const clientId = cleanEnvValue(process.env.GOOGLE_DRIVE_CLIENT_ID || '');
+  const clientSecret = cleanEnvValue(process.env.GOOGLE_DRIVE_CLIENT_SECRET || '');
+  const refreshToken = cleanEnvValue(process.env.GOOGLE_DRIVE_REFRESH_TOKEN || '');
 
-  if (!(clientEmail && privateKey)) {
+  if (!(clientId && clientSecret && refreshToken)) {
     return null;
   }
 
   const folderId = cleanEnvValue(process.env.GOOGLE_DRIVE_FOLDER_ID || '') || null;
 
-  cachedCredentials = { clientEmail, privateKey, folderId };
+  cachedCredentials = { clientId, clientSecret, refreshToken, folderId };
   return cachedCredentials;
 }
 
@@ -120,19 +112,11 @@ async function fetchAccessToken() {
   }
 
   pendingTokenPromise = (async () => {
-    const now = Math.floor(Date.now() / 1000);
-    const payload = {
-      iss: credentials.clientEmail,
-      scope: DRIVE_SCOPE,
-      aud: TOKEN_URI,
-      iat: now,
-      exp: now + 3600,
-    };
-
-    const assertion = jwt.sign(payload, credentials.privateKey, { algorithm: 'RS256' });
     const params = new URLSearchParams({
-      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
-      assertion,
+      client_id: credentials.clientId,
+      client_secret: credentials.clientSecret,
+      refresh_token: credentials.refreshToken,
+      grant_type: 'refresh_token',
     });
     const bodyString = params.toString();
     const headers = {
@@ -140,12 +124,29 @@ async function fetchAccessToken() {
       'Content-Length': Buffer.byteLength(bodyString),
     };
 
-    const response = await requestGoogle({
-      url: TOKEN_URI,
-      method: 'POST',
-      headers,
-      body: Buffer.from(bodyString, 'utf8'),
-    });
+    let response;
+    try {
+      response = await requestGoogle({
+        url: TOKEN_URI,
+        method: 'POST',
+        headers,
+        body: Buffer.from(bodyString, 'utf8'),
+      });
+    } catch (err) {
+      let errorToThrow = err;
+      if (err?.body) {
+        try {
+          const parsed = JSON.parse(err.body.toString('utf8'));
+          const message = parsed?.error_description || parsed?.error || null;
+          if (message) {
+            errorToThrow = new Error(`Google OAuth: ${message}`);
+          }
+        } catch (_) {
+          // ignore parsing failures
+        }
+      }
+      throw errorToThrow;
+    }
 
     let data;
     try {
@@ -154,15 +155,22 @@ async function fetchAccessToken() {
       throw new Error('Resposta inválida ao obter token do Google Drive.');
     }
 
+    if (data?.error) {
+      const message = data.error_description || data.error || 'Erro ao obter token do Google Drive.';
+      const error = new Error(`Google OAuth: ${message}`);
+      error.data = data;
+      throw error;
+    }
+
     const accessToken = data?.access_token;
     if (!accessToken) {
       throw new Error('Token de acesso não recebido do Google Drive.');
     }
 
     const expiresIn = Number(data.expires_in) || 3600;
+    const safetyWindowSeconds = Math.max(expiresIn - 120, 60);
     cachedAccessToken = accessToken;
-    cachedAccessTokenExpiry = Date.now() + (expiresIn - 120) * 1000;
-    pendingTokenPromise = null;
+    cachedAccessTokenExpiry = Date.now() + safetyWindowSeconds * 1000;
 
     return accessToken;
   })();
@@ -230,17 +238,27 @@ async function uploadBufferToDrive(buffer, options = {}) {
   const token = await fetchAccessToken();
   const boundary = `gc_boundary_${Date.now()}_${Math.random().toString(16).slice(2)}`;
   const mimeType = options.mimeType || 'application/octet-stream';
-  const parents = Array.isArray(options.parents) ? options.parents.filter(Boolean) : [];
-  const folderId = options.folderId || credentials.folderId;
+  const parentsRaw = Array.isArray(options.parents) ? options.parents : [];
+  const parents = parentsRaw
+    .filter((value) => value !== null && value !== undefined)
+    .map((value) => cleanEnvValue(typeof value === 'string' ? value : String(value)))
+    .filter(Boolean);
+  const folderSource = typeof options.folderId !== 'undefined' ? options.folderId : credentials.folderId;
+  const folderId = cleanEnvValue(
+    folderSource === null || folderSource === undefined
+      ? ''
+      : (typeof folderSource === 'string' ? folderSource : String(folderSource)),
+  );
   if (folderId) {
     parents.push(folderId);
   }
+  const uniqueParents = Array.from(new Set(parents)).filter(Boolean);
 
   const metadata = {
     name: options.name || `arquivo-${Date.now()}`,
   };
-  if (parents.length) {
-    metadata.parents = parents;
+  if (uniqueParents.length) {
+    metadata.parents = uniqueParents;
   }
 
   const metaString = JSON.stringify(metadata);


### PR DESCRIPTION
## Summary
- substituir o fluxo com service account por autenticação OAuth 2.0 usando client id, secret e refresh token para gerar o access token do Google Drive
- garantir sanitização e deduplicação dos IDs de pastas ao montar o metadata dos uploads

## Testing
- node -e "require('./servidor/utils/googleDrive')"

------
https://chatgpt.com/codex/tasks/task_e_68cc1598ced88323a2ca7dc8e2bcd962