### PR TITLE
Add pet weight tracking for vet ficha clínica

### DIFF
--- a/pages/funcionarios/vet-ficha-clinica.html
+++ b/pages/funcionarios/vet-ficha-clinica.html
@@ -272,7 +272,7 @@
                             <span class="flex items-center gap-2 text-gray-800"><i class="fas fa-paperclip"></i>
                                 Anexo</span>
                         </a>
-                        <a
+                        <a id="vet-add-peso-btn" href="#"
                             class="flex items-center justify-between px-3 py-3 rounded-lg bg-gray-100 ring-1 ring-gray-200">
                             <span class="flex items-center gap-2 text-gray-800"><i class="fas fa-weight-scale"></i>
                                 Peso</span>

--- a/scripts/funcionarios/vet/ficha-clinica/consultas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/consultas.js
@@ -1097,7 +1097,7 @@ export function updateConsultaAgendaCard() {
   const hasAnexos = anexos.length > 0;
   const isLoadingAnexos = !!state.anexosLoading;
   const pesos = Array.isArray(state.pesos) ? state.pesos : [];
-  const hasPesos = pesos.length > 0;
+  const hasPesos = pesos.some((entry) => entry && !entry.isInitial);
   const isLoadingPesos = !!state.pesosLoading;
   const context = state.agendaContext;
   const selectedPetId = normalizeId(state.selectedPetId);
@@ -1286,9 +1286,10 @@ export function updateConsultaAgendaCard() {
     });
 
     const baselinePeso = orderedPesos.find((entry) => entry && entry.isInitial) || orderedPesos[orderedPesos.length - 1] || null;
+    const orderedVetPesos = orderedPesos.filter((entry) => entry && !entry.isInitial);
 
-    orderedPesos.forEach((peso, index) => {
-      const previous = orderedPesos[index + 1] || null;
+    orderedVetPesos.forEach((peso, index) => {
+      const previous = orderedVetPesos[index + 1] || null;
       const card = createPesoCard(peso, baselinePeso, previous);
       if (card) scroll.appendChild(card);
     });

--- a/scripts/funcionarios/vet/ficha-clinica/consultas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/consultas.js
@@ -11,6 +11,9 @@ import {
   formatDateDisplay,
   formatDateTimeDisplay,
   formatMoney,
+  formatPetWeight,
+  formatWeightDifference,
+  computeWeightDifference,
   getVetServices,
   getStatusLabel,
   CONSULTA_PLACEHOLDER_CLASSNAMES,
@@ -608,6 +611,91 @@ function createVacinaCard(vacina) {
   return card;
 }
 
+function createPesoCard(peso, baseline, previous) {
+  if (!peso) return null;
+
+  const card = document.createElement('article');
+  card.className = 'rounded-xl border border-orange-200 bg-white p-4 shadow-sm';
+
+  const header = document.createElement('div');
+  header.className = 'flex items-start gap-3';
+  card.appendChild(header);
+
+  const icon = document.createElement('div');
+  icon.className = 'flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-orange-100 text-orange-600';
+  icon.innerHTML = '<i class="fas fa-weight-scale"></i>';
+  header.appendChild(icon);
+
+  const headerText = document.createElement('div');
+  headerText.className = 'flex-1';
+  header.appendChild(headerText);
+
+  const title = document.createElement('h3');
+  title.className = 'text-sm font-semibold text-orange-700';
+  title.textContent = peso.isInitial ? 'Peso inicial registrado' : 'Atualização de peso';
+  headerText.appendChild(title);
+
+  if (peso.createdAt) {
+    const meta = document.createElement('p');
+    meta.className = 'mt-0.5 text-xs text-gray-500';
+    meta.textContent = `Registrado em ${formatDateTimeDisplay(peso.createdAt)}`;
+    headerText.appendChild(meta);
+  }
+
+  const summary = document.createElement('p');
+  summary.className = 'mt-3 text-sm text-gray-700';
+  const weightText = formatPetWeight(peso.peso) || '—';
+  summary.innerHTML = `Peso registrado: <span class="font-semibold text-gray-900">${weightText}</span>`;
+  headerText.appendChild(summary);
+
+  const details = document.createElement('div');
+  details.className = 'mt-4 space-y-2 text-sm';
+  card.appendChild(details);
+
+  if (baseline && !peso.isInitial) {
+    const diffValue = computeWeightDifference(peso.peso, baseline.peso) || 0;
+    const diffText = formatWeightDifference(peso.peso, baseline.peso);
+    const diffEl = document.createElement('p');
+    diffEl.className = 'font-medium';
+    if (!diffText || diffText === 'Sem variação') {
+      diffEl.classList.add('text-gray-600');
+      diffEl.textContent = 'Sem variação desde o primeiro registro.';
+    } else {
+      diffEl.classList.add(diffValue > 0 ? 'text-emerald-600' : 'text-rose-600');
+      diffEl.textContent = `Variação desde o primeiro registro: ${diffText}`;
+    }
+    details.appendChild(diffEl);
+
+    const baselineEl = document.createElement('p');
+    baselineEl.className = 'text-xs text-gray-500';
+    baselineEl.textContent = `Peso inicial: ${formatPetWeight(baseline.peso) || '—'}`;
+    details.appendChild(baselineEl);
+  } else if (peso.isInitial) {
+    const note = document.createElement('p');
+    note.className = 'text-sm text-gray-600';
+    note.textContent = 'Primeiro registro de peso do pet.';
+    details.appendChild(note);
+  }
+
+  if (previous && !peso.isInitial) {
+    const diffPrevValue = computeWeightDifference(peso.peso, previous.peso);
+    if (diffPrevValue !== null) {
+      const diffPrevText = formatWeightDifference(peso.peso, previous.peso, { showZero: true });
+      const diffPrevEl = document.createElement('p');
+      diffPrevEl.className = 'text-xs text-gray-500';
+      if (!diffPrevText || diffPrevText === '0 Kg') {
+        diffPrevEl.textContent = 'Sem variação em relação ao registro anterior.';
+      } else {
+        const when = previous.createdAt ? ` (${formatDateTimeDisplay(previous.createdAt)})` : '';
+        diffPrevEl.textContent = `Comparado ao registro anterior${when}: ${diffPrevText}`;
+      }
+      details.appendChild(diffPrevEl);
+    }
+  }
+
+  return card;
+}
+
 function createModalTextareaField(label, fieldName) {
   const wrapper = document.createElement('label');
   wrapper.className = 'grid gap-1';
@@ -957,6 +1045,9 @@ export function updateConsultaAgendaCard() {
   const anexos = Array.isArray(state.anexos) ? state.anexos : [];
   const hasAnexos = anexos.length > 0;
   const isLoadingAnexos = !!state.anexosLoading;
+  const pesos = Array.isArray(state.pesos) ? state.pesos : [];
+  const hasPesos = pesos.length > 0;
+  const isLoadingPesos = !!state.pesosLoading;
   const context = state.agendaContext;
   const selectedPetId = normalizeId(state.selectedPetId);
   const selectedTutorId = normalizeId(state.selectedCliente?._id);
@@ -1081,10 +1172,10 @@ export function updateConsultaAgendaCard() {
     }
   }
 
-  const hasAnyContent = hasManualConsultas || hasAgendaContent || hasVacinas || hasAnexos;
+  const hasAnyContent = hasManualConsultas || hasAgendaContent || hasVacinas || hasAnexos || hasPesos;
   const shouldShowPlaceholder = !hasAnyContent;
 
-  if ((isLoadingConsultas || isLoadingAnexos) && !hasAnyContent) {
+  if ((isLoadingConsultas || isLoadingAnexos || isLoadingPesos) && !hasAnyContent) {
     area.className = CONSULTA_PLACEHOLDER_CLASSNAMES;
     area.innerHTML = '';
     const paragraph = document.createElement('p');
@@ -1133,6 +1224,28 @@ export function updateConsultaAgendaCard() {
       const card = createVacinaCard(vacina);
       if (card) scroll.appendChild(card);
     });
+  }
+
+  if (hasPesos) {
+    const orderedPesos = [...pesos];
+    orderedPesos.sort((a, b) => {
+      const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return bTime - aTime;
+    });
+
+    const baselinePeso = orderedPesos.find((entry) => entry && entry.isInitial) || orderedPesos[orderedPesos.length - 1] || null;
+
+    orderedPesos.forEach((peso, index) => {
+      const previous = orderedPesos[index + 1] || null;
+      const card = createPesoCard(peso, baselinePeso, previous);
+      if (card) scroll.appendChild(card);
+    });
+  } else if (isLoadingPesos) {
+    const loadingPesos = document.createElement('div');
+    loadingPesos.className = 'rounded-xl border border-dashed border-orange-200 bg-orange-50 px-4 py-3 text-sm text-orange-600';
+    loadingPesos.textContent = 'Carregando registros de peso...';
+    scroll.appendChild(loadingPesos);
   }
 
   if (hasManualConsultas) {

--- a/scripts/funcionarios/vet/ficha-clinica/init.js
+++ b/scripts/funcionarios/vet/ficha-clinica/init.js
@@ -3,6 +3,7 @@ import { els, debounce } from './core.js';
 import { openConsultaModal } from './consultas.js';
 import { openVacinaModal } from './vacinas.js';
 import { openAnexoModal } from './anexos.js';
+import { openPesoModal } from './pesos.js';
 import {
   searchClientes,
   hideSugestoes,
@@ -81,6 +82,13 @@ export function initFichaClinica() {
     els.addAnexoBtn.addEventListener('click', (event) => {
       event.preventDefault();
       openAnexoModal();
+    });
+  }
+
+  if (els.addPesoBtn) {
+    els.addPesoBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      openPesoModal();
     });
   }
 

--- a/scripts/funcionarios/vet/ficha-clinica/pesos.js
+++ b/scripts/funcionarios/vet/ficha-clinica/pesos.js
@@ -1,0 +1,541 @@
+// Peso modal and histórico management for the Vet ficha clínica
+import {
+  state,
+  api,
+  notify,
+  normalizeId,
+  toIsoOrNull,
+  formatPetWeight,
+  formatDateTimeDisplay,
+  formatWeightDifference,
+  computeWeightDifference,
+  parseWeightValue,
+  formatWeightDelta,
+  pesoModal,
+} from './core.js';
+import { ensureTutorAndPetSelected, updateConsultaAgendaCard } from './consultas.js';
+import { updateCardDisplay } from './ui.js';
+
+function getPesosKey(clienteId, petId) {
+  const tutor = normalizeId(clienteId);
+  const pet = normalizeId(petId);
+  if (!(tutor && pet)) return null;
+  return `${tutor}|${pet}`;
+}
+
+function normalizePesoRecord(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const petId = normalizeId(raw.petId || raw.pet);
+  const clienteId = normalizeId(raw.clienteId || raw.cliente);
+  const fallbackId = raw.isInitial ? `initial-${petId || 'pet'}` : null;
+  const id = normalizeId(raw.id || raw._id) || fallbackId;
+  if (!id) return null;
+  const peso = parseWeightValue(raw.peso);
+  if (peso === null) return null;
+  return {
+    id,
+    _id: id,
+    petId,
+    clienteId,
+    peso,
+    isInitial: !!raw.isInitial,
+    registradoPor: normalizeId(raw.registradoPor || raw.registradoPorId) || null,
+    createdAt: toIsoOrNull(raw.createdAt || raw.created_at || raw.createdEm || raw.registradoEm) || null,
+  };
+}
+
+function getOrderedPesos() {
+  const entries = Array.isArray(state.pesos) ? state.pesos.slice() : [];
+  entries.sort((a, b) => {
+    const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return bTime - aTime;
+  });
+  return entries;
+}
+
+function setPesoModalSubmitting(isSubmitting) {
+  pesoModal.isSubmitting = !!isSubmitting;
+  if (pesoModal.submitBtn) {
+    if (!pesoModal.submitBtnOriginalHtml) {
+      pesoModal.submitBtnOriginalHtml = pesoModal.submitBtn.innerHTML;
+    }
+    pesoModal.submitBtn.disabled = !!isSubmitting;
+    pesoModal.submitBtn.classList.toggle('opacity-60', !!isSubmitting);
+    pesoModal.submitBtn.classList.toggle('cursor-not-allowed', !!isSubmitting);
+    pesoModal.submitBtn.innerHTML = isSubmitting
+      ? '<i class="fas fa-spinner fa-spin"></i><span>Salvando...</span>'
+      : pesoModal.submitBtnOriginalHtml;
+  }
+  if (pesoModal.cancelBtn) {
+    pesoModal.cancelBtn.disabled = !!isSubmitting;
+    pesoModal.cancelBtn.classList.toggle('opacity-50', !!isSubmitting);
+    pesoModal.cancelBtn.classList.toggle('cursor-not-allowed', !!isSubmitting);
+  }
+  if (pesoModal.input) {
+    pesoModal.input.disabled = !!isSubmitting;
+  }
+}
+
+function ensurePesoModal() {
+  if (pesoModal.overlay) return pesoModal;
+
+  const overlay = document.createElement('div');
+  overlay.id = 'vet-peso-modal';
+  overlay.className = 'hidden fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4';
+  overlay.setAttribute('aria-hidden', 'true');
+
+  const dialog = document.createElement('div');
+  dialog.className = 'w-full max-w-xl rounded-xl bg-white shadow-xl focus:outline-none';
+  dialog.tabIndex = -1;
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
+  overlay.appendChild(dialog);
+
+  const form = document.createElement('form');
+  form.className = 'flex flex-col gap-6 p-6';
+  dialog.appendChild(form);
+
+  const header = document.createElement('div');
+  header.className = 'flex items-start justify-between gap-3';
+  form.appendChild(header);
+
+  const titleWrap = document.createElement('div');
+  header.appendChild(titleWrap);
+
+  const title = document.createElement('h2');
+  title.className = 'text-lg font-semibold text-gray-800';
+  title.textContent = 'Histórico de peso';
+  titleWrap.appendChild(title);
+
+  const subtitle = document.createElement('p');
+  subtitle.className = 'text-sm text-gray-600';
+  subtitle.textContent = 'Registre novas pesagens e acompanhe a evolução do pet.';
+  titleWrap.appendChild(subtitle);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.className = 'h-8 w-8 grid place-content-center rounded-lg bg-gray-100 text-gray-500 transition hover:text-gray-700';
+  closeBtn.innerHTML = '<i class="fas fa-xmark"></i>';
+  header.appendChild(closeBtn);
+
+  const fieldset = document.createElement('div');
+  fieldset.className = 'grid gap-2';
+  form.appendChild(fieldset);
+
+  const label = document.createElement('label');
+  label.className = 'text-sm font-medium text-gray-700';
+  label.textContent = 'Novo peso (Kg)';
+  fieldset.appendChild(label);
+
+  const inputRow = document.createElement('div');
+  inputRow.className = 'flex items-center gap-3';
+  fieldset.appendChild(inputRow);
+
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.step = '0.01';
+  input.min = '0';
+  input.placeholder = 'Ex.: 12,5';
+  input.className = 'flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-800 focus:outline-none focus:ring-2 focus:ring-primary';
+  inputRow.appendChild(input);
+
+  const submitBtn = document.createElement('button');
+  submitBtn.type = 'submit';
+  submitBtn.className = 'inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700';
+  submitBtn.innerHTML = '<i class="fas fa-plus"></i><span>Adicionar</span>';
+  inputRow.appendChild(submitBtn);
+
+  const historySection = document.createElement('div');
+  historySection.className = 'grid gap-3';
+  form.appendChild(historySection);
+
+  const historyHeader = document.createElement('div');
+  historyHeader.className = 'flex items-center justify-between';
+  historySection.appendChild(historyHeader);
+
+  const historyTitle = document.createElement('h3');
+  historyTitle.className = 'text-sm font-semibold uppercase tracking-wide text-gray-700';
+  historyTitle.textContent = 'Histórico registrado';
+  historyHeader.appendChild(historyTitle);
+
+  const summary = document.createElement('p');
+  summary.className = 'text-sm text-gray-600';
+  summary.textContent = 'Acompanhe os registros de peso do pet.';
+  historySection.appendChild(summary);
+
+  const list = document.createElement('div');
+  list.className = 'max-h-80 space-y-3 overflow-y-auto';
+  historySection.appendChild(list);
+
+  const loadingState = document.createElement('div');
+  loadingState.className = 'hidden rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-center text-sm text-gray-500';
+  loadingState.textContent = 'Carregando registros de peso...';
+  historySection.appendChild(loadingState);
+
+  const emptyState = document.createElement('div');
+  emptyState.className = 'hidden rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-center text-sm text-gray-500';
+  emptyState.textContent = 'Nenhum peso registrado até o momento.';
+  historySection.appendChild(emptyState);
+
+  const footer = document.createElement('div');
+  footer.className = 'flex items-center justify-end gap-2 border-t border-gray-200 pt-3';
+  form.appendChild(footer);
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.type = 'button';
+  cancelBtn.className = 'inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-50';
+  cancelBtn.innerHTML = '<i class="fas fa-xmark"></i><span>Fechar</span>';
+  footer.appendChild(cancelBtn);
+
+  form.addEventListener('submit', handlePesoSubmit);
+  closeBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    closePesoModal();
+  });
+  cancelBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    closePesoModal();
+  });
+  overlay.addEventListener('click', (event) => {
+    if (event.target === overlay) {
+      closePesoModal();
+    }
+  });
+
+  document.body.appendChild(overlay);
+
+  pesoModal.overlay = overlay;
+  pesoModal.dialog = dialog;
+  pesoModal.form = form;
+  pesoModal.closeBtn = closeBtn;
+  pesoModal.cancelBtn = cancelBtn;
+  pesoModal.submitBtn = submitBtn;
+  pesoModal.submitBtnOriginalHtml = submitBtn.innerHTML;
+  pesoModal.input = input;
+  pesoModal.list = list;
+  pesoModal.summary = summary;
+  pesoModal.emptyState = emptyState;
+  pesoModal.loadingState = loadingState;
+
+  return pesoModal;
+}
+
+function renderPesoList() {
+  if (!pesoModal.list) return;
+
+  const ordered = getOrderedPesos();
+  const listEl = pesoModal.list;
+  const emptyEl = pesoModal.emptyState;
+  const loadingEl = pesoModal.loadingState;
+  const summaryEl = pesoModal.summary;
+
+  if (loadingEl) {
+    loadingEl.classList.toggle('hidden', !state.pesosLoading);
+  }
+
+  const hasItems = ordered.length > 0;
+  if (listEl) {
+    listEl.classList.toggle('hidden', state.pesosLoading || !hasItems);
+  }
+  if (emptyEl) {
+    emptyEl.classList.toggle('hidden', state.pesosLoading || hasItems);
+  }
+
+  if (summaryEl) {
+    if (!hasItems) {
+      summaryEl.textContent = 'Nenhum peso registrado até o momento.';
+    }
+  }
+
+  if (state.pesosLoading) {
+    listEl.innerHTML = '';
+    return;
+  }
+
+  listEl.innerHTML = '';
+  if (!hasItems) {
+    return;
+  }
+
+  const baseline = ordered.find((entry) => entry && entry.isInitial) || ordered[ordered.length - 1] || null;
+  const latest = ordered[0] || null;
+
+  if (summaryEl && latest) {
+    const weightText = formatPetWeight(latest.peso) || '';
+    const diffText = baseline ? formatWeightDifference(latest.peso, baseline.peso) : '';
+    if (weightText) {
+      if (diffText && diffText !== 'Sem variação') {
+        summaryEl.textContent = `Peso atual: ${weightText} · Diferença desde o primeiro registro: ${diffText}`;
+      } else if (diffText === 'Sem variação') {
+        summaryEl.textContent = `Peso atual: ${weightText} · Sem variação desde o primeiro registro.`;
+      } else {
+        summaryEl.textContent = `Peso atual: ${weightText}`;
+      }
+    } else {
+      summaryEl.textContent = 'Acompanhe os registros de peso do pet.';
+    }
+  }
+
+  ordered.forEach((entry, index) => {
+    const item = document.createElement('div');
+    item.className = 'rounded-lg border border-gray-200 bg-white px-3 py-2 shadow-sm';
+
+    const header = document.createElement('div');
+    header.className = 'flex items-center justify-between gap-2';
+    item.appendChild(header);
+
+    const valueEl = document.createElement('p');
+    valueEl.className = 'text-sm font-semibold text-gray-800';
+    valueEl.textContent = formatPetWeight(entry.peso) || '—';
+    header.appendChild(valueEl);
+
+    if (entry.isInitial) {
+      const badge = document.createElement('span');
+      badge.className = 'inline-flex items-center gap-1 rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[11px] font-semibold text-sky-700';
+      badge.innerHTML = '<i class="fas fa-flag"></i><span>Peso inicial</span>';
+      header.appendChild(badge);
+    } else if (index === 0) {
+      const badge = document.createElement('span');
+      badge.className = 'inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700';
+      badge.innerHTML = '<i class="fas fa-weight-hanging"></i><span>Registro mais recente</span>';
+      header.appendChild(badge);
+    }
+
+    const details = document.createElement('div');
+    details.className = 'mt-1 space-y-1';
+    item.appendChild(details);
+
+    if (entry.createdAt) {
+      const dateEl = document.createElement('p');
+      dateEl.className = 'text-xs text-gray-500';
+      dateEl.textContent = `Registrado em ${formatDateTimeDisplay(entry.createdAt)}`;
+      details.appendChild(dateEl);
+    }
+
+    if (baseline && !entry.isInitial) {
+      const diffText = formatWeightDifference(entry.peso, baseline.peso);
+      const diffEl = document.createElement('p');
+      diffEl.className = 'text-xs font-medium';
+      if (!diffText || diffText === 'Sem variação') {
+        diffEl.classList.add('text-gray-600');
+        diffEl.textContent = 'Sem variação desde o primeiro registro.';
+      } else {
+        const diffValue = computeWeightDifference(entry.peso, baseline.peso) || 0;
+        diffEl.classList.add(diffValue > 0 ? 'text-emerald-600' : 'text-rose-600');
+        diffEl.textContent = `Diferença desde o primeiro registro: ${diffText}`;
+      }
+      details.appendChild(diffEl);
+    } else if (entry.isInitial) {
+      const infoEl = document.createElement('p');
+      infoEl.className = 'text-xs text-gray-600';
+      infoEl.textContent = 'Registro inicial cadastrado para o pet.';
+      details.appendChild(infoEl);
+    }
+
+    const previous = ordered[index + 1] || null;
+    if (previous && !entry.isInitial) {
+      const diffPrevValue = computeWeightDifference(entry.peso, previous.peso);
+      if (diffPrevValue !== null) {
+        const diffPrevText = formatWeightDelta(diffPrevValue, { showZero: true });
+        const diffPrevEl = document.createElement('p');
+        diffPrevEl.className = 'text-xs text-gray-500';
+        if (!diffPrevText || diffPrevText === '0 Kg') {
+          diffPrevEl.textContent = 'Sem variação em relação ao registro anterior.';
+        } else {
+          diffPrevEl.textContent = `Comparado ao registro anterior: ${diffPrevText}`;
+        }
+        details.appendChild(diffPrevEl);
+      }
+    }
+
+    listEl.appendChild(item);
+  });
+}
+
+function updatePetWeightInState(newPeso) {
+  const petId = normalizeId(state.selectedPetId);
+  if (!petId) return;
+  if (state.petsById && state.petsById[petId]) {
+    state.petsById[petId] = {
+      ...state.petsById[petId],
+      peso: newPeso,
+      pesoAtual: newPeso,
+    };
+  }
+}
+
+export async function loadPesosFromServer(options = {}) {
+  const { force = false } = options || {};
+  const clienteId = normalizeId(state.selectedCliente?._id);
+  const petId = normalizeId(state.selectedPetId);
+
+  if (!(clienteId && petId)) {
+    state.pesos = [];
+    state.pesosLoadKey = null;
+    state.pesosLoading = false;
+    if (pesoModal.overlay && !pesoModal.overlay.classList.contains('hidden')) {
+      renderPesoList();
+    }
+    updateConsultaAgendaCard();
+    return;
+  }
+
+  const key = getPesosKey(clienteId, petId);
+  if (!force && key && state.pesosLoadKey === key && Array.isArray(state.pesos) && state.pesos.length) {
+    return;
+  }
+
+  state.pesosLoading = true;
+  if (pesoModal.overlay && !pesoModal.overlay.classList.contains('hidden')) {
+    renderPesoList();
+  }
+
+  try {
+    const params = new URLSearchParams({ clienteId, petId });
+    const resp = await api(`/func/vet/pesos?${params.toString()}`);
+    const payload = await resp.json().catch(() => (resp.ok ? [] : {}));
+    if (!resp.ok) {
+      const message = typeof payload?.message === 'string' ? payload.message : 'Erro ao carregar pesos.';
+      throw new Error(message);
+    }
+    const list = Array.isArray(payload) ? payload : [];
+    const normalized = list.map(normalizePesoRecord).filter(Boolean);
+    normalized.sort((a, b) => {
+      const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return bTime - aTime;
+    });
+    state.pesos = normalized;
+    state.pesosLoadKey = key;
+  } catch (error) {
+    console.error('loadPesosFromServer', error);
+    state.pesos = [];
+    state.pesosLoadKey = null;
+    notify(error.message || 'Erro ao carregar pesos.', 'error');
+  } finally {
+    state.pesosLoading = false;
+    if (pesoModal.overlay && !pesoModal.overlay.classList.contains('hidden')) {
+      renderPesoList();
+    }
+    updateConsultaAgendaCard();
+  }
+}
+
+export function closePesoModal() {
+  if (!pesoModal.overlay) return;
+  pesoModal.overlay.classList.add('hidden');
+  pesoModal.overlay.setAttribute('aria-hidden', 'true');
+  if (pesoModal.form) {
+    try { pesoModal.form.reset(); } catch (_) { /* ignore */ }
+  }
+  setPesoModalSubmitting(false);
+  if (pesoModal.keydownHandler) {
+    document.removeEventListener('keydown', pesoModal.keydownHandler);
+    pesoModal.keydownHandler = null;
+  }
+}
+
+export function openPesoModal() {
+  if (!ensureTutorAndPetSelected()) {
+    return;
+  }
+
+  const modal = ensurePesoModal();
+  setPesoModalSubmitting(false);
+  if (modal.form) {
+    try { modal.form.reset(); } catch (_) { /* ignore */ }
+  }
+  if (pesoModal.input) {
+    pesoModal.input.value = '';
+  }
+
+  renderPesoList();
+
+  pesoModal.overlay.classList.remove('hidden');
+  pesoModal.overlay.removeAttribute('aria-hidden');
+  if (pesoModal.dialog) {
+    pesoModal.dialog.focus();
+  }
+
+  if (pesoModal.keydownHandler) {
+    document.removeEventListener('keydown', pesoModal.keydownHandler);
+  }
+  pesoModal.keydownHandler = (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closePesoModal();
+    }
+  };
+  document.addEventListener('keydown', pesoModal.keydownHandler);
+
+  setTimeout(() => {
+    if (pesoModal.input) {
+      try { pesoModal.input.focus(); } catch (_) { /* ignore */ }
+    }
+  }, 50);
+
+  const promise = loadPesosFromServer();
+  if (promise && typeof promise.then === 'function') {
+    promise.catch(() => {});
+  }
+}
+
+async function handlePesoSubmit(event) {
+  event.preventDefault();
+  if (!ensureTutorAndPetSelected()) {
+    return;
+  }
+
+  const clienteId = normalizeId(state.selectedCliente?._id);
+  const petId = normalizeId(state.selectedPetId);
+  const raw = pesoModal.input ? pesoModal.input.value : '';
+  const pesoValor = parseWeightValue(raw);
+
+  if (pesoValor === null || pesoValor <= 0) {
+    notify('Informe um peso válido (maior que zero).', 'warning');
+    if (pesoModal.input) {
+      try { pesoModal.input.focus(); } catch (_) { /* ignore */ }
+    }
+    return;
+  }
+
+  const payload = {
+    clienteId,
+    petId,
+    peso: pesoValor,
+  };
+
+  setPesoModalSubmitting(true);
+
+  try {
+    const response = await api('/func/vet/pesos', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    const data = await response.json().catch(() => (response.ok ? {} : {}));
+    if (!response.ok) {
+      const message = typeof data?.message === 'string' ? data.message : 'Erro ao registrar peso.';
+      throw new Error(message);
+    }
+
+    if (pesoModal.form) {
+      try { pesoModal.form.reset(); } catch (_) { /* ignore */ }
+    }
+    if (pesoModal.input) {
+      pesoModal.input.value = '';
+    }
+
+    updatePetWeightInState(pesoValor);
+    updateCardDisplay();
+
+    await loadPesosFromServer({ force: true });
+    notify('Peso registrado com sucesso.', 'success');
+  } catch (error) {
+    console.error('handlePesoSubmit', error);
+    notify(error.message || 'Erro ao registrar peso.', 'error');
+  } finally {
+    setPesoModalSubmitting(false);
+    renderPesoList();
+  }
+}

--- a/scripts/funcionarios/vet/ficha-clinica/tutor.js
+++ b/scripts/funcionarios/vet/ficha-clinica/tutor.js
@@ -14,6 +14,7 @@ import {
 import { loadConsultasFromServer, updateConsultaAgendaCard } from './consultas.js';
 import { loadVacinasForSelection } from './vacinas.js';
 import { loadAnexosForSelection, loadAnexosFromServer } from './anexos.js';
+import { loadPesosFromServer } from './pesos.js';
 import { updateCardDisplay, updatePageVisibility, setCardMode } from './ui.js';
 
 function hideSugestoes() {
@@ -136,6 +137,12 @@ export async function onSelectCliente(cli, opts = {}) {
   state.anexos = [];
   state.anexosLoadKey = null;
   state.anexosLoading = false;
+  state.pesos = [];
+  state.pesosLoadKey = null;
+  state.pesosLoading = false;
+  state.pesos = [];
+  state.pesosLoadKey = null;
+  state.pesosLoading = false;
 
   if (state.agendaContext) {
     const contextTutorId = normalizeId(state.agendaContext.tutorId);
@@ -235,6 +242,9 @@ export async function onSelectPet(petId, opts = {}) {
   state.anexos = [];
   state.anexosLoadKey = null;
   state.anexosLoading = false;
+  state.pesos = [];
+  state.pesosLoadKey = null;
+  state.pesosLoading = false;
   loadVacinasForSelection();
   loadAnexosForSelection();
   updateCardDisplay();
@@ -246,6 +256,7 @@ export async function onSelectPet(petId, opts = {}) {
   await Promise.all([
     loadConsultasFromServer({ force: true }),
     loadAnexosFromServer({ force: true }),
+    loadPesosFromServer({ force: true }),
   ]);
 }
 
@@ -261,6 +272,9 @@ export function clearCliente() {
   state.anexos = [];
   state.anexosLoadKey = null;
   state.anexosLoading = false;
+  state.pesos = [];
+  state.pesosLoadKey = null;
+  state.pesosLoading = false;
   persistAgendaContext(null);
   if (els.cliInput) els.cliInput.value = '';
   hideSugestoes();

--- a/servidor/models/PetWeight.js
+++ b/servidor/models/PetWeight.js
@@ -23,6 +23,10 @@ const petWeightSchema = new Schema({
     ref: 'User',
     default: null,
   },
+  isInitial: {
+    type: Boolean,
+    default: false,
+  },
 }, { timestamps: true });
 
 module.exports = mongoose.model('PetWeight', petWeightSchema);

--- a/servidor/models/PetWeight.js
+++ b/servidor/models/PetWeight.js
@@ -1,0 +1,28 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const petWeightSchema = new Schema({
+  cliente: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+  },
+  pet: {
+    type: Schema.Types.ObjectId,
+    ref: 'Pet',
+    required: true,
+  },
+  peso: {
+    type: Number,
+    required: true,
+    min: 0,
+  },
+  registradoPor: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    default: null,
+  },
+}, { timestamps: true });
+
+module.exports = mongoose.model('PetWeight', petWeightSchema);

--- a/servidor/routes/funcVet.js
+++ b/servidor/routes/funcVet.js
@@ -10,6 +10,7 @@ const Service = require('../models/Service');
 const Appointment = require('../models/Appointment');
 const VetConsultation = require('../models/VetConsultation');
 const VetAttachment = require('../models/VetAttachment');
+const PetWeight = require('../models/PetWeight');
 const {
   isDriveConfigured,
   getDriveFolderId,
@@ -234,6 +235,157 @@ function formatAttachment(doc) {
     arquivos,
   };
 }
+
+function parseWeight(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value < 0 ? null : value;
+  }
+  const raw = String(value).trim();
+  if (!raw) return null;
+  const sanitized = raw.replace(/[^0-9.,]+/g, '');
+  if (!sanitized) return null;
+  const hasComma = sanitized.includes(',');
+  let normalized = sanitized;
+  if (hasComma) {
+    normalized = sanitized.replace(/\./g, '').replace(',', '.');
+  } else {
+    const firstDot = sanitized.indexOf('.');
+    if (firstDot >= 0) {
+      const before = sanitized.slice(0, firstDot + 1);
+      const after = sanitized.slice(firstDot + 1).replace(/\./g, '');
+      normalized = `${before}${after}`;
+    }
+  }
+  const num = Number(normalized);
+  if (!Number.isFinite(num) || num < 0) return null;
+  return num;
+}
+
+function formatPetWeightEntry(doc) {
+  if (!doc) return null;
+  const weightValue = parseWeight(doc.peso);
+  if (weightValue === null) return null;
+  const createdAt = toIsoDate(doc.createdAt);
+  const updatedAt = toIsoDate(doc.updatedAt) || createdAt;
+  return {
+    id: toStringSafe(doc._id),
+    _id: toStringSafe(doc._id),
+    clienteId: toStringSafe(doc.cliente),
+    petId: toStringSafe(doc.pet),
+    peso: weightValue,
+    registradoPor: doc.registradoPor ? toStringSafe(doc.registradoPor) : null,
+    createdAt,
+    updatedAt,
+    isInitial: !!doc.isInitial,
+  };
+}
+
+router.get('/vet/pesos', authMiddleware, requireStaff, async (req, res) => {
+  try {
+    const clienteId = normalizeObjectId(req.query.clienteId);
+    const petId = normalizeObjectId(req.query.petId);
+
+    if (!(clienteId && petId)) {
+      return res.status(400).json({ message: 'clienteId e petId são obrigatórios.' });
+    }
+
+    const petDoc = await Pet.findById(petId)
+      .select('owner peso createdAt updatedAt')
+      .lean();
+
+    if (!petDoc) {
+      return res.status(404).json({ message: 'Pet não encontrado.' });
+    }
+
+    if (clienteId && toStringSafe(petDoc.owner) !== clienteId) {
+      return res.status(400).json({ message: 'Pet não pertence ao tutor informado.' });
+    }
+
+    const docs = await PetWeight.find({ pet: petId })
+      .sort({ createdAt: -1 })
+      .lean();
+
+    const formatted = docs.map(formatPetWeightEntry).filter(Boolean);
+
+    const initialWeight = parseWeight(petDoc.peso);
+    if (initialWeight !== null) {
+      const hasInitial = formatted.some((entry) => entry && entry.isInitial);
+      if (!hasInitial) {
+        const initialEntry = formatPetWeightEntry({
+          _id: `initial-${petId}`,
+          cliente: petDoc.owner,
+          pet: petId,
+          peso: initialWeight,
+          createdAt: petDoc.createdAt || petDoc.updatedAt || new Date(),
+          updatedAt: petDoc.createdAt || petDoc.updatedAt || new Date(),
+          isInitial: true,
+        });
+        if (initialEntry) {
+          formatted.push(initialEntry);
+        }
+      }
+    }
+
+    formatted.sort((a, b) => {
+      const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return bTime - aTime;
+    });
+
+    return res.json(formatted);
+  } catch (error) {
+    console.error('GET /func/vet/pesos', error);
+    return res.status(500).json({ message: 'Erro ao carregar pesos.' });
+  }
+});
+
+router.post('/vet/pesos', authMiddleware, requireStaff, async (req, res) => {
+  try {
+    const clienteId = normalizeObjectId(req.body.clienteId);
+    const petId = normalizeObjectId(req.body.petId);
+    const pesoValue = parseWeight(req.body.peso);
+
+    if (!(clienteId && petId)) {
+      return res.status(400).json({ message: 'clienteId e petId são obrigatórios.' });
+    }
+
+    if (pesoValue === null || pesoValue <= 0) {
+      return res.status(400).json({ message: 'Informe um peso válido.' });
+    }
+
+    const petDoc = await Pet.findById(petId).select('owner peso');
+    if (!petDoc) {
+      return res.status(404).json({ message: 'Pet não encontrado.' });
+    }
+
+    if (clienteId && toStringSafe(petDoc.owner) !== clienteId) {
+      return res.status(400).json({ message: 'Pet não pertence ao tutor informado.' });
+    }
+
+    const payload = {
+      cliente: clienteId,
+      pet: petId,
+      peso: pesoValue,
+    };
+
+    const registeredBy = normalizeObjectId(req.user?.id || req.user?._id);
+    if (registeredBy) {
+      payload.registradoPor = registeredBy;
+    }
+
+    const created = await PetWeight.create(payload);
+
+    petDoc.peso = String(pesoValue);
+    await petDoc.save();
+
+    const formatted = formatPetWeightEntry(created.toObject());
+    return res.status(201).json(formatted);
+  } catch (error) {
+    console.error('POST /func/vet/pesos', error);
+    return res.status(500).json({ message: 'Erro ao registrar peso.' });
+  }
+});
 
 router.get('/vet/anexos', authMiddleware, requireStaff, async (req, res) => {
   try {

--- a/src/output.css
+++ b/src/output.css
@@ -76,7 +76,9 @@
     --color-rose-50: oklch(96.9% 0.015 12.422);
     --color-rose-100: oklch(94.1% 0.03 12.58);
     --color-rose-200: oklch(89.2% 0.058 10.001);
+    --color-rose-500: oklch(64.5% 0.246 16.439);
     --color-rose-600: oklch(58.6% 0.253 17.585);
+    --color-rose-700: oklch(51.4% 0.222 16.935);
     --color-slate-50: oklch(98.4% 0.003 247.858);
     --color-slate-100: oklch(96.8% 0.007 247.896);
     --color-slate-200: oklch(92.9% 0.013 255.508);
@@ -1987,6 +1989,9 @@
   .text-red-700 {
     color: var(--color-red-700);
   }
+  .text-rose-500 {
+    color: var(--color-rose-500);
+  }
   .text-rose-600 {
     color: var(--color-rose-600);
   }
@@ -2615,6 +2620,13 @@
       }
     }
   }
+  .hover\:bg-rose-100 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-rose-100);
+      }
+    }
+  }
   .hover\:bg-rose-600 {
     &:hover {
       @media (hover: hover) {
@@ -2748,6 +2760,13 @@
     &:hover {
       @media (hover: hover) {
         color: var(--color-red-800);
+      }
+    }
+  }
+  .hover\:text-rose-700 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-rose-700);
       }
     }
   }

