### PR TITLE
Ajusta modal de documentos e impressão

### DIFF
--- a/scripts/funcionarios/vet/ficha-clinica/consultas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/consultas.js
@@ -571,7 +571,7 @@ function createDocumentoRegistroCard(entry) {
 
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
-  removeBtn.className = 'inline-flex items-center gap-2 rounded-lg border border-rose-200 px-3 py-2 text-sm font-medium text-rose-600 transition hover:bg-rose-50 focus:outline-none focus:ring-2 focus:ring-rose-200';
+  removeBtn.className = 'inline-flex items-center gap-2 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700 transition hover:bg-emerald-600 hover:text-white focus:outline-none focus:ring-2 focus:ring-emerald-200';
   removeBtn.innerHTML = '<i class="fas fa-trash-can text-[12px]"></i><span>Remover</span>';
   removeBtn.title = 'Remover documento';
   removeBtn.setAttribute('aria-label', 'Remover documento');
@@ -1519,6 +1519,7 @@ export function updateConsultaAgendaCard() {
   const hasObservacoes = observacoes.length > 0;
   const documentos = Array.isArray(state.documentos) ? state.documentos : [];
   const hasDocumentos = documentos.length > 0;
+  const isLoadingDocumentos = !!state.documentosLoading;
   const context = state.agendaContext;
   const selectedPetId = normalizeId(state.selectedPetId);
   const selectedTutorId = normalizeId(state.selectedCliente?._id);
@@ -1770,6 +1771,11 @@ export function updateConsultaAgendaCard() {
       const card = createDocumentoRegistroCard(documento);
       if (card) scroll.appendChild(card);
     });
+  } else if (isLoadingDocumentos) {
+    const loadingDocumentos = document.createElement('div');
+    loadingDocumentos.className = 'rounded-xl border border-dashed border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-600';
+    loadingDocumentos.textContent = 'Carregando documentos salvos...';
+    scroll.appendChild(loadingDocumentos);
   }
 
   if (hasManualConsultas) {

--- a/scripts/funcionarios/vet/ficha-clinica/core.js
+++ b/scripts/funcionarios/vet/ficha-clinica/core.js
@@ -125,6 +125,8 @@ export const state = {
   pesosLoadKey: null,
   observacoes: [],
   documentos: [],
+  documentosLoading: false,
+  documentosLoadKey: null,
 };
 
 export const consultaModal = {

--- a/scripts/funcionarios/vet/ficha-clinica/documentos.js
+++ b/scripts/funcionarios/vet/ficha-clinica/documentos.js
@@ -488,7 +488,8 @@ function ensureDocumentoModal() {
   overlay.setAttribute('aria-hidden', 'true');
 
   const dialog = document.createElement('div');
-  dialog.className = 'w-full max-w-3xl overflow-hidden rounded-xl bg-white shadow-2xl focus:outline-none';
+  dialog.className = 'w-full overflow-hidden rounded-xl bg-white shadow-2xl focus:outline-none';
+  dialog.style.maxWidth = '72rem';
   dialog.style.maxHeight = 'calc(100vh - 2rem)';
   dialog.setAttribute('role', 'dialog');
   dialog.setAttribute('aria-modal', 'true');
@@ -535,7 +536,7 @@ function ensureDocumentoModal() {
   content.appendChild(bodyWrapper);
 
   const leftColumn = document.createElement('div');
-  leftColumn.className = 'flex flex-1 flex-col gap-4';
+  leftColumn.className = 'flex min-w-0 flex-1 flex-col gap-4';
   leftColumn.style.minHeight = '0';
   bodyWrapper.appendChild(leftColumn);
 
@@ -580,7 +581,7 @@ function ensureDocumentoModal() {
   leftColumn.appendChild(emptyState);
 
   const previewCard = document.createElement('div');
-  previewCard.className = 'flex flex-1 flex-col overflow-hidden rounded-xl border border-slate-200 bg-slate-50 shadow-inner';
+  previewCard.className = 'flex min-w-0 flex-1 flex-col overflow-hidden rounded-xl border border-slate-200 bg-slate-50 shadow-inner';
   previewCard.style.minHeight = '260px';
   leftColumn.appendChild(previewCard);
 

--- a/scripts/funcionarios/vet/ficha-clinica/documentos.js
+++ b/scripts/funcionarios/vet/ficha-clinica/documentos.js
@@ -14,7 +14,7 @@ import {
   getAgendaStoreId,
   normalizeId,
 } from './core.js';
-import { ensureTutorAndPetSelected, updateConsultaAgendaCard } from './consultas.js';
+import { ensureTutorAndPetSelected, updateConsultaAgendaCard, getConsultasKey } from './consultas.js';
 import {
   KEYWORD_GROUPS,
   renderPreviewFrameContent,
@@ -864,45 +864,193 @@ async function loadDocuments({ force = false } = {}) {
   }
 }
 
-function generateDocumentEntry(doc, resolvedHtml = '') {
-  const timestamp = new Date().toISOString();
+export async function loadDocumentosFromServer(options = {}) {
+  const { force = false } = options || {};
+  const clienteId = normalizeId(state.selectedCliente?._id);
+  const petId = normalizeId(state.selectedPetId);
+
+  if (!(clienteId && petId)) {
+    state.documentos = [];
+    state.documentosLoadKey = null;
+    state.documentosLoading = false;
+    updateConsultaAgendaCard();
+    return;
+  }
+
+  const key = getConsultasKey(clienteId, petId);
+  if (!force && key && state.documentosLoadKey === key) return;
+
+  state.documentosLoading = true;
+  updateConsultaAgendaCard();
+
+  try {
+    const params = new URLSearchParams({ clienteId, petId });
+    const appointmentId = normalizeId(state.agendaContext?.appointmentId);
+    if (appointmentId) params.set('appointmentId', appointmentId);
+
+    const resp = await api(`/func/vet/documentos-registros?${params.toString()}`);
+    const payload = await resp.json().catch(() => (resp.ok ? [] : {}));
+    if (!resp.ok) {
+      const message = typeof payload?.message === 'string' ? payload.message : 'Erro ao carregar documentos do atendimento.';
+      throw new Error(message);
+    }
+
+    setDocumentoRegistrosInState(Array.isArray(payload) ? payload : []);
+  } catch (error) {
+    console.error('loadDocumentosFromServer', error);
+    state.documentos = [];
+    state.documentosLoadKey = null;
+    notify(error.message || 'Erro ao carregar documentos do atendimento.', 'error');
+  } finally {
+    state.documentosLoading = false;
+    updateConsultaAgendaCard();
+  }
+}
+
+function prepareDocumentRecordPayload(doc, resolvedHtml = '') {
+  if (!doc || typeof doc !== 'object') return null;
+  const docId = normalizeId(doc.id || doc._id);
+  if (!docId) return null;
   const finalHtml = typeof resolvedHtml === 'string' ? resolvedHtml : '';
-  const previewSource = finalHtml || doc.conteudo || '';
+  const previewSource = finalHtml || (typeof doc.conteudo === 'string' ? doc.conteudo : '');
   return {
-    id: `doc-reg-${Date.now()}-${Math.floor(Math.random() * 1e6)}`,
-    documentoId: doc.id,
-    descricao: doc.descricao || 'Documento',
+    documentoId: docId,
+    descricao: typeof doc.descricao === 'string' && doc.descricao.trim()
+      ? doc.descricao.trim()
+      : 'Documento',
     conteudo: finalHtml,
-    conteudoOriginal: doc.conteudo || '',
-    createdAt: timestamp,
-    updatedAt: timestamp,
+    conteudoOriginal: typeof doc.conteudo === 'string' ? doc.conteudo : '',
     preview: getPreviewText(previewSource),
   };
 }
 
-export function deleteDocumentoRegistro(target, options = {}) {
+function normalizeDocumentoRegistroRecord(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const id = normalizeId(raw.id || raw._id);
+  if (!id) return null;
+
+  const documentoId = normalizeId(raw.documentoId || raw.documento);
+  const descricao = typeof raw.descricao === 'string' ? raw.descricao.trim() : '';
+  const conteudo = typeof raw.conteudo === 'string' ? raw.conteudo : '';
+  const conteudoOriginal = typeof raw.conteudoOriginal === 'string' ? raw.conteudoOriginal : '';
+  const previewSource = typeof raw.preview === 'string' && raw.preview
+    ? raw.preview
+    : getPreviewText(conteudo || conteudoOriginal);
+
+  const clienteId = normalizeId(raw.clienteId || raw.cliente);
+  const petId = normalizeId(raw.petId || raw.pet);
+  const appointmentId = normalizeId(raw.appointmentId || raw.appointment);
+
+  const createdAtDate = parseDateValue(raw.createdAt || raw.criadoEm || raw.dataCriacao);
+  const updatedAtDate = parseDateValue(raw.updatedAt || raw.atualizadoEm || raw.dataAtualizacao) || createdAtDate;
+  const createdAt = createdAtDate ? createdAtDate.toISOString() : null;
+  const updatedAt = updatedAtDate ? updatedAtDate.toISOString() : createdAt;
+
+  return {
+    id,
+    _id: id,
+    documentoId,
+    descricao,
+    conteudo,
+    conteudoOriginal,
+    preview: previewSource,
+    createdAt,
+    updatedAt,
+    clienteId,
+    petId,
+    appointmentId,
+  };
+}
+
+function upsertDocumentoRegistroInState(record) {
+  const normalized = normalizeDocumentoRegistroRecord(record);
+  if (!normalized) return null;
+
+  const list = Array.isArray(state.documentos) ? [...state.documentos] : [];
+  const targetId = normalizeId(normalized.id || normalized._id);
+  const existingIdx = list.findIndex((item) => normalizeId(item?.id || item?._id) === targetId);
+
+  if (existingIdx >= 0) {
+    list[existingIdx] = { ...list[existingIdx], ...normalized };
+  } else {
+    list.unshift(normalized);
+  }
+
+  list.sort((a, b) => {
+    const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return bTime - aTime;
+  });
+
+  state.documentos = list;
+  const key = getConsultasKey(state.selectedCliente?._id, state.selectedPetId);
+  if (key) state.documentosLoadKey = key;
+
+  return list.find((item) => normalizeId(item?.id || item?._id) === targetId) || normalized;
+}
+
+function setDocumentoRegistrosInState(records) {
+  const list = Array.isArray(records)
+    ? records.map(normalizeDocumentoRegistroRecord).filter(Boolean)
+    : [];
+
+  list.sort((a, b) => {
+    const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return bTime - aTime;
+  });
+
+  state.documentos = list;
+  const key = getConsultasKey(state.selectedCliente?._id, state.selectedPetId);
+  if (key) state.documentosLoadKey = key;
+
+  return list;
+}
+
+export async function deleteDocumentoRegistro(target, options = {}) {
   const { suppressNotify = false } = options;
   const targetId = normalizeId(
     target && typeof target === 'object' ? target.id || target._id : target,
   );
-  if (!targetId) return Promise.resolve(false);
+  if (!targetId) return false;
 
   const current = Array.isArray(state.documentos) ? state.documentos : [];
-  const filtered = current.filter(
-    (item) => normalizeId(item?.id || item?._id) !== targetId,
-  );
+  const filtered = current.filter((item) => normalizeId(item?.id || item?._id) !== targetId);
+  const hadEntry = filtered.length !== current.length;
 
-  if (filtered.length === current.length) {
-    return Promise.resolve(false);
+  try {
+    const resp = await api(`/func/vet/documentos-registros/${encodeURIComponent(targetId)}`, {
+      method: 'DELETE',
+    });
+
+    if (!resp.ok) {
+      if (resp.status === 404 && hadEntry) {
+        state.documentos = filtered;
+        if (!suppressNotify) {
+          notify('Documento removido com sucesso.', 'success');
+        }
+        updateConsultaAgendaCard();
+        return true;
+      }
+
+      const payload = await resp.json().catch(() => ({}));
+      const message = typeof payload?.message === 'string'
+        ? payload.message
+        : 'Não foi possível remover o documento.';
+      throw new Error(message);
+    }
+
+    state.documentos = filtered;
+    if (!suppressNotify) {
+      notify('Documento removido com sucesso.', 'success');
+    }
+    updateConsultaAgendaCard();
+    return true;
+  } catch (error) {
+    console.error('deleteDocumentoRegistro', error);
+    notify(error.message || 'Não foi possível remover o documento.', 'error');
+    return false;
   }
-
-  state.documentos = filtered;
-  if (!suppressNotify) {
-    notify('Documento removido com sucesso.', 'success');
-  }
-  updateConsultaAgendaCard();
-
-  return Promise.resolve(true);
 }
 
 state.deleteDocumento = deleteDocumentoRegistro;
@@ -915,20 +1063,67 @@ async function handleSave() {
     return;
   }
 
+  const clienteId = normalizeId(state.selectedCliente?._id);
+  const petId = normalizeId(state.selectedPetId);
+  if (!(clienteId && petId)) {
+    notify('Selecione um tutor e um pet para registrar o documento no atendimento.', 'warning');
+    return;
+  }
+
   documentoModal.isGenerating = true;
   updateButtonsState();
 
   try {
     const { html } = await resolveDocumentContent(doc);
-    const entry = generateDocumentEntry(doc, typeof html === 'string' ? html : doc.conteudo || '');
-    const current = Array.isArray(state.documentos) ? state.documentos.slice() : [];
-    current.unshift(entry);
-    state.documentos = current;
+    const finalHtml = typeof html === 'string' ? html : (doc.conteudo || '');
+    const recordPayload = prepareDocumentRecordPayload(doc, finalHtml);
+    if (!recordPayload) {
+      throw new Error('Não foi possível preparar os dados do documento.');
+    }
+
+    const payload = {
+      ...recordPayload,
+      clienteId,
+      petId,
+    };
+
+    const appointmentId = normalizeId(state.agendaContext?.appointmentId);
+    if (appointmentId) {
+      payload.appointmentId = appointmentId;
+    }
+
+    const resp = await api('/func/vet/documentos-registros', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    const data = await resp.json().catch(() => null);
+    if (!resp.ok) {
+      const message = typeof data?.message === 'string' ? data.message : 'Não foi possível salvar o documento.';
+      throw new Error(message);
+    }
+
+    const fallbackRecord = {
+      ...recordPayload,
+      id: normalizeId(data?.id || data?._id) || `doc-reg-${Date.now()}-${Math.floor(Math.random() * 1e6)}`,
+      _id: data?._id,
+      createdAt: data?.createdAt || new Date().toISOString(),
+      updatedAt: data?.updatedAt || data?.createdAt || new Date().toISOString(),
+      clienteId,
+      petId,
+      appointmentId,
+    };
+
+    const saved = upsertDocumentoRegistroInState(data || fallbackRecord);
+    if (!saved && fallbackRecord) {
+      upsertDocumentoRegistroInState(fallbackRecord);
+    }
+
     notify('Documento adicionado na aba de consultas.', 'success');
+    closeDocumentoModal();
     updateConsultaAgendaCard();
   } catch (error) {
     console.error('handleSave', error);
-    notify('Não foi possível preparar o documento para salvar.', 'error');
+    notify(error.message || 'Não foi possível preparar o documento para salvar.', 'error');
   } finally {
     documentoModal.isGenerating = false;
     updateButtonsState();

--- a/scripts/funcionarios/vet/ficha-clinica/documentos.js
+++ b/scripts/funcionarios/vet/ficha-clinica/documentos.js
@@ -20,6 +20,7 @@ import {
   getPreviewText,
   openDocumentPrintWindow,
   applyKeywordReplacements,
+  keywordAppearsInContent,
 } from '../document-utils.js';
 
 const documentoModal = {
@@ -101,7 +102,7 @@ function renderKeywordReference() {
 function highlightKeywords(content) {
   const value = typeof content === 'string' ? content : '';
   documentoModal.keywordItems.forEach((item) => {
-    const found = value.includes(item.token);
+    const found = keywordAppearsInContent(value, item.token);
     item.element.classList.toggle('border-emerald-300', found);
     item.element.classList.toggle('bg-emerald-50', found);
     item.element.classList.toggle('text-emerald-700', found);

--- a/scripts/funcionarios/vet/ficha-clinica/documentos.js
+++ b/scripts/funcionarios/vet/ficha-clinica/documentos.js
@@ -12,6 +12,7 @@ import {
   formatPetMicrochip,
   getSelectedPet,
   getAgendaStoreId,
+  normalizeId,
 } from './core.js';
 import { ensureTutorAndPetSelected, updateConsultaAgendaCard } from './consultas.js';
 import {
@@ -878,6 +879,33 @@ function generateDocumentEntry(doc, resolvedHtml = '') {
     preview: getPreviewText(previewSource),
   };
 }
+
+export function deleteDocumentoRegistro(target, options = {}) {
+  const { suppressNotify = false } = options;
+  const targetId = normalizeId(
+    target && typeof target === 'object' ? target.id || target._id : target,
+  );
+  if (!targetId) return Promise.resolve(false);
+
+  const current = Array.isArray(state.documentos) ? state.documentos : [];
+  const filtered = current.filter(
+    (item) => normalizeId(item?.id || item?._id) !== targetId,
+  );
+
+  if (filtered.length === current.length) {
+    return Promise.resolve(false);
+  }
+
+  state.documentos = filtered;
+  if (!suppressNotify) {
+    notify('Documento removido com sucesso.', 'success');
+  }
+  updateConsultaAgendaCard();
+
+  return Promise.resolve(true);
+}
+
+state.deleteDocumento = deleteDocumentoRegistro;
 
 async function handleSave() {
   if (documentoModal.isLoading || documentoModal.isGenerating) return;

--- a/scripts/funcionarios/vet/ficha-clinica/tutor.js
+++ b/scripts/funcionarios/vet/ficha-clinica/tutor.js
@@ -17,6 +17,7 @@ import { loadAnexosForSelection, loadAnexosFromServer } from './anexos.js';
 import { loadExamesForSelection } from './exames.js';
 import { loadObservacoesForSelection } from './observacoes.js';
 import { loadPesosFromServer } from './pesos.js';
+import { loadDocumentosFromServer } from './documentos.js';
 import { updateCardDisplay, updatePageVisibility, setCardMode } from './ui.js';
 
 function hideSugestoes() {
@@ -256,6 +257,8 @@ export async function onSelectPet(petId, opts = {}) {
   state.pesosLoading = false;
   state.observacoes = [];
   state.documentos = [];
+  state.documentosLoadKey = null;
+  state.documentosLoading = false;
   loadVacinasForSelection();
   loadAnexosForSelection();
   loadExamesForSelection();
@@ -270,6 +273,7 @@ export async function onSelectPet(petId, opts = {}) {
     loadConsultasFromServer({ force: true }),
     loadAnexosFromServer({ force: true }),
     loadPesosFromServer({ force: true }),
+    loadDocumentosFromServer({ force: true }),
   ]);
 }
 
@@ -293,6 +297,8 @@ export function clearCliente() {
   state.pesosLoading = false;
   state.observacoes = [];
   state.documentos = [];
+  state.documentosLoadKey = null;
+  state.documentosLoading = false;
   persistAgendaContext(null);
   if (els.cliInput) els.cliInput.value = '';
   hideSugestoes();
@@ -324,6 +330,8 @@ export function clearPet() {
   state.examesLoading = false;
   state.observacoes = [];
   state.documentos = [];
+  state.documentosLoadKey = null;
+  state.documentosLoading = false;
   updateCardDisplay();
   updatePageVisibility();
 }

--- a/servidor/models/VetDocumentRecord.js
+++ b/servidor/models/VetDocumentRecord.js
@@ -1,0 +1,62 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const VetDocumentRecordSchema = new Schema({
+  cliente: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true,
+  },
+  pet: {
+    type: Schema.Types.ObjectId,
+    ref: 'Pet',
+    required: true,
+    index: true,
+  },
+  documento: {
+    type: Schema.Types.ObjectId,
+    ref: 'VetDocument',
+    default: null,
+  },
+  appointment: {
+    type: Schema.Types.ObjectId,
+    ref: 'Appointment',
+    default: null,
+  },
+  descricao: {
+    type: String,
+    trim: true,
+    default: '',
+    maxlength: 180,
+  },
+  conteudo: {
+    type: String,
+    required: true,
+  },
+  conteudoOriginal: {
+    type: String,
+    default: '',
+  },
+  preview: {
+    type: String,
+    default: '',
+    maxlength: 2000,
+  },
+  createdBy: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    default: null,
+  },
+  updatedBy: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    default: null,
+  },
+}, { timestamps: true });
+
+VetDocumentRecordSchema.index({ cliente: 1, pet: 1, createdAt: -1 });
+VetDocumentRecordSchema.index({ appointment: 1 });
+
+module.exports = mongoose.model('VetDocumentRecord', VetDocumentRecordSchema);

--- a/src/output.css
+++ b/src/output.css
@@ -1367,9 +1367,6 @@
   .border-blue-500 {
     border-color: var(--color-blue-500);
   }
-  .border-emerald-100 {
-    border-color: var(--color-emerald-100);
-  }
   .border-emerald-200 {
     border-color: var(--color-emerald-200);
   }
@@ -2595,6 +2592,13 @@
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-emerald-50);
+      }
+    }
+  }
+  .hover\:bg-emerald-600 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-emerald-600);
       }
     }
   }


### PR DESCRIPTION
## Summary
- aumenta a largura útil do modal de documentos veterinários para facilitar a leitura da pré-visualização
- mantém a coluna do preview elástica com largura mínima para evitar cortes do conteúdo
- corrige a lógica de abertura da janela de impressão garantindo que o HTML seja injetado antes de chamar o print

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd59153d908323bcebd16306e500fc