### PR TITLE
Organiza pastas do Drive para anexos veterinários

### DIFF
--- a/servidor/routes/funcVet.js
+++ b/servidor/routes/funcVet.js
@@ -6,6 +6,7 @@ const multer = require('multer');
 const authMiddleware = require('../middlewares/authMiddleware');
 const authorizeRoles = require('../middlewares/authorizeRoles');
 const Pet = require('../models/Pet');
+const User = require('../models/User');
 const Service = require('../models/Service');
 const Appointment = require('../models/Appointment');
 const VetConsultation = require('../models/VetConsultation');
@@ -25,6 +26,7 @@ const ALLOWED_ANEXO_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.pdf']);
 const ALLOWED_ANEXO_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'application/pdf']);
 const MAX_ANEXO_FILE_SIZE = 20 * 1024 * 1024; // 20MB
 const MAX_ANEXO_FILE_COUNT = 10;
+const EXAME_ATTACHMENT_OBSERVACAO_PREFIX = '__vet_exame__:';
 
 const uploadAnexoMiddleware = multer({
   storage: multer.memoryStorage(),
@@ -89,6 +91,13 @@ function sanitizeFileName(name) {
     .trim();
 }
 
+function sanitizeFolderSegment(name, fallback = '') {
+  const primary = sanitizeFileName(name).slice(0, 100);
+  if (primary) return primary;
+  const secondary = sanitizeFileName(fallback).slice(0, 100);
+  return secondary || '';
+}
+
 function ensureFileNameWithExtension(name, extension) {
   if (!extension) return name || '';
   const ext = extension.startsWith('.') ? extension : `.${extension}`;
@@ -117,14 +126,14 @@ function isVetService(serviceDoc = {}) {
 }
 
 async function ensurePetBelongsToCliente(petId, clienteId) {
-  const pet = await Pet.findById(petId).select('owner').lean();
+  const pet = await Pet.findById(petId).select('owner nome').lean();
   if (!pet) {
     return { ok: false, status: 404, message: 'Pet não encontrado.' };
   }
   if (clienteId && toStringSafe(pet.owner) !== clienteId) {
     return { ok: false, status: 400, message: 'Pet não pertence ao tutor informado.' };
   }
-  return { ok: true };
+  return { ok: true, pet };
 }
 
 async function fetchVetService(servicoId) {
@@ -143,7 +152,7 @@ async function ensureAppointmentLink(appointmentId, clienteId, petId, servicoId)
     return { ok: true, appointment: null };
   }
   const appointment = await Appointment.findById(appointmentId)
-    .select('cliente pet servico itens')
+    .select('cliente pet servico itens codigoVenda createdAt')
     .lean();
   if (!appointment) {
     return { ok: false, status: 404, message: 'Agendamento não encontrado.' };
@@ -628,6 +637,48 @@ router.post('/vet/anexos', authMiddleware, requireStaff, handleAnexoUpload, asyn
       return res.status(appointmentCheck.status).json({ message: appointmentCheck.message });
     }
 
+    const observacaoRaw = typeof req.body.observacao === 'string' ? req.body.observacao.trim() : '';
+    const isExameAttachment = observacaoRaw.startsWith(EXAME_ATTACHMENT_OBSERVACAO_PREFIX);
+
+    const clienteDoc = await User.findById(cliente)
+      .select('cpf nomeCompleto email celular telefone')
+      .lean();
+    if (!clienteDoc) {
+      return res.status(404).json({ message: 'Tutor não encontrado.' });
+    }
+
+    const petDoc = petCheck.pet || null;
+    const tutorCpfDigits = clienteDoc.cpf ? String(clienteDoc.cpf).replace(/\D+/g, '') : '';
+    const tutorFallbackId = cliente ? String(cliente).slice(-6) || String(cliente) : 'tutor';
+    let tutorFolderName = tutorCpfDigits;
+    if (!tutorFolderName) {
+      const fallbackTutorName = clienteDoc.nomeCompleto || clienteDoc.email || clienteDoc.celular || clienteDoc.telefone || '';
+      tutorFolderName = sanitizeFolderSegment(
+        fallbackTutorName,
+        `sem-cpf-${tutorFallbackId}`,
+      ) || `sem-cpf-${tutorFallbackId}`;
+    }
+
+    const appointmentDoc = appointmentCheck.appointment || null;
+    let appointmentFolderName = '';
+    if (appointmentDoc) {
+      const rawCode = typeof appointmentDoc.codigoVenda === 'string' ? appointmentDoc.codigoVenda.trim() : '';
+      if (rawCode) {
+        appointmentFolderName = sanitizeFolderSegment(rawCode, rawCode);
+      } else if (appointmentDoc._id) {
+        appointmentFolderName = sanitizeFolderSegment(`atendimento-${appointmentDoc._id}`);
+      }
+    }
+    if (!appointmentFolderName) {
+      appointmentFolderName = sanitizeFolderSegment('sem-atendimento') || 'sem-atendimento';
+    }
+
+    const petFallbackId = pet ? String(pet).slice(-6) || String(pet) : 'pet';
+    const petFolderName = sanitizeFolderSegment(petDoc?.nome || '', `pet-${petFallbackId}`) || `pet-${petFallbackId}`;
+
+    const typeFolderName = sanitizeFolderSegment(isExameAttachment ? 'Exames' : 'Anexos') || (isExameAttachment ? 'Exames' : 'Anexos');
+    const folderPath = [tutorFolderName, appointmentFolderName, petFolderName, typeFolderName];
+
     const rawNames = req.body['nomes[]'];
     const providedNames = Array.isArray(rawNames)
       ? rawNames
@@ -657,6 +708,7 @@ router.post('/vet/anexos', authMiddleware, requireStaff, handleAnexoUpload, asyn
         mimeType: file.mimetype || 'application/octet-stream',
         name: driveFileName,
         folderId,
+        folderPath,
       });
 
       if (uploadResult?.id) {
@@ -682,7 +734,7 @@ router.post('/vet/anexos', authMiddleware, requireStaff, handleAnexoUpload, asyn
       cliente,
       pet,
       appointment: appointment || undefined,
-      observacao: typeof req.body.observacao === 'string' ? req.body.observacao.trim() : '',
+      observacao: observacaoRaw,
       arquivos: uploadedFiles,
       createdBy: nowUserId || undefined,
       updatedBy: nowUserId || undefined,


### PR DESCRIPTION
## Summary
- cria utilitários para localizar ou criar pastas no Google Drive antes do upload e reaproveitá-las via cache
- estrutura os uploads veterinários em pastas hierárquicas por CPF do tutor, código do atendimento, pet e tipo (Anexos ou Exames)
- busca dados do tutor, pet e agendamento ao salvar anexos para montar o caminho correto no Drive

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc9d4e7f8c8323aea52b8689d4d654