--- a/src/output.css
+++ b/src/output.css
@@ -14,7 +14,12 @@
     --color-red-600: oklch(57.7% 0.245 27.325);
     --color-red-700: oklch(50.5% 0.213 27.518);
     --color-red-800: oklch(44.4% 0.177 26.899);
+    --color-orange-50: oklch(98% 0.016 73.684);
+    --color-orange-100: oklch(95.4% 0.038 75.164);
+    --color-orange-200: oklch(90.1% 0.076 70.697);
     --color-orange-500: oklch(70.5% 0.213 47.604);
+    --color-orange-600: oklch(64.6% 0.222 41.116);
+    --color-orange-700: oklch(55.3% 0.195 38.402);
     --color-amber-50: oklch(98.7% 0.022 95.277);
     --color-amber-100: oklch(96.2% 0.059 95.617);
     --color-amber-200: oklch(92.4% 0.12 95.746);
@@ -70,6 +75,7 @@
     --color-indigo-700: oklch(45.7% 0.24 277.023);
     --color-rose-50: oklch(96.9% 0.015 12.422);
     --color-rose-100: oklch(94.1% 0.03 12.58);
+    --color-rose-200: oklch(89.2% 0.058 10.001);
     --color-rose-600: oklch(58.6% 0.253 17.585);
     --color-slate-50: oklch(98.4% 0.003 247.858);
     --color-slate-100: oklch(96.8% 0.007 247.896);
