### PR TITLE
feat: personalize ficha clínica document preview

### DIFF
--- a/pages/funcionarios/vet-ficha-clinica.html
+++ b/pages/funcionarios/vet-ficha-clinica.html
@@ -283,7 +283,7 @@
                             <span class="flex items-center gap-2 text-gray-800"><i class="fas fa-vial"></i>
                                 Exames</span>
                         </a>
-                        <a
+                        <a id="vet-add-documento-btn" href="#"
                             class="flex items-center justify-between px-3 py-3 rounded-lg bg-emerald-50 ring-1 ring-emerald-100">
                             <span class="flex items-center gap-2 text-gray-800"><i class="fas fa-file-lines"></i>
                                 Documento</span>

--- a/scripts/funcionarios/vet/document-utils.js
+++ b/scripts/funcionarios/vet/document-utils.js
@@ -1,0 +1,283 @@
+export const KEYWORD_GROUPS = [
+  {
+    title: 'Tutor',
+    items: [
+      { token: '<NomeTutor>', description: 'Nome completo do tutor responsável pelo pet.' },
+      { token: '<EmailTutor>', description: 'E-mail principal do tutor.' },
+      { token: '<TelefoneTutor>', description: 'Telefone ou celular do tutor, formatado.' },
+      {
+        token: '<DocumentoTutor>',
+        description: 'Documento principal (CPF ou CNPJ) informado pelo tutor.',
+      },
+    ],
+  },
+  {
+    title: 'Pet',
+    items: [
+      { token: '<NomePet>', description: 'Nome do pet atendido.' },
+      { token: '<EspeciePet>', description: 'Espécie do pet (cão, gato, etc.).' },
+      { token: '<RacaPet>', description: 'Raça do pet.' },
+      { token: '<SexoPet>', description: 'Sexo do pet.' },
+      { token: '<NascimentoPet>', description: 'Data de nascimento do pet.' },
+      { token: '<IdadePet>', description: 'Idade atual estimada do pet.' },
+      { token: '<PesoPet>', description: 'Último peso registrado do pet.' },
+      { token: '<MicrochipPet>', description: 'Número de microchip do pet, quando disponível.' },
+    ],
+  },
+  {
+    title: 'Atendimento',
+    items: [
+      { token: '<DataAtendimento>', description: 'Data agendada ou realizada do atendimento.' },
+      { token: '<HoraAtendimento>', description: 'Horário do atendimento.' },
+      { token: '<NomeServico>', description: 'Nome do serviço ou procedimento veterinário.' },
+      { token: '<MotivoConsulta>', description: 'Motivo ou anamnese registrada para a consulta.' },
+      { token: '<DiagnosticoConsulta>', description: 'Diagnóstico registrado na consulta.' },
+      { token: '<ExameFisicoConsulta>', description: 'Resumo do exame físico registrado.' },
+      { token: '<NomeVeterinario>', description: 'Nome do profissional responsável pelo atendimento.' },
+    ],
+  },
+  {
+    title: 'Clínica e sistema',
+    items: [
+      { token: '<NomeClinica>', description: 'Nome da clínica ou unidade onde o atendimento ocorreu.' },
+      { token: '<EnderecoClinica>', description: 'Endereço completo da clínica.' },
+      { token: '<TelefoneClinica>', description: 'Telefone principal da clínica.' },
+      { token: '<WhatsappClinica>', description: 'WhatsApp oficial da clínica.' },
+      { token: '<DataAtual>', description: 'Data atual no formato local.' },
+      { token: '<HoraAtual>', description: 'Horário atual.' },
+      { token: '<DataHoraAtual>', description: 'Data e hora atuais.' },
+    ],
+  },
+];
+
+export function escapeHtml(value) {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  let escaped = str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+  escaped = escaped.replace(/\r\n|\n|\r/g, '<br />');
+  return escaped;
+}
+
+export function sanitizeDocumentHtml(html, { allowStyles = false } = {}) {
+  if (typeof html !== 'string') return '';
+  let safe = html;
+
+  const blockedTagPatterns = [
+    /<script[\s\S]*?>[\s\S]*?<\/script>/gi,
+    /<iframe[\s\S]*?>[\s\S]*?<\/iframe>/gi,
+    /<object[\s\S]*?>[\s\S]*?<\/object>/gi,
+    /<embed[\s\S]*?>[\s\S]*?<\/embed>/gi,
+    /<link[^>]*?>/gi,
+    /<meta[^>]*?>/gi,
+    /<base[^>]*?>/gi,
+  ];
+
+  blockedTagPatterns.forEach((pattern) => {
+    safe = safe.replace(pattern, '');
+  });
+
+  if (!allowStyles) {
+    safe = safe.replace(/<style[\s\S]*?>[\s\S]*?<\/style>/gi, '');
+  }
+
+  safe = safe
+    .replace(/\son[a-z]+\s*=\s*(['"])[\s\S]*?\1/gi, '')
+    .replace(/\s+(?:xlink:)?href\s*=\s*(['"])\s*(?:javascript|vbscript):[^'">]*\1/gi, ' href="#"')
+    .replace(/\s+src\s*=\s*(['"])\s*(?:javascript|vbscript):[^'">]*\1/gi, ' src="#"')
+    .replace(/url\((['"]?)\s*(?:javascript|vbscript):[^)]*?\1\)/gi, 'url()')
+    .replace(/data:text\/html/gi, '');
+
+  return safe;
+}
+
+export function extractPlainText(html) {
+  if (!html) return '';
+  const temp = document.createElement('div');
+  temp.innerHTML = html;
+  return (temp.textContent || temp.innerText || '').trim();
+}
+
+export function getPreviewText(html, maxLength = 220) {
+  const text = extractPlainText(html).replace(/\s+/g, ' ').trim();
+  if (!text) return '';
+  if (text.length > maxLength) {
+    return `${text.slice(0, maxLength).trim()}…`;
+  }
+  return text;
+}
+
+const keywordRegexCache = new Map();
+
+export function applyKeywordReplacements(html, replacements = {}) {
+  if (typeof html !== 'string') return '';
+  if (!replacements || typeof replacements !== 'object') {
+    return html;
+  }
+
+  let output = html;
+  Object.entries(replacements).forEach(([token, rawValue]) => {
+    const normalizedToken = typeof token === 'string' ? token.trim() : '';
+    if (!normalizedToken) return;
+    const value = escapeHtml(rawValue);
+    if (!keywordRegexCache.has(normalizedToken)) {
+      const escapedToken = normalizedToken.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
+      keywordRegexCache.set(normalizedToken, new RegExp(escapedToken, 'g'));
+    }
+    const regex = keywordRegexCache.get(normalizedToken);
+    if (!regex) return;
+    output = output.replace(regex, value);
+  });
+
+  return output;
+}
+
+function updatePreviewFrameHeight(frame, minHeight = 320) {
+  if (!frame) return;
+  try {
+    const doc = frame.contentDocument || frame.contentWindow?.document;
+    if (!doc) return;
+    const body = doc.body;
+    const html = doc.documentElement;
+    const bodyHeight = body ? Math.max(body.scrollHeight, body.offsetHeight, body.clientHeight) : 0;
+    const htmlHeight = html ? Math.max(html.scrollHeight, html.offsetHeight, html.clientHeight) : 0;
+    const height = Math.max(bodyHeight, htmlHeight, minHeight);
+    frame.style.height = `${height}px`;
+  } catch (_) {
+    // Ignore preview sizing errors
+  }
+}
+
+export function renderPreviewFrameContent(
+  frame,
+  html,
+  { minHeight = 320, padding = 24, background = '#f1f5f9', allowStyles = true } = {},
+) {
+  if (!frame) return '';
+  frame.style.minHeight = `${minHeight}px`;
+  frame.style.height = `${minHeight}px`;
+  const sanitized = sanitizeDocumentHtml(html, { allowStyles });
+  const hasContent = !!sanitized && sanitized.trim().length > 0;
+  const placeholder = `
+    <div class="preview-empty">
+      Nenhum conteúdo para pré-visualizar.
+    </div>
+  `;
+  const documentHtml = `<!DOCTYPE html>
+    <html lang="pt-BR">
+      <head>
+        <meta charset="utf-8" />
+        <base target="_blank" />
+        <style>
+          :root { color-scheme: light; }
+          *, *::before, *::after { box-sizing: border-box; }
+          body { margin: 0; background: ${background}; font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif; color: #0f172a; }
+          .preview-wrapper { padding: ${padding}px; min-height: ${Math.max(minHeight - padding * 2, 0)}px; }
+          img { max-width: 100%; height: auto; display: block; }
+          table { width: 100%; border-collapse: collapse; }
+          .preview-empty {
+            display: grid;
+            place-items: center;
+            min-height: 160px;
+            border-radius: 16px;
+            border: 1px dashed rgba(148, 163, 184, 0.6);
+            background: rgba(148, 163, 184, 0.12);
+            color: #475569;
+            font-size: 14px;
+            line-height: 1.5;
+            text-align: center;
+            padding: 24px;
+          }
+        </style>
+      </head>
+      <body>
+        <div class="preview-wrapper">
+          ${hasContent ? sanitized : placeholder}
+        </div>
+      </body>
+    </html>`;
+
+  frame.srcdoc = documentHtml;
+
+  if (!frame.dataset.previewInitialized) {
+    frame.addEventListener('load', () => updatePreviewFrameHeight(frame, minHeight));
+    frame.dataset.previewInitialized = 'true';
+  }
+
+  setTimeout(() => updatePreviewFrameHeight(frame, minHeight), 60);
+
+  return sanitized;
+}
+
+export function openDocumentPrintWindow(html, { title = 'Documento', styles = '' } = {}) {
+  if (typeof window === 'undefined') return false;
+  const sanitized = sanitizeDocumentHtml(html, { allowStyles: true });
+  const safeContent = sanitized && sanitized.trim()
+    ? sanitized
+    : '<p style="font-size:14px;color:#475569;">Documento sem conteúdo para impressão.</p>';
+
+  const documentHtml = `<!DOCTYPE html>
+    <html lang="pt-BR">
+      <head>
+        <meta charset="utf-8" />
+        <title>${title ? String(title).replace(/</g, '&lt;').replace(/>/g, '&gt;') : 'Documento'}</title>
+        <style>
+          :root { color-scheme: light; }
+          *, *::before, *::after { box-sizing: border-box; }
+          body {
+            margin: 0;
+            padding: 32px;
+            background: #f8fafc;
+            font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+            color: #0f172a;
+            line-height: 1.6;
+            font-size: 14px;
+          }
+          h1, h2, h3, h4, h5, h6 { color: #0f172a; margin-top: 1.2em; }
+          table { width: 100%; border-collapse: collapse; }
+          table th, table td { border: 1px solid #cbd5f5; padding: 8px; }
+          img { max-width: 100%; height: auto; }
+          ${styles || ''}
+        </style>
+      </head>
+      <body>${safeContent}</body>
+    </html>`;
+
+  let printWindow = null;
+  try {
+    printWindow = window.open('', '_blank', 'noopener,noreferrer');
+    if (!printWindow) {
+      return false;
+    }
+    printWindow.document.open();
+    printWindow.document.write(documentHtml);
+    printWindow.document.close();
+    const triggerPrint = () => {
+      try {
+        printWindow.focus();
+        printWindow.print();
+      } catch (error) {
+        console.error('openDocumentPrintWindow', error);
+      }
+    };
+    if (printWindow.addEventListener) {
+      printWindow.addEventListener('load', () => setTimeout(triggerPrint, 100));
+    }
+    setTimeout(triggerPrint, 300);
+    return true;
+  } catch (error) {
+    console.error('openDocumentPrintWindow', error);
+    if (printWindow) {
+      try {
+        printWindow.close();
+      } catch (_) {
+        /* ignore */
+      }
+    }
+    return false;
+  }
+}

--- a/scripts/funcionarios/vet/ficha-clinica/core.js
+++ b/scripts/funcionarios/vet/ficha-clinica/core.js
@@ -98,6 +98,7 @@ export const els = {
   addConsultaBtn: document.getElementById('vet-add-consulta-btn'),
   addVacinaBtn: document.getElementById('vet-add-vacina-btn'),
   addAnexoBtn: document.getElementById('vet-add-anexo-btn'),
+  addDocumentoBtn: document.getElementById('vet-add-documento-btn'),
   addExameBtn: document.getElementById('vet-add-exame-btn'),
   addPesoBtn: document.getElementById('vet-add-peso-btn'),
   addObservacaoBtn: document.getElementById('vet-add-observacao-btn'),
@@ -123,6 +124,7 @@ export const state = {
   pesosLoading: false,
   pesosLoadKey: null,
   observacoes: [],
+  documentos: [],
 };
 
 export const consultaModal = {

--- a/scripts/funcionarios/vet/ficha-clinica/documentos.js
+++ b/scripts/funcionarios/vet/ficha-clinica/documentos.js
@@ -1,0 +1,939 @@
+// Documento modal handling for the Vet ficha clínica
+import {
+  state,
+  api,
+  notify,
+  pickFirst,
+  formatPhone,
+  formatDateDisplay,
+  formatDateTimeDisplay,
+  formatPetSex,
+  formatPetWeight,
+  formatPetMicrochip,
+  getSelectedPet,
+  getAgendaStoreId,
+} from './core.js';
+import { ensureTutorAndPetSelected, updateConsultaAgendaCard } from './consultas.js';
+import {
+  KEYWORD_GROUPS,
+  renderPreviewFrameContent,
+  getPreviewText,
+  openDocumentPrintWindow,
+  applyKeywordReplacements,
+} from '../document-utils.js';
+
+const documentoModal = {
+  overlay: null,
+  dialog: null,
+  select: null,
+  previewFrame: null,
+  previewTitle: null,
+  previewEmpty: null,
+  loadingState: null,
+  emptyState: null,
+  saveBtn: null,
+  printBtn: null,
+  keywordContainer: null,
+  previewDefaultMessage: '',
+  keywordItems: [],
+  documents: [],
+  isLoading: false,
+  isGenerating: false,
+  selectedId: '',
+  keydownHandler: null,
+};
+
+const PREVIEW_LOADING_MESSAGE = 'Carregando pré-visualização com os dados do atendimento...';
+const PREVIEW_ERROR_MESSAGE = 'Erro ao gerar pré-visualização do documento.';
+const storeCache = new Map();
+const storePromiseCache = new Map();
+let previewUpdateToken = 0;
+
+function renderKeywordReference() {
+  if (!documentoModal.keywordContainer) return;
+  documentoModal.keywordContainer.innerHTML = '';
+  documentoModal.keywordItems = [];
+
+  KEYWORD_GROUPS.forEach((group) => {
+    if (!group || !Array.isArray(group.items) || !group.items.length) return;
+
+    const section = document.createElement('div');
+    section.className = 'space-y-2';
+
+    const heading = document.createElement('h3');
+    heading.className = 'text-xs font-semibold uppercase tracking-wide text-slate-500';
+    heading.textContent = group.title;
+    section.appendChild(heading);
+
+    const list = document.createElement('div');
+    list.className = 'grid gap-2';
+
+    group.items.forEach((item) => {
+      const token = typeof item?.token === 'string' ? item.token.trim() : '';
+      if (!token) return;
+
+      const wrapper = document.createElement('div');
+      wrapper.className = 'rounded-lg border border-slate-200 bg-white px-3 py-2 shadow-sm transition';
+
+      const tokenEl = document.createElement('div');
+      tokenEl.className = 'font-mono text-[11px] font-semibold text-slate-700';
+      tokenEl.textContent = token;
+      wrapper.appendChild(tokenEl);
+
+      if (item.description) {
+        const description = document.createElement('p');
+        description.className = 'mt-1 text-xs text-slate-500';
+        description.textContent = item.description;
+        wrapper.appendChild(description);
+      }
+
+      documentoModal.keywordItems.push({ token, element: wrapper, label: tokenEl });
+      list.appendChild(wrapper);
+    });
+
+    if (list.children.length) {
+      section.appendChild(list);
+      documentoModal.keywordContainer.appendChild(section);
+    }
+  });
+}
+
+function highlightKeywords(content) {
+  const value = typeof content === 'string' ? content : '';
+  documentoModal.keywordItems.forEach((item) => {
+    const found = value.includes(item.token);
+    item.element.classList.toggle('border-emerald-300', found);
+    item.element.classList.toggle('bg-emerald-50', found);
+    item.element.classList.toggle('text-emerald-700', found);
+    if (item.label) {
+      item.label.classList.toggle('text-emerald-700', found);
+    }
+  });
+}
+
+function setModalLoading(isLoading) {
+  documentoModal.isLoading = !!isLoading;
+  if (documentoModal.loadingState) {
+    documentoModal.loadingState.classList.toggle('hidden', !isLoading);
+  }
+  if (documentoModal.select) {
+    documentoModal.select.disabled = !!isLoading;
+    documentoModal.select.classList.toggle('opacity-60', !!isLoading);
+  }
+  updateButtonsState();
+}
+
+function updateButtonsState() {
+  const hasSelection = !!getSelectedDocument();
+  const disabled = documentoModal.isLoading || documentoModal.isGenerating || !hasSelection;
+  if (documentoModal.saveBtn) {
+    documentoModal.saveBtn.disabled = disabled;
+    documentoModal.saveBtn.classList.toggle('opacity-60', disabled);
+    documentoModal.saveBtn.classList.toggle('cursor-not-allowed', disabled);
+  }
+  if (documentoModal.printBtn) {
+    documentoModal.printBtn.disabled = disabled;
+    documentoModal.printBtn.classList.toggle('opacity-60', disabled);
+    documentoModal.printBtn.classList.toggle('cursor-not-allowed', disabled);
+  }
+}
+
+function normalizeDocumentRecord(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const id = String(raw.id || raw._id || '').trim();
+  if (!id) return null;
+  const descricao = typeof raw.descricao === 'string' ? raw.descricao.trim() : '';
+  const conteudo = typeof raw.conteudo === 'string' ? raw.conteudo : '';
+  const createdAt = raw.createdAt ? new Date(raw.createdAt).toISOString() : null;
+  const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).toISOString() : createdAt;
+  return { id, descricao, conteudo, createdAt, updatedAt };
+}
+
+function formatDocumentNumber(value) {
+  if (value === null || value === undefined) return '';
+  const str = String(value).trim();
+  if (!str) return '';
+  const digits = str.replace(/\D+/g, '');
+  if (digits.length === 11) {
+    return digits.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
+  }
+  if (digits.length === 14) {
+    return digits.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, '$1.$2.$3/$4-$5');
+  }
+  return str;
+}
+
+function parseDateValue(value) {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : new Date(value.getTime());
+  }
+  if (typeof value === 'number') {
+    const dateFromNumber = new Date(value);
+    return Number.isNaN(dateFromNumber.getTime()) ? null : dateFromNumber;
+  }
+  const str = String(value).trim();
+  if (!str) return null;
+  let parsed = new Date(str);
+  if (!Number.isNaN(parsed.getTime())) return parsed;
+  const match = str.match(/^(\d{2})[\/\-](\d{2})[\/\-](\d{4})$/);
+  if (match) {
+    const [, day, month, year] = match;
+    parsed = new Date(`${year}-${month}-${day}T00:00:00`);
+    if (!Number.isNaN(parsed.getTime())) return parsed;
+  }
+  return null;
+}
+
+function formatTimeDisplay(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
+  try {
+    return date.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
+  } catch (error) {
+    return '';
+  }
+}
+
+function formatPetAge(pet) {
+  if (!pet) return '';
+  const birthRaw = pickFirst(pet?.dataNascimento, pet?.nascimento);
+  const birthDate = parseDateValue(birthRaw);
+  if (!birthDate) return '';
+  const now = new Date();
+  if (Number.isNaN(now.getTime()) || birthDate > now) return '';
+
+  let totalMonths = (now.getFullYear() - birthDate.getFullYear()) * 12 + (now.getMonth() - birthDate.getMonth());
+  if (now.getDate() < birthDate.getDate()) {
+    totalMonths -= 1;
+  }
+  if (totalMonths < 0) totalMonths = 0;
+
+  const years = Math.floor(totalMonths / 12);
+  const months = totalMonths % 12;
+  const parts = [];
+  if (years > 0) parts.push(`${years} ano${years === 1 ? '' : 's'}`);
+  if (months > 0) parts.push(`${months} mês${months === 1 ? '' : 'es'}`);
+  if (!parts.length) {
+    const diffMs = now.getTime() - birthDate.getTime();
+    const days = Math.max(Math.floor(diffMs / (1000 * 60 * 60 * 24)), 0);
+    if (days > 0) {
+      parts.push(`${days} dia${days === 1 ? '' : 's'}`);
+    } else {
+      parts.push('Recém-nascido');
+    }
+  }
+  return parts.join(' e ');
+}
+
+function getLatestPetWeightValue() {
+  const entries = Array.isArray(state.pesos) ? state.pesos.slice() : [];
+  if (!entries.length) return null;
+  entries.sort((a, b) => {
+    const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return bTime - aTime;
+  });
+  const recent = entries.find((entry) => entry && entry.peso !== null && entry.peso !== undefined && !entry.isInitial);
+  const fallback = entries.find((entry) => entry && entry.peso !== null && entry.peso !== undefined);
+  const target = recent || fallback || null;
+  if (!target) return null;
+  const value = target.peso;
+  if (value === null || value === undefined) return null;
+  return value;
+}
+
+function getLatestConsultaWithData() {
+  const consultas = Array.isArray(state.consultas) ? state.consultas.slice() : [];
+  if (!consultas.length) return null;
+  consultas.sort((a, b) => {
+    const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return bTime - aTime;
+  });
+  for (const consulta of consultas) {
+    if (!consulta) continue;
+    if (pickFirst(consulta.anamnese, consulta.diagnostico, consulta.exameFisico, consulta.servicoNome)) {
+      return consulta;
+    }
+  }
+  return consultas[0] || null;
+}
+
+function extractServiceName(consulta, agenda) {
+  const consultaName = pickFirst(consulta?.servicoNome);
+  if (consultaName) return consultaName;
+  const services = Array.isArray(agenda?.servicos) ? agenda.servicos : [];
+  for (const service of services) {
+    const name = pickFirst(
+      service?.nome,
+      service?.servicoNome,
+      service?.descricao,
+      service?.label,
+      service?.servico?.nome,
+      typeof service === 'string' ? service : '',
+    );
+    if (name) return name;
+  }
+  return pickFirst(
+    agenda?.servicoNome,
+    agenda?.servico,
+    agenda?.nomeServico,
+    agenda?.descricaoServico,
+  );
+}
+
+function getAgendaScheduledDate(agenda, consulta) {
+  const candidates = [
+    agenda?.scheduledAt,
+    agenda?.data,
+    agenda?.dataHora,
+    agenda?.horario,
+    agenda?.inicio,
+    consulta?.createdAt,
+  ];
+  for (const candidate of candidates) {
+    const parsed = parseDateValue(candidate);
+    if (parsed) return parsed;
+  }
+  return null;
+}
+
+async function fetchStoreInfoById(storeId) {
+  const normalized = typeof storeId === 'string' ? storeId.trim() : '';
+  if (!normalized) return null;
+  if (storeCache.has(normalized)) return storeCache.get(normalized);
+  if (storePromiseCache.has(normalized)) return storePromiseCache.get(normalized);
+
+  const promise = api(`/stores/${encodeURIComponent(normalized)}`)
+    .then((resp) => {
+      if (!resp.ok) return null;
+      return resp.json().catch(() => null);
+    })
+    .then((data) => {
+      if (data && data._id) {
+        storeCache.set(normalized, data);
+        return data;
+      }
+      return null;
+    })
+    .catch((error) => {
+      console.error('fetchStoreInfoById', error);
+      return null;
+    })
+    .finally(() => {
+      storePromiseCache.delete(normalized);
+    });
+
+  storePromiseCache.set(normalized, promise);
+  return promise;
+}
+
+async function buildKeywordReplacements() {
+  const replacements = {};
+  KEYWORD_GROUPS.forEach((group) => {
+    if (!group || !Array.isArray(group.items)) return;
+    group.items.forEach((item) => {
+      const token = typeof item?.token === 'string' ? item.token : '';
+      if (token && !(token in replacements)) {
+        replacements[token] = '';
+      }
+    });
+  });
+
+  try {
+    const tutor = state.selectedCliente || null;
+    const pet = getSelectedPet();
+    const agenda = state.agendaContext || {};
+    const consulta = getLatestConsultaWithData();
+    const now = new Date();
+
+    replacements['<NomeTutor>'] = pickFirst(
+      tutor?.nome,
+      tutor?.nomeCompleto,
+      tutor?.razaoSocial,
+      tutor?.nomeFantasia,
+      tutor?.nomeContato,
+      tutor?.apelido,
+      tutor?.displayName,
+    );
+    replacements['<EmailTutor>'] = pickFirst(tutor?.email);
+    const tutorPhone = pickFirst(
+      tutor?.celular,
+      tutor?.telefone,
+      tutor?.whatsapp,
+      tutor?.phone,
+      tutor?.mobile,
+    );
+    replacements['<TelefoneTutor>'] = tutorPhone ? formatPhone(tutorPhone) : '';
+    const tutorDocument = pickFirst(
+      formatDocumentNumber(tutor?.documento),
+      formatDocumentNumber(tutor?.documentoPrincipal),
+      formatDocumentNumber(tutor?.cpf),
+      formatDocumentNumber(tutor?.cpfCnpj),
+      formatDocumentNumber(tutor?.cnpj),
+      formatDocumentNumber(tutor?.inscricaoEstadual),
+    );
+    replacements['<DocumentoTutor>'] = tutorDocument;
+
+    replacements['<NomePet>'] = pickFirst(
+      pet?.nome,
+      pet?.nomePet,
+      pet?.apelido,
+    );
+    replacements['<EspeciePet>'] = pickFirst(
+      pet?.especie,
+      pet?.tipo,
+      pet?.tipoPet,
+      pet?.categoria,
+      pet?.porte,
+      pet?.especiePet,
+    );
+    replacements['<RacaPet>'] = pickFirst(
+      pet?.raca,
+      pet?.breed,
+      pet?.racaNome,
+      pet?.racaDescricao,
+      pet?.racaPrincipal,
+      pet?.racaOriginal,
+      pet?.racaPet,
+      pet?.racaLabel,
+      pet?.raca?.nome,
+      pet?.raca?.descricao,
+      pet?.raca?.label,
+    );
+    replacements['<SexoPet>'] = pet ? formatPetSex(pet.sexo) : '';
+
+    const nascimento = parseDateValue(pickFirst(pet?.dataNascimento, pet?.nascimento));
+    replacements['<NascimentoPet>'] = nascimento ? formatDateDisplay(nascimento) : '';
+    replacements['<IdadePet>'] = formatPetAge(pet);
+
+    const latestPeso = getLatestPetWeightValue();
+    const pesoFonte = latestPeso !== null ? latestPeso : pickFirst(pet?.pesoAtual, pet?.peso, pet?.ultimoPeso);
+    replacements['<PesoPet>'] =
+      pesoFonte !== null && pesoFonte !== undefined && pesoFonte !== ''
+        ? formatPetWeight(pesoFonte)
+        : '';
+
+    const microchip = pickFirst(pet?.microchip, pet?.microChip, pet?.chip);
+    replacements['<MicrochipPet>'] = microchip ? formatPetMicrochip(microchip) : '';
+
+    const atendimentoDate = getAgendaScheduledDate(agenda, consulta);
+    replacements['<DataAtendimento>'] = atendimentoDate ? formatDateDisplay(atendimentoDate) : '';
+    replacements['<HoraAtendimento>'] = atendimentoDate ? formatTimeDisplay(atendimentoDate) : '';
+
+    replacements['<NomeServico>'] = extractServiceName(consulta, agenda);
+
+    replacements['<MotivoConsulta>'] = pickFirst(
+      consulta?.anamnese,
+      agenda?.observacoes,
+      agenda?.observacao,
+      agenda?.nota,
+      agenda?.motivo,
+    );
+    replacements['<DiagnosticoConsulta>'] = pickFirst(consulta?.diagnostico);
+    replacements['<ExameFisicoConsulta>'] = pickFirst(consulta?.exameFisico);
+    replacements['<NomeVeterinario>'] = pickFirst(
+      agenda?.profissionalNome,
+      agenda?.veterinarioNome,
+      agenda?.profissional?.nome,
+      agenda?.profissional?.nomeCompleto,
+    );
+
+    const storeId = getAgendaStoreId({ persist: false });
+    const store = storeId ? await fetchStoreInfoById(storeId) : null;
+
+    replacements['<NomeClinica>'] = pickFirst(
+      agenda?.storeNome,
+      agenda?.lojaNome,
+      agenda?.filialNome,
+      agenda?.empresaNome,
+      agenda?.empresa,
+      store?.nome,
+    );
+    replacements['<EnderecoClinica>'] = pickFirst(
+      agenda?.storeEndereco,
+      agenda?.lojaEndereco,
+      agenda?.endereco,
+      store?.endereco,
+    );
+    const clinicPhone = pickFirst(agenda?.storeTelefone, agenda?.telefone, store?.telefone);
+    replacements['<TelefoneClinica>'] = clinicPhone ? formatPhone(clinicPhone) : '';
+    const clinicWhatsapp = pickFirst(agenda?.storeWhatsapp, agenda?.whatsapp, store?.whatsapp);
+    replacements['<WhatsappClinica>'] = clinicWhatsapp ? formatPhone(clinicWhatsapp) : '';
+
+    replacements['<DataAtual>'] = formatDateDisplay(now);
+    replacements['<HoraAtual>'] = formatTimeDisplay(now);
+    replacements['<DataHoraAtual>'] = formatDateTimeDisplay(now);
+  } catch (error) {
+    console.error('buildKeywordReplacements', error);
+  }
+
+  return replacements;
+}
+
+async function resolveDocumentContent(doc) {
+  const rawContent = typeof doc?.conteudo === 'string' ? doc.conteudo : '';
+  const replacements = await buildKeywordReplacements();
+  const html = applyKeywordReplacements(rawContent, replacements);
+  return { html, replacements };
+}
+
+function ensureDocumentoModal() {
+  if (documentoModal.overlay) return documentoModal;
+
+  const overlay = document.createElement('div');
+  overlay.id = 'vet-documento-modal';
+  overlay.className = 'hidden fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4';
+  overlay.setAttribute('aria-hidden', 'true');
+
+  const dialog = document.createElement('div');
+  dialog.className = 'w-full max-w-3xl rounded-xl bg-white shadow-2xl focus:outline-none';
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
+  dialog.tabIndex = -1;
+  overlay.appendChild(dialog);
+
+  const layout = document.createElement('div');
+  layout.className = 'flex max-h-[90vh] flex-col';
+  dialog.appendChild(layout);
+
+  const header = document.createElement('div');
+  header.className = 'flex items-start justify-between gap-3 border-b border-gray-100 px-6 py-4';
+  layout.appendChild(header);
+
+  const titleWrap = document.createElement('div');
+  header.appendChild(titleWrap);
+
+  const title = document.createElement('h2');
+  title.className = 'text-lg font-semibold text-gray-900';
+  title.textContent = 'Gerar documento';
+  titleWrap.appendChild(title);
+
+  const subtitle = document.createElement('p');
+  subtitle.className = 'text-sm text-gray-600';
+  subtitle.textContent = 'Selecione um documento salvo para utilizar durante o atendimento.';
+  titleWrap.appendChild(subtitle);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.className = 'h-9 w-9 grid place-content-center rounded-lg bg-gray-100 text-gray-500 transition hover:bg-gray-200 hover:text-gray-700';
+  closeBtn.innerHTML = '<i class="fas fa-xmark"></i>';
+  closeBtn.addEventListener('click', () => closeDocumentoModal());
+  header.appendChild(closeBtn);
+
+  const content = document.createElement('div');
+  content.className = 'flex-1 space-y-5 overflow-y-auto px-6 py-5';
+  layout.appendChild(content);
+
+  const selectField = document.createElement('div');
+  selectField.className = 'space-y-2';
+  content.appendChild(selectField);
+
+  const selectLabel = document.createElement('label');
+  selectLabel.className = 'text-sm font-medium text-gray-700';
+  selectLabel.textContent = 'Documento salvo';
+  selectLabel.setAttribute('for', 'vet-documento-select');
+  selectField.appendChild(selectLabel);
+
+  const select = document.createElement('select');
+  select.id = 'vet-documento-select';
+  select.className = 'w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200';
+  select.addEventListener('change', () => handleSelectChange());
+  selectField.appendChild(select);
+
+  const selectHelp = document.createElement('p');
+  selectHelp.className = 'text-xs text-gray-500';
+  selectHelp.textContent = 'Os modelos utilizam palavras-chave que serão substituídas automaticamente pelos dados do tutor, pet e atendimento.';
+  selectField.appendChild(selectHelp);
+
+  const loadingState = document.createElement('div');
+  loadingState.className = 'hidden rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-600';
+  loadingState.textContent = 'Carregando documentos salvos...';
+  content.appendChild(loadingState);
+
+  const emptyState = document.createElement('div');
+  emptyState.className = 'hidden rounded-lg border border-dashed border-slate-300 bg-white px-4 py-3 text-sm text-slate-600';
+  emptyState.textContent = 'Nenhum documento salvo foi encontrado.';
+  content.appendChild(emptyState);
+
+  const previewCard = document.createElement('div');
+  previewCard.className = 'overflow-hidden rounded-xl border border-slate-200 bg-slate-50 shadow-inner';
+  content.appendChild(previewCard);
+
+  const previewBar = document.createElement('div');
+  previewBar.className = 'flex items-center gap-2 border-b border-slate-200 bg-slate-100 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600';
+  previewBar.innerHTML = '<i class="fas fa-eye text-sky-600"></i><span>Pré-visualização</span>';
+  previewCard.appendChild(previewBar);
+
+  const previewTitle = document.createElement('p');
+  previewTitle.className = 'px-4 py-2 text-sm font-medium text-slate-700';
+  previewTitle.textContent = 'Nenhum documento selecionado.';
+  previewCard.appendChild(previewTitle);
+
+  const previewWrapper = document.createElement('div');
+  previewWrapper.className = 'relative';
+  previewCard.appendChild(previewWrapper);
+
+  const previewFrame = document.createElement('iframe');
+  previewFrame.className = 'block h-[320px] w-full bg-white';
+  previewFrame.id = 'vet-documento-preview-frame';
+  previewFrame.setAttribute('loading', 'lazy');
+  previewWrapper.appendChild(previewFrame);
+
+  const previewEmpty = document.createElement('div');
+  previewEmpty.className = 'absolute inset-0 flex items-center justify-center px-6 text-center text-sm text-slate-500';
+  previewEmpty.textContent = 'Selecione um documento para visualizar com as palavras-chave atualizadas.';
+  previewEmpty.dataset.defaultMessage = previewEmpty.textContent;
+  previewWrapper.appendChild(previewEmpty);
+
+  const keywordsSection = document.createElement('div');
+  keywordsSection.className = 'rounded-xl border border-dashed border-slate-300 bg-white p-4';
+  content.appendChild(keywordsSection);
+
+  const keywordsTitle = document.createElement('h3');
+  keywordsTitle.className = 'text-sm font-semibold text-slate-700';
+  keywordsTitle.textContent = 'Palavras-chave disponíveis';
+  keywordsSection.appendChild(keywordsTitle);
+
+  const keywordsHelp = document.createElement('p');
+  keywordsHelp.className = 'mt-1 text-xs text-slate-500';
+  keywordsHelp.textContent = 'As palavras abaixo são substituídas automaticamente pelos dados atuais do atendimento.';
+  keywordsSection.appendChild(keywordsHelp);
+
+  const keywordsContainer = document.createElement('div');
+  keywordsContainer.className = 'mt-3 grid gap-2 sm:grid-cols-2';
+  keywordsSection.appendChild(keywordsContainer);
+
+  const footer = document.createElement('div');
+  footer.className = 'flex flex-wrap items-center justify-between gap-3 border-t border-gray-200 bg-slate-50 px-6 py-4';
+  layout.appendChild(footer);
+
+  const footerInfo = document.createElement('p');
+  footerInfo.className = 'text-xs text-slate-500';
+  footerInfo.textContent = 'Salve para registrar o documento na aba de consultas ou imprima imediatamente.';
+  footer.appendChild(footerInfo);
+
+  const footerActions = document.createElement('div');
+  footerActions.className = 'flex flex-wrap items-center gap-2';
+  footer.appendChild(footerActions);
+
+  const printBtn = document.createElement('button');
+  printBtn.type = 'button';
+  printBtn.className = 'inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200';
+  printBtn.innerHTML = '<i class="fas fa-print"></i><span>Imprimir</span>';
+  printBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    const result = handlePrint();
+    if (result && typeof result.catch === 'function') {
+      result.catch(() => {});
+    }
+  });
+  footerActions.appendChild(printBtn);
+
+  const saveBtn = document.createElement('button');
+  saveBtn.type = 'button';
+  saveBtn.className = 'inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-300';
+  saveBtn.innerHTML = '<i class="fas fa-save"></i><span>Salvar no atendimento</span>';
+  saveBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    const result = handleSave();
+    if (result && typeof result.catch === 'function') {
+      result.catch(() => {});
+    }
+  });
+  footerActions.appendChild(saveBtn);
+
+  overlay.addEventListener('click', (event) => {
+    if (event.target === overlay) {
+      closeDocumentoModal();
+    }
+  });
+
+  documentoModal.overlay = overlay;
+  documentoModal.dialog = dialog;
+  documentoModal.select = select;
+  documentoModal.previewFrame = previewFrame;
+  documentoModal.previewTitle = previewTitle;
+  documentoModal.previewEmpty = previewEmpty;
+  documentoModal.previewDefaultMessage = previewEmpty.textContent || '';
+  documentoModal.loadingState = loadingState;
+  documentoModal.emptyState = emptyState;
+  documentoModal.saveBtn = saveBtn;
+  documentoModal.printBtn = printBtn;
+  documentoModal.keywordContainer = keywordsContainer;
+  documentoModal.keywordItems = [];
+  documentoModal.documents = [];
+  documentoModal.selectedId = '';
+  documentoModal.isLoading = false;
+  documentoModal.isGenerating = false;
+
+  renderKeywordReference();
+  document.body.appendChild(overlay);
+  return documentoModal;
+}
+
+function getSelectedDocument() {
+  const id = String(documentoModal.selectedId || '').trim();
+  if (!id) return null;
+  return documentoModal.documents.find((doc) => doc.id === id) || null;
+}
+
+function populateDocumentOptions() {
+  if (!documentoModal.select) return;
+
+  const docs = Array.isArray(documentoModal.documents) ? documentoModal.documents : [];
+  documentoModal.select.innerHTML = '';
+
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = docs.length ? 'Selecione um documento salvo' : 'Nenhum documento encontrado';
+  placeholder.disabled = !!docs.length;
+  placeholder.selected = true;
+  documentoModal.select.appendChild(placeholder);
+
+  docs.forEach((doc) => {
+    const option = document.createElement('option');
+    option.value = doc.id;
+    option.textContent = doc.descricao || 'Documento';
+    documentoModal.select.appendChild(option);
+  });
+
+  if (documentoModal.emptyState) {
+    documentoModal.emptyState.classList.toggle('hidden', docs.length > 0);
+  }
+
+  if (docs.length) {
+    const hasPreviousSelection = docs.some((doc) => doc.id === documentoModal.selectedId);
+    const targetId = hasPreviousSelection ? documentoModal.selectedId : docs[0].id;
+    documentoModal.selectedId = targetId;
+    documentoModal.select.value = targetId;
+    updatePreview().catch(() => {});
+  } else {
+    documentoModal.selectedId = '';
+    updatePreview().catch(() => {});
+  }
+
+  updateButtonsState();
+}
+
+async function updatePreview() {
+  const doc = getSelectedDocument();
+  const previewFrame = documentoModal.previewFrame;
+  const previewTitle = documentoModal.previewTitle;
+  const previewEmpty = documentoModal.previewEmpty;
+  const defaultMessage = documentoModal.previewDefaultMessage
+    || previewEmpty?.dataset?.defaultMessage
+    || 'Selecione um documento para visualizar com as palavras-chave atualizadas.';
+
+  if (!doc) {
+    if (previewTitle) {
+      previewTitle.textContent = 'Nenhum documento selecionado.';
+    }
+    if (previewEmpty) {
+      previewEmpty.textContent = defaultMessage;
+      previewEmpty.classList.remove('hidden');
+    }
+    if (previewFrame) {
+      renderPreviewFrameContent(previewFrame, '', { minHeight: 320, background: '#f8fafc' });
+    }
+    highlightKeywords('');
+    documentoModal.isGenerating = false;
+    updateButtonsState();
+    return;
+  }
+
+  if (previewTitle) {
+    previewTitle.textContent = doc.descricao || 'Documento salvo';
+  }
+  highlightKeywords(doc.conteudo || '');
+  if (previewEmpty) {
+    previewEmpty.textContent = PREVIEW_LOADING_MESSAGE;
+    previewEmpty.classList.remove('hidden');
+  }
+  if (previewFrame) {
+    renderPreviewFrameContent(previewFrame, '', { minHeight: 320, background: '#f8fafc' });
+  }
+
+  const requestId = ++previewUpdateToken;
+  documentoModal.isGenerating = true;
+  updateButtonsState();
+
+  try {
+    const { html } = await resolveDocumentContent(doc);
+    if (requestId !== previewUpdateToken) return;
+    if (previewFrame) {
+      renderPreviewFrameContent(previewFrame, html, { minHeight: 320, background: '#f8fafc' });
+    }
+    if (previewEmpty) {
+      previewEmpty.textContent = defaultMessage;
+      previewEmpty.classList.add('hidden');
+    }
+  } catch (error) {
+    console.error('updatePreview', error);
+    if (requestId !== previewUpdateToken) return;
+    if (previewEmpty) {
+      previewEmpty.textContent = PREVIEW_ERROR_MESSAGE;
+      previewEmpty.classList.remove('hidden');
+    }
+    if (previewFrame) {
+      renderPreviewFrameContent(previewFrame, '', { minHeight: 320, background: '#f8fafc' });
+    }
+  } finally {
+    if (requestId === previewUpdateToken) {
+      documentoModal.isGenerating = false;
+      updateButtonsState();
+    }
+  }
+}
+
+function handleSelectChange() {
+  if (!documentoModal.select) return;
+  documentoModal.selectedId = documentoModal.select.value || '';
+  updatePreview().catch(() => {});
+}
+
+async function loadDocuments({ force = false } = {}) {
+  const modal = ensureDocumentoModal();
+  if (modal.isLoading) return;
+  if (!force && Array.isArray(modal.documents) && modal.documents.length) {
+    populateDocumentOptions();
+    return;
+  }
+
+  setModalLoading(true);
+  try {
+    const resp = await api('/func/vet/documentos');
+    const payload = await resp.json().catch(() => (resp.ok ? [] : {}));
+    if (!resp.ok) {
+      const message = typeof payload?.message === 'string' ? payload.message : 'Erro ao carregar documentos.';
+      throw new Error(message);
+    }
+
+    const docs = Array.isArray(payload) ? payload : [];
+    const normalized = docs.map(normalizeDocumentRecord).filter(Boolean);
+    normalized.sort((a, b) => {
+      const aTime = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+      const bTime = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+      return bTime - aTime;
+    });
+
+    modal.documents = normalized;
+    populateDocumentOptions();
+  } catch (error) {
+    console.error('loadDocumentos', error);
+    notify(error.message || 'Erro ao carregar documentos salvos.', 'error');
+    modal.documents = [];
+    populateDocumentOptions();
+  } finally {
+    setModalLoading(false);
+  }
+}
+
+function generateDocumentEntry(doc, resolvedHtml = '') {
+  const timestamp = new Date().toISOString();
+  const finalHtml = typeof resolvedHtml === 'string' ? resolvedHtml : '';
+  const previewSource = finalHtml || doc.conteudo || '';
+  return {
+    id: `doc-reg-${Date.now()}-${Math.floor(Math.random() * 1e6)}`,
+    documentoId: doc.id,
+    descricao: doc.descricao || 'Documento',
+    conteudo: finalHtml,
+    conteudoOriginal: doc.conteudo || '',
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    preview: getPreviewText(previewSource),
+  };
+}
+
+async function handleSave() {
+  if (documentoModal.isLoading || documentoModal.isGenerating) return;
+  const doc = getSelectedDocument();
+  if (!doc) {
+    notify('Selecione um documento salvo para registrar.', 'warning');
+    return;
+  }
+
+  documentoModal.isGenerating = true;
+  updateButtonsState();
+
+  try {
+    const { html } = await resolveDocumentContent(doc);
+    const entry = generateDocumentEntry(doc, typeof html === 'string' ? html : doc.conteudo || '');
+    const current = Array.isArray(state.documentos) ? state.documentos.slice() : [];
+    current.unshift(entry);
+    state.documentos = current;
+    notify('Documento adicionado na aba de consultas.', 'success');
+    updateConsultaAgendaCard();
+  } catch (error) {
+    console.error('handleSave', error);
+    notify('Não foi possível preparar o documento para salvar.', 'error');
+  } finally {
+    documentoModal.isGenerating = false;
+    updateButtonsState();
+  }
+}
+
+async function handlePrint() {
+  if (documentoModal.isLoading || documentoModal.isGenerating) return;
+  const doc = getSelectedDocument();
+  if (!doc) {
+    notify('Selecione um documento salvo para imprimir.', 'warning');
+    return;
+  }
+
+  documentoModal.isGenerating = true;
+  updateButtonsState();
+
+  try {
+    const { html } = await resolveDocumentContent(doc);
+    const finalHtml = typeof html === 'string' && html.length ? html : (doc.conteudo || '');
+    const success = openDocumentPrintWindow(finalHtml, { title: doc.descricao || 'Documento' });
+    if (!success) {
+      notify('Não foi possível abrir a impressão. Verifique se o navegador bloqueou pop-ups.', 'error');
+    }
+  } catch (error) {
+    console.error('handlePrint', error);
+    notify('Não foi possível preparar o documento para impressão.', 'error');
+  } finally {
+    documentoModal.isGenerating = false;
+    updateButtonsState();
+  }
+}
+
+export function closeDocumentoModal() {
+  if (!documentoModal.overlay) return;
+  documentoModal.overlay.classList.add('hidden');
+  documentoModal.overlay.setAttribute('aria-hidden', 'true');
+  documentoModal.isGenerating = false;
+  updateButtonsState();
+  if (documentoModal.keydownHandler) {
+    document.removeEventListener('keydown', documentoModal.keydownHandler);
+    documentoModal.keydownHandler = null;
+  }
+}
+
+export function openDocumentoModal() {
+  if (!ensureTutorAndPetSelected()) return;
+
+  const modal = ensureDocumentoModal();
+  modal.overlay.classList.remove('hidden');
+  modal.overlay.setAttribute('aria-hidden', 'false');
+  try {
+    modal.dialog.focus({ preventScroll: true });
+  } catch (_) {
+    modal.dialog.focus();
+  }
+
+  if (!modal.keydownHandler) {
+    modal.keydownHandler = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeDocumentoModal();
+      }
+    };
+    document.addEventListener('keydown', modal.keydownHandler);
+  }
+
+  loadDocuments({ force: true });
+  updateButtonsState();
+}

--- a/scripts/funcionarios/vet/ficha-clinica/init.js
+++ b/scripts/funcionarios/vet/ficha-clinica/init.js
@@ -3,6 +3,7 @@ import { els, debounce } from './core.js';
 import { openConsultaModal } from './consultas.js';
 import { openVacinaModal } from './vacinas.js';
 import { openAnexoModal } from './anexos.js';
+import { openDocumentoModal } from './documentos.js';
 import { openExameModal } from './exames.js';
 import { openPesoModal } from './pesos.js';
 import { openObservacaoModal } from './observacoes.js';
@@ -84,6 +85,13 @@ export function initFichaClinica() {
     els.addAnexoBtn.addEventListener('click', (event) => {
       event.preventDefault();
       openAnexoModal();
+    });
+  }
+
+  if (els.addDocumentoBtn) {
+    els.addDocumentoBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      openDocumentoModal();
     });
   }
 

--- a/scripts/funcionarios/vet/ficha-clinica/tutor.js
+++ b/scripts/funcionarios/vet/ficha-clinica/tutor.js
@@ -148,6 +148,7 @@ export async function onSelectCliente(cli, opts = {}) {
   state.pesos = [];
   state.pesosLoadKey = null;
   state.pesosLoading = false;
+  state.documentos = [];
 
   if (state.agendaContext) {
     const contextTutorId = normalizeId(state.agendaContext.tutorId);
@@ -254,6 +255,7 @@ export async function onSelectPet(petId, opts = {}) {
   state.pesosLoadKey = null;
   state.pesosLoading = false;
   state.observacoes = [];
+  state.documentos = [];
   loadVacinasForSelection();
   loadAnexosForSelection();
   loadExamesForSelection();
@@ -290,6 +292,7 @@ export function clearCliente() {
   state.pesosLoadKey = null;
   state.pesosLoading = false;
   state.observacoes = [];
+  state.documentos = [];
   persistAgendaContext(null);
   if (els.cliInput) els.cliInput.value = '';
   hideSugestoes();
@@ -320,6 +323,7 @@ export function clearPet() {
   state.examesLoadKey = null;
   state.examesLoading = false;
   state.observacoes = [];
+  state.documentos = [];
   updateCardDisplay();
   updatePageVisibility();
 }

--- a/src/output.css
+++ b/src/output.css
@@ -46,6 +46,7 @@
     --color-emerald-50: oklch(97.9% 0.021 166.113);
     --color-emerald-100: oklch(95% 0.052 163.051);
     --color-emerald-200: oklch(90.5% 0.093 164.15);
+    --color-emerald-300: oklch(84.5% 0.143 164.978);
     --color-emerald-400: oklch(76.5% 0.177 163.223);
     --color-emerald-500: oklch(69.6% 0.17 162.48);
     --color-emerald-600: oklch(59.6% 0.145 163.225);
@@ -714,6 +715,9 @@
   .h-\[55px\] {
     height: 55px;
   }
+  .h-\[320px\] {
+    height: 320px;
+  }
   .h-\[420px\] {
     height: 420px;
   }
@@ -743,6 +747,9 @@
   }
   .max-h-\[70vh\] {
     max-height: 70vh;
+  }
+  .max-h-\[90vh\] {
+    max-height: 90vh;
   }
   .max-h-\[350px\] {
     max-height: 350px;
@@ -1363,8 +1370,14 @@
   .border-blue-500 {
     border-color: var(--color-blue-500);
   }
+  .border-emerald-100 {
+    border-color: var(--color-emerald-100);
+  }
   .border-emerald-200 {
     border-color: var(--color-emerald-200);
+  }
+  .border-emerald-300 {
+    border-color: var(--color-emerald-300);
   }
   .border-gray-100 {
     border-color: var(--color-gray-100);
@@ -2581,6 +2594,13 @@
       }
     }
   }
+  .hover\:bg-emerald-50 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-emerald-50);
+      }
+    }
+  }
   .hover\:bg-emerald-700 {
     &:hover {
       @media (hover: hover) {
@@ -2999,6 +3019,11 @@
       border-color: var(--color-sky-400);
     }
   }
+  .focus\:border-sky-500 {
+    &:focus {
+      border-color: var(--color-sky-500);
+    }
+  }
   .focus\:border-transparent {
     &:focus {
       border-color: transparent;
@@ -3031,6 +3056,11 @@
       --tw-ring-color: var(--color-emerald-200);
     }
   }
+  .focus\:ring-emerald-300 {
+    &:focus {
+      --tw-ring-color: var(--color-emerald-300);
+    }
+  }
   .focus\:ring-emerald-400 {
     &:focus {
       --tw-ring-color: var(--color-emerald-400);
@@ -3039,6 +3069,11 @@
   .focus\:ring-emerald-500 {
     &:focus {
       --tw-ring-color: var(--color-emerald-500);
+    }
+  }
+  .focus\:ring-gray-200 {
+    &:focus {
+      --tw-ring-color: var(--color-gray-200);
     }
   }
   .focus\:ring-indigo-200 {
@@ -3080,6 +3115,11 @@
   .focus\:ring-rose-400 {
     &:focus {
       --tw-ring-color: var(--color-rose-400);
+    }
+  }
+  .focus\:ring-sky-200 {
+    &:focus {
+      --tw-ring-color: var(--color-sky-200);
     }
   }
   .focus\:ring-sky-300 {


### PR DESCRIPTION
## Summary
- add shared HTML escaping and keyword replacement helpers for veterinary documents
- resolve ficha clínica document templates with tutor, pet, agenda, and clinic data before preview, save, and print
- disable actions while generating content and reuse resolved HTML when adding consultation cards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cccc66618483238a93d98cd5f68aaa