@@ -677,6 +683,9 @@
   .h-28 {
     height: calc(var(--spacing) * 28);
   }
+  .h-32 {
+    height: calc(var(--spacing) * 32);
+  }
   .h-40 {
     height: calc(var(--spacing) * 40);
   }
@@ -754,9 +763,6 @@
   }
   .min-h-\[64px\] {
     min-height: 64px;
-  }
-  .min-h-\[120px\] {
-    min-height: 120px;
   }
   .min-h-\[140px\] {
     min-height: 140px;
@@ -1201,6 +1207,9 @@
       border-color: var(--color-gray-200);
     }
   }
+  .self-start {
+    align-self: flex-start;
+  }
   .truncate {
     overflow: hidden;
     text-overflow: ellipsis;
@@ -1364,8 +1373,11 @@
   .border-indigo-300 {
     border-color: var(--color-indigo-300);
   }
-  .border-indigo-400 {
-    border-color: var(--color-indigo-400);
+  .border-indigo-500 {
+    border-color: var(--color-indigo-500);
+  }
+  .border-orange-200 {
+    border-color: var(--color-orange-200);
   }
   .border-primary {
     border-color: var(--color-primary);
@@ -1375,6 +1387,9 @@
   }
   .border-red-500 {
     border-color: var(--color-red-500);
+  }
+  .border-rose-200 {
+    border-color: var(--color-rose-200);
   }
   .border-sky-200 {
     border-color: var(--color-sky-200);
@@ -1478,12 +1493,6 @@
   .bg-indigo-50 {
     background-color: var(--color-indigo-50);
   }
-  .bg-indigo-50\/60 {
-    background-color: color-mix(in srgb, oklch(96.2% 0.018 272.314) 60%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-indigo-50) 60%, transparent);
-    }
-  }
   .bg-indigo-50\/70 {
     background-color: color-mix(in srgb, oklch(96.2% 0.018 272.314) 70%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -1501,6 +1510,12 @@
   }
   .bg-lime-500 {
     background-color: var(--color-lime-500);
+  }
+  .bg-orange-50 {
+    background-color: var(--color-orange-50);
+  }
+  .bg-orange-100 {
+    background-color: var(--color-orange-100);
   }
   .bg-orange-500 {
     background-color: var(--color-orange-500);
@@ -1945,9 +1960,6 @@
   .text-green-800 {
     color: var(--color-green-800);
   }
-  .text-indigo-400 {
-    color: var(--color-indigo-400);
-  }
   .text-indigo-500 {
     color: var(--color-indigo-500);
   }
@@ -1956,6 +1968,12 @@
   }
   .text-indigo-700 {
     color: var(--color-indigo-700);
+  }
+  .text-orange-600 {
+    color: var(--color-orange-600);
+  }
+  .text-orange-700 {
+    color: var(--color-orange-700);
   }
   .text-primary {
     color: var(--color-primary);
@@ -2394,13 +2412,6 @@
       }
     }
   }
-  .hover\:border-indigo-400 {
-    &:hover {
-      @media (hover: hover) {
-        border-color: var(--color-indigo-400);
-      }
-    }
-  }
   .hover\:border-primary {
     &:hover {
       @media (hover: hover) {
@@ -2604,6 +2615,13 @@
       }
     }
   }
+  .hover\:bg-rose-600 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-rose-600);
+      }
+    }
+  }
   .hover\:bg-secondary {
     &:hover {
       @media (hover: hover) {
@@ -2692,13 +2710,6 @@
     &:hover {
       @media (hover: hover) {
         color: var(--color-green-800);
-      }
-    }
-  }
-  .hover\:text-indigo-600 {
-    &:hover {
-      @media (hover: hover) {
-        color: var(--color-indigo-600);
       }
     }
   }
@@ -2836,9 +2847,9 @@
       border-color: var(--color-primary);
     }
   }
-  .focus\:border-sky-500 {
+  .focus\:border-sky-400 {
     &:focus {
-      border-color: var(--color-sky-500);
+      border-color: var(--color-sky-400);
     }
   }
   .focus\:border-transparent {
@@ -2896,9 +2907,14 @@
       }
     }
   }
-  .focus\:ring-sky-200 {
+  .focus\:ring-rose-200 {
     &:focus {
-      --tw-ring-color: var(--color-sky-200);
+      --tw-ring-color: var(--color-rose-200);
+    }
+  }
+  .focus\:ring-sky-300 {
+    &:focus {
+      --tw-ring-color: var(--color-sky-300);
     }
   }
   .focus\:ring-sky-400 {
@@ -2931,11 +2947,6 @@
   .disabled\:opacity-50 {
     &:disabled {
       opacity: 50%;
-    }
-  }
-  .disabled\:opacity-60 {
-    &:disabled {
-      opacity: 60%;
     }
   }
   .disabled\:opacity-75 {


### PR DESCRIPTION
## Summary
- add a PetWeight model with GET/POST routes to persist weight history and refresh the pet record
- build a peso modal that loads history, registers new weights, and wires the quick action button/state flows
- surface weight cards in the consulta agenda panel with variation details and loading feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc2fda9ea08323bd1182e6d906b0fb