### PR TITLE
feat: replicar tela de documentos para receitas

### DIFF
--- a/pages/funcionarios/vet-ficha-clinica.html
+++ b/pages/funcionarios/vet-ficha-clinica.html
@@ -289,7 +289,8 @@
                                 Documento</span>
                         </a>
 
-                        <a class="flex items-center justify-between px-3 py-3 rounded-lg bg-sky-50 ring-1 ring-sky-100">
+                        <a id="vet-add-receita-btn" href="#"
+                            class="flex items-center justify-between px-3 py-3 rounded-lg bg-sky-50 ring-1 ring-sky-100">
                             <span class="flex items-center gap-2 text-gray-800"><i
                                     class="fas fa-prescription-bottle-medical"></i> Receita</span>
                         </a>

--- a/pages/funcionarios/vet-receitas.html
+++ b/pages/funcionarios/vet-receitas.html
@@ -2,10 +2,242 @@
 <html lang="pt-BR">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Funcionários — Veterinário — Receitas</title>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
-  <link rel="stylesheet" href="../../src/output.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" />
+  <link rel="stylesheet" href="../../src/output.css" />
+  <link rel="stylesheet" href="https://cdn.quilljs.com/1.3.7/quill.snow.css" />
+  <style>
+    .vet-rec-editor .ql-toolbar.ql-snow {
+      border-color: #e5e7eb;
+      border-top-left-radius: 0.75rem;
+      border-top-right-radius: 0.75rem;
+    }
+    .vet-rec-editor .ql-container.ql-snow {
+      border-color: #e5e7eb;
+      border-bottom-left-radius: 0.75rem;
+      border-bottom-right-radius: 0.75rem;
+      min-height: 280px;
+    }
+    .vet-rec-editor .ql-container .ql-editor {
+      min-height: 240px;
+      font-size: 0.95rem;
+      color: #1f2937;
+    }
+    .vet-rec-editor .ql-toolbar button:hover,
+    .vet-rec-editor .ql-toolbar button.ql-active {
+      color: #2563eb;
+    }
+    .vet-rec-textarea {
+      width: 100%;
+      min-height: 260px;
+      border: 1px solid #d1d5db;
+      border-radius: 0.75rem;
+      padding: 1rem;
+      font-size: 0.95rem;
+      color: #1f2937;
+      resize: vertical;
+    }
+    .vet-rec-textarea:focus {
+      outline: none;
+      border-color: #2563eb;
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+    }
+    .vet-rec-mode-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.3rem;
+      border-radius: 9999px;
+      background: linear-gradient(135deg, #f8fafc, #f1f5f9);
+      border: 1px solid #e2e8f0;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+    }
+    .vet-rec-mode-btn {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border: none;
+      border-radius: 9999px;
+      padding: 0.35rem 0.9rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: #475569;
+      background: transparent;
+      cursor: pointer;
+      transition: all 0.2s ease-in-out;
+    }
+    .vet-rec-mode-btn:hover:not([disabled]) {
+      color: #1d4ed8;
+    }
+    .vet-rec-mode-btn:focus-visible {
+      outline: 2px solid rgba(37, 99, 235, 0.45);
+      outline-offset: 2px;
+    }
+    .vet-rec-mode-btn[disabled] {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+    .vet-rec-mode-btn-active {
+      background: linear-gradient(135deg, #2563eb, #3b82f6);
+      color: #f8fafc;
+      box-shadow: 0 6px 14px rgba(37, 99, 235, 0.25);
+    }
+    .vet-rec-mode-btn-active::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: 9999px;
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      pointer-events: none;
+    }
+    .vet-rec-code {
+      width: 100%;
+      min-height: 280px;
+      border: 1px solid #1f2937;
+      border-radius: 0.75rem;
+      padding: 1rem 1.1rem;
+      font-size: 0.9rem;
+      line-height: 1.7;
+      color: #e2e8f0;
+      background: #0f172a;
+      font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas,
+        'Liberation Mono', 'Courier New', monospace;
+      resize: vertical;
+      white-space: pre;
+      overflow-x: auto;
+      overflow-wrap: normal;
+      word-break: normal;
+      box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.6);
+    }
+    .vet-rec-code:focus {
+      outline: none;
+      border-color: #3b82f6;
+      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+    }
+    .vet-rec-preview {
+      position: relative;
+      width: 100%;
+      border: 1px solid #d1d5db;
+      border-radius: 0.75rem;
+      background: linear-gradient(180deg, #f8fafc, #f1f5f9);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+      overflow: hidden;
+    }
+    .vet-rec-preview:focus {
+      outline: 2px solid rgba(37, 99, 235, 0.4);
+      outline-offset: 2px;
+    }
+    .vet-rec-preview-bar {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.65rem 1rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+      color: #1f2937;
+      background: rgba(148, 163, 184, 0.18);
+      border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+    }
+    .vet-rec-preview-bar i {
+      color: #2563eb;
+    }
+    .vet-rec-preview-frame {
+      width: 100%;
+      border: none;
+      background: transparent;
+      min-height: 320px;
+      display: block;
+    }
+    .vet-rec-card [data-doc-body] {
+      padding: 0;
+      overflow: hidden;
+      border-radius: 0.75rem;
+    }
+    .vet-rec-card .vet-rec-preview-embed {
+      width: 100%;
+      border: none;
+      background: transparent;
+      border-radius: 0 0 0.75rem 0.75rem;
+      border-top: 1px solid rgba(148, 163, 184, 0.3);
+      min-height: 260px;
+      box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+    }
+    .vet-rec-code::-webkit-scrollbar {
+      width: 10px;
+      height: 10px;
+    }
+    .vet-rec-code::-webkit-scrollbar-track {
+      background: rgba(148, 163, 184, 0.15);
+      border-radius: 9999px;
+    }
+    .vet-rec-code::-webkit-scrollbar-thumb {
+      background: rgba(59, 130, 246, 0.6);
+      border-radius: 9999px;
+    }
+    .vet-rec-code::-webkit-scrollbar-thumb:hover {
+      background: rgba(37, 99, 235, 0.8);
+    }
+    .vet-rec-card details summary {
+      list-style: none;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .vet-rec-card details summary::-webkit-details-marker {
+      display: none;
+    }
+    .vet-rec-card details summary:focus {
+      outline: none;
+    }
+    .vet-rec-card details[open] .vet-rec-summary-icon {
+      transform: rotate(180deg);
+    }
+    .vet-rec-body h1,
+    .vet-rec-body h2,
+    .vet-rec-body h3,
+    .vet-rec-body h4 {
+      font-weight: 600;
+      color: #111827;
+      margin-top: 1.25rem;
+    }
+    .vet-rec-body h1 { font-size: 1.25rem; }
+    .vet-rec-body h2 { font-size: 1.15rem; }
+    .vet-rec-body h3 { font-size: 1.05rem; }
+    .vet-rec-body h4 { font-size: 1rem; }
+    .vet-rec-body p {
+      margin-top: 0.75rem;
+      line-height: 1.7;
+    }
+    .vet-rec-body ul,
+    .vet-rec-body ol {
+      margin-top: 0.75rem;
+      padding-left: 1.25rem;
+    }
+    .vet-rec-body ul { list-style: disc; }
+    .vet-rec-body ol { list-style: decimal; }
+    .vet-rec-body blockquote {
+      border-left: 3px solid #cbd5f5;
+      padding-left: 1rem;
+      color: #374151;
+      font-style: italic;
+      margin-top: 0.75rem;
+    }
+    .vet-rec-body a {
+      color: #2563eb;
+      text-decoration: underline;
+    }
+    .vet-rec-body code {
+      background-color: #f3f4f6;
+      padding: 0.1rem 0.3rem;
+      border-radius: 0.25rem;
+      font-size: 0.85em;
+    }
+  </style>
 </head>
 <body class="bg-gray-100">
   <div id="func-header-placeholder"></div>
@@ -14,12 +246,148 @@
     <div class="mb-6" id="func-sidebar-placeholder"></div>
 
     <section class="bg-white rounded-xl shadow-sm ring-1 ring-black/5 p-6">
-      <div class="flex items-center gap-3 mb-4">
-        <i class="fas fa-prescription-bottle-medical text-primary"></i>
-        <h1 class="text-xl font-semibold text-gray-800">Receitas</h1>
+      <div class="flex items-start gap-3">
+        <div class="h-12 w-12 rounded-xl bg-primary/10 text-primary grid place-items-center text-xl">
+          <i class="fas fa-prescription-bottle-medical"></i>
+        </div>
+        <div class="flex-1">
+          <h1 class="text-xl font-semibold text-gray-800">Receitas</h1>
+          <p class="text-sm text-gray-500 mt-1">
+            Crie, edite e organize as receitas emitidas na clínica veterinária.
+          </p>
+        </div>
       </div>
-      <div class="rounded-lg border border-dashed border-gray-300 p-8 text-center">
-        <p class="text-gray-500">Em breve — estamos preparando esta área.</p>
+
+      <div class="mt-8">
+        <h2 id="vet-rec-form-title" class="text-lg font-semibold text-gray-800">Nova receita</h2>
+        <p class="text-sm text-gray-500 mt-1">
+          Informe uma descrição e escreva o conteúdo utilizando o editor avançado para salvar esta receita.
+        </p>
+
+        <form id="vet-rec-form" class="mt-4 space-y-5">
+          <div>
+            <label for="vet-rec-descricao" class="text-sm font-medium text-gray-700">Descrição</label>
+            <input
+              id="vet-rec-descricao"
+              name="descricao"
+              type="text"
+              maxlength="180"
+              placeholder="Ex.: Declaração de atendimento, Relatório clínico do paciente, etc."
+              class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-800 placeholder:text-gray-400 focus:border-primary focus:ring-2 focus:ring-primary/30"
+              autocomplete="off"
+              required
+            />
+          </div>
+
+          <div>
+            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <label class="text-sm font-medium text-gray-700">Conteúdo</label>
+              <div id="vet-rec-mode-toggle" class="vet-rec-mode-toggle">
+                <button
+                  type="button"
+                  class="vet-rec-mode-btn vet-rec-mode-btn-active"
+                  data-mode="visual"
+                  aria-pressed="true"
+                >
+                  Normal
+                </button>
+                <button
+                  type="button"
+                  class="vet-rec-mode-btn"
+                  data-mode="code"
+                  aria-pressed="false"
+                >
+                  Código
+                </button>
+              </div>
+            </div>
+            <div
+              id="vet-rec-editor"
+              class="vet-rec-editor mt-2"
+            ></div>
+            <div id="vet-rec-preview" class="vet-rec-preview mt-2 hidden">
+              <div class="vet-rec-preview-bar">
+                <i class="fas fa-eye"></i>
+                <span>Pré-visualização da receita</span>
+              </div>
+              <iframe
+                id="vet-rec-preview-frame"
+                class="vet-rec-preview-frame"
+                title="Pré-visualização da receita"
+              ></iframe>
+            </div>
+            <textarea
+              id="vet-rec-code"
+              class="vet-rec-code mt-2 hidden"
+              spellcheck="false"
+              autocomplete="off"
+              wrap="off"
+            ></textarea>
+          </div>
+
+          <div>
+            <div class="rounded-xl border border-dashed border-primary/40 bg-primary/5 p-4">
+              <div class="flex items-start gap-3">
+                <div class="hidden h-10 w-10 place-items-center rounded-lg bg-primary/10 text-primary sm:grid">
+                  <i class="fas fa-tags"></i>
+                </div>
+                <div class="flex-1">
+                  <h3 class="text-sm font-semibold text-primary">Palavras-chave disponíveis</h3>
+                  <p class="mt-1 text-xs text-primary/80">
+                    Clique em uma palavra-chave para inserir no conteúdo. Elas serão preenchidas automaticamente quando a receita for utilizada em outras telas.
+                  </p>
+                </div>
+              </div>
+              <div id="vet-rec-keywords" class="mt-4 space-y-4"></div>
+            </div>
+          </div>
+
+          <div class="flex flex-wrap items-center gap-3">
+            <button
+              id="vet-rec-save"
+              type="submit"
+              class="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/30"
+            >
+              <i class="fas fa-save"></i>
+              <span>Salvar receita</span>
+            </button>
+            <button
+              id="vet-rec-cancel-edit"
+              type="button"
+              class="hidden inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            >
+              <i class="fas fa-rotate-left"></i>
+              <span>Cancelar edição</span>
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <div class="mt-10 border-t border-gray-100 pt-6">
+        <div class="flex items-center gap-3">
+          <h2 class="text-lg font-semibold text-gray-800">Receitas salvas</h2>
+          <span id="vet-rec-count" class="inline-flex items-center justify-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-semibold text-gray-600">0</span>
+        </div>
+        <p class="mt-1 text-sm text-gray-500">As receitas mais recentes aparecem primeiro.</p>
+
+        <div
+          id="vet-rec-error"
+          class="mt-4 hidden rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+        ></div>
+
+        <div id="vet-rec-loading" class="mt-6 hidden items-center gap-2 text-sm text-gray-500">
+          <span class="inline-block h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-transparent"></span>
+          <span>Carregando receitas...</span>
+        </div>
+
+        <div
+          id="vet-rec-empty"
+          class="mt-6 rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-center text-sm text-gray-500"
+        >
+          Nenhuma receita cadastrada até o momento.
+        </div>
+
+        <div id="vet-rec-list" class="mt-6 space-y-4"></div>
       </div>
     </section>
   </main>
@@ -33,5 +401,7 @@
   <script src="../../scripts/core/ui.js"></script>
   <script src="../../scripts/core/main.js"></script>
   <script src="../../scripts/funcionarios/funcionarios.js"></script>
+  <script src="https://cdn.quilljs.com/1.3.7/quill.min.js"></script>
+  <script type="module" src="../../scripts/funcionarios/vet/receitas.js"></script>
 </body>
 </html>

--- a/scripts/core/main.js
+++ b/scripts/core/main.js
@@ -128,11 +128,11 @@ function initFuncionarioVetHoverMenu() {
   const trigger = wrap.querySelector('#func-vet-hover');
   if (!trigger) return;
 
-  // Itens do menu (todos "Em breve")
+  // Itens do menu
   const ITEMS = [
     { label: 'Ficha Clínica', icon: 'fas fa-notes-medical', href: '/pages/funcionarios/vet-ficha-clinica.html', status: 'Em breve' },
     { label: 'Documentos',    icon: 'fas fa-file-medical', href: '/pages/funcionarios/vet-documentos.html',    status: '' },
-    { label: 'Receitas',      icon: 'fas fa-prescription-bottle-medical', href: '/pages/funcionarios/vet-receitas.html', status: 'Em breve' },
+    { label: 'Receitas',      icon: 'fas fa-prescription-bottle-medical', href: '/pages/funcionarios/vet-receitas.html', status: '' },
     { label: 'Assinatura',    icon: 'fas fa-signature',     href: '/pages/funcionarios/vet-assinatura.html',   status: 'Em breve' },
   ];
 

--- a/scripts/funcionarios/vet/ficha-clinica/core.js
+++ b/scripts/funcionarios/vet/ficha-clinica/core.js
@@ -99,6 +99,7 @@ export const els = {
   addVacinaBtn: document.getElementById('vet-add-vacina-btn'),
   addAnexoBtn: document.getElementById('vet-add-anexo-btn'),
   addDocumentoBtn: document.getElementById('vet-add-documento-btn'),
+  addReceitaBtn: document.getElementById('vet-add-receita-btn'),
   addExameBtn: document.getElementById('vet-add-exame-btn'),
   addPesoBtn: document.getElementById('vet-add-peso-btn'),
   addObservacaoBtn: document.getElementById('vet-add-observacao-btn'),
@@ -127,6 +128,9 @@ export const state = {
   documentos: [],
   documentosLoading: false,
   documentosLoadKey: null,
+  receitas: [],
+  receitasLoading: false,
+  receitasLoadKey: null,
 };
 
 export const consultaModal = {

--- a/scripts/funcionarios/vet/ficha-clinica/init.js
+++ b/scripts/funcionarios/vet/ficha-clinica/init.js
@@ -4,6 +4,7 @@ import { openConsultaModal } from './consultas.js';
 import { openVacinaModal } from './vacinas.js';
 import { openAnexoModal } from './anexos.js';
 import { openDocumentoModal } from './documentos.js';
+import { openReceitaModal } from './receitas.js';
 import { openExameModal } from './exames.js';
 import { openPesoModal } from './pesos.js';
 import { openObservacaoModal } from './observacoes.js';
@@ -92,6 +93,13 @@ export function initFichaClinica() {
     els.addDocumentoBtn.addEventListener('click', (event) => {
       event.preventDefault();
       openDocumentoModal();
+    });
+  }
+
+  if (els.addReceitaBtn) {
+    els.addReceitaBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      openReceitaModal();
     });
   }
 

--- a/scripts/funcionarios/vet/ficha-clinica/receitas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/receitas.js
@@ -1,0 +1,1196 @@
+// Receita modal handling for the Vet ficha clínica
+import {
+  state,
+  api,
+  notify,
+  pickFirst,
+  formatPhone,
+  formatDateDisplay,
+  formatDateTimeDisplay,
+  formatPetSex,
+  formatPetWeight,
+  formatPetMicrochip,
+  getSelectedPet,
+  getAgendaStoreId,
+  normalizeId,
+} from './core.js';
+import { ensureTutorAndPetSelected, updateConsultaAgendaCard, getConsultasKey } from './consultas.js';
+import {
+  KEYWORD_GROUPS,
+  renderPreviewFrameContent,
+  getPreviewText,
+  openDocumentPrintWindow,
+  applyKeywordReplacements,
+  keywordAppearsInContent,
+} from '../document-utils.js';
+
+const receitaModal = {
+  overlay: null,
+  dialog: null,
+  select: null,
+  previewFrame: null,
+  previewTitle: null,
+  previewEmpty: null,
+  loadingState: null,
+  emptyState: null,
+  saveBtn: null,
+  printBtn: null,
+  keywordContainer: null,
+  previewDefaultMessage: '',
+  keywordItems: [],
+  templates: [],
+  isLoading: false,
+  isGenerating: false,
+  selectedId: '',
+  keydownHandler: null,
+};
+
+const PREVIEW_LOADING_MESSAGE = 'Carregando pré-visualização com os dados do atendimento...';
+const PREVIEW_ERROR_MESSAGE = 'Erro ao gerar pré-visualização da receita.';
+const storeCache = new Map();
+const storePromiseCache = new Map();
+let previewUpdateToken = 0;
+
+function renderKeywordReference() {
+  if (!receitaModal.keywordContainer) return;
+  receitaModal.keywordContainer.innerHTML = '';
+  receitaModal.keywordItems = [];
+
+  KEYWORD_GROUPS.forEach((group) => {
+    if (!group || !Array.isArray(group.items) || !group.items.length) return;
+
+    const section = document.createElement('div');
+    section.className = 'space-y-2';
+
+    const heading = document.createElement('h3');
+    heading.className = 'text-xs font-semibold uppercase tracking-wide text-slate-500';
+    heading.textContent = group.title;
+    section.appendChild(heading);
+
+    const list = document.createElement('div');
+    list.className = 'grid gap-2';
+
+    group.items.forEach((item) => {
+      const token = typeof item?.token === 'string' ? item.token.trim() : '';
+      if (!token) return;
+
+      const wrapper = document.createElement('div');
+      wrapper.className = 'rounded-lg border border-slate-200 bg-white px-3 py-2 shadow-sm transition';
+
+      const tokenEl = document.createElement('div');
+      tokenEl.className = 'font-mono text-[11px] font-semibold text-slate-700';
+      tokenEl.textContent = token;
+      wrapper.appendChild(tokenEl);
+
+      if (item.description) {
+        const description = document.createElement('p');
+        description.className = 'mt-1 text-xs text-slate-500';
+        description.textContent = item.description;
+        wrapper.appendChild(description);
+      }
+
+      receitaModal.keywordItems.push({ token, element: wrapper, label: tokenEl });
+      list.appendChild(wrapper);
+    });
+
+    if (list.children.length) {
+      section.appendChild(list);
+      receitaModal.keywordContainer.appendChild(section);
+    }
+  });
+}
+
+function highlightKeywords(content) {
+  const value = typeof content === 'string' ? content : '';
+  receitaModal.keywordItems.forEach((item) => {
+    const found = keywordAppearsInContent(value, item.token);
+    item.element.classList.toggle('border-emerald-300', found);
+    item.element.classList.toggle('bg-emerald-50', found);
+    item.element.classList.toggle('text-emerald-700', found);
+    if (item.label) {
+      item.label.classList.toggle('text-emerald-700', found);
+    }
+  });
+}
+
+function setModalLoading(isLoading) {
+  receitaModal.isLoading = !!isLoading;
+  if (receitaModal.loadingState) {
+    receitaModal.loadingState.classList.toggle('hidden', !isLoading);
+  }
+  if (receitaModal.select) {
+    receitaModal.select.disabled = !!isLoading;
+    receitaModal.select.classList.toggle('opacity-60', !!isLoading);
+  }
+  updateButtonsState();
+}
+
+function updateButtonsState() {
+  const hasSelection = !!getSelectedReceita();
+  const disabled = receitaModal.isLoading || receitaModal.isGenerating || !hasSelection;
+  if (receitaModal.saveBtn) {
+    receitaModal.saveBtn.disabled = disabled;
+    receitaModal.saveBtn.classList.toggle('opacity-60', disabled);
+    receitaModal.saveBtn.classList.toggle('cursor-not-allowed', disabled);
+  }
+  if (receitaModal.printBtn) {
+    receitaModal.printBtn.disabled = disabled;
+    receitaModal.printBtn.classList.toggle('opacity-60', disabled);
+    receitaModal.printBtn.classList.toggle('cursor-not-allowed', disabled);
+  }
+}
+
+function normalizeRecipeTemplate(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const id = String(raw.id || raw._id || '').trim();
+  if (!id) return null;
+  const descricao = typeof raw.descricao === 'string' ? raw.descricao.trim() : '';
+  const conteudo = typeof raw.conteudo === 'string' ? raw.conteudo : '';
+  const createdAt = raw.createdAt ? new Date(raw.createdAt).toISOString() : null;
+  const updatedAt = raw.updatedAt ? new Date(raw.updatedAt).toISOString() : createdAt;
+  return { id, descricao, conteudo, createdAt, updatedAt };
+}
+
+function formatDocumentNumber(value) {
+  if (value === null || value === undefined) return '';
+  const str = String(value).trim();
+  if (!str) return '';
+  const digits = str.replace(/\D+/g, '');
+  if (digits.length === 11) {
+    return digits.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
+  }
+  if (digits.length === 14) {
+    return digits.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, '$1.$2.$3/$4-$5');
+  }
+  return str;
+}
+
+function parseDateValue(value) {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : new Date(value.getTime());
+  }
+  if (typeof value === 'number') {
+    const dateFromNumber = new Date(value);
+    return Number.isNaN(dateFromNumber.getTime()) ? null : dateFromNumber;
+  }
+  const str = String(value).trim();
+  if (!str) return null;
+  let parsed = new Date(str);
+  if (!Number.isNaN(parsed.getTime())) return parsed;
+  const match = str.match(/^(\d{2})[\/\-](\d{2})[\/\-](\d{4})$/);
+  if (match) {
+    const [, day, month, year] = match;
+    parsed = new Date(`${year}-${month}-${day}T00:00:00`);
+    if (!Number.isNaN(parsed.getTime())) return parsed;
+  }
+  return null;
+}
+
+function formatTimeDisplay(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
+  try {
+    return date.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
+  } catch (error) {
+    return '';
+  }
+}
+
+function formatPetAge(pet) {
+  if (!pet) return '';
+  const birthRaw = pickFirst(pet?.dataNascimento, pet?.nascimento);
+  const birthDate = parseDateValue(birthRaw);
+  if (!birthDate) return '';
+  const now = new Date();
+  if (Number.isNaN(now.getTime()) || birthDate > now) return '';
+
+  let totalMonths = (now.getFullYear() - birthDate.getFullYear()) * 12 + (now.getMonth() - birthDate.getMonth());
+  if (now.getDate() < birthDate.getDate()) {
+    totalMonths -= 1;
+  }
+  if (totalMonths < 0) totalMonths = 0;
+
+  const years = Math.floor(totalMonths / 12);
+  const months = totalMonths % 12;
+  const parts = [];
+  if (years > 0) parts.push(`${years} ano${years === 1 ? '' : 's'}`);
+  if (months > 0) parts.push(`${months} mês${months === 1 ? '' : 'es'}`);
+  if (!parts.length) {
+    const diffMs = now.getTime() - birthDate.getTime();
+    const days = Math.max(Math.floor(diffMs / (1000 * 60 * 60 * 24)), 0);
+    if (days > 0) {
+      parts.push(`${days} dia${days === 1 ? '' : 's'}`);
+    } else {
+      parts.push('Recém-nascido');
+    }
+  }
+  return parts.join(' e ');
+}
+
+function getLatestPetWeightValue() {
+  const entries = Array.isArray(state.pesos) ? state.pesos.slice() : [];
+  if (!entries.length) return null;
+  entries.sort((a, b) => {
+    const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return bTime - aTime;
+  });
+  const recent = entries.find((entry) => entry && entry.peso !== null && entry.peso !== undefined && !entry.isInitial);
+  const fallback = entries.find((entry) => entry && entry.peso !== null && entry.peso !== undefined);
+  const target = recent || fallback || null;
+  if (!target) return null;
+  const value = target.peso;
+  if (value === null || value === undefined) return null;
+  return value;
+}
+
+function getLatestConsultaWithData() {
+  const consultas = Array.isArray(state.consultas) ? state.consultas.slice() : [];
+  if (!consultas.length) return null;
+  consultas.sort((a, b) => {
+    const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return bTime - aTime;
+  });
+  for (const consulta of consultas) {
+    if (!consulta) continue;
+    if (pickFirst(consulta.anamnese, consulta.diagnostico, consulta.exameFisico, consulta.servicoNome)) {
+      return consulta;
+    }
+  }
+  return consultas[0] || null;
+}
+
+function extractServiceName(consulta, agenda) {
+  const consultaName = pickFirst(consulta?.servicoNome);
+  if (consultaName) return consultaName;
+  const services = Array.isArray(agenda?.servicos) ? agenda.servicos : [];
+  for (const service of services) {
+    const name = pickFirst(
+      service?.nome,
+      service?.servicoNome,
+      service?.descricao,
+      service?.label,
+      service?.servico?.nome,
+      typeof service === 'string' ? service : '',
+    );
+    if (name) return name;
+  }
+  return pickFirst(
+    agenda?.servicoNome,
+    agenda?.servico,
+    agenda?.nomeServico,
+    agenda?.descricaoServico,
+  );
+}
+
+function getAgendaScheduledDate(agenda, consulta) {
+  const candidates = [
+    agenda?.scheduledAt,
+    agenda?.data,
+    agenda?.dataHora,
+    agenda?.horario,
+    agenda?.inicio,
+    consulta?.createdAt,
+  ];
+  for (const candidate of candidates) {
+    const parsed = parseDateValue(candidate);
+    if (parsed) return parsed;
+  }
+  return null;
+}
+
+async function fetchStoreInfoById(storeId) {
+  const normalized = typeof storeId === 'string' ? storeId.trim() : '';
+  if (!normalized) return null;
+  if (storeCache.has(normalized)) return storeCache.get(normalized);
+  if (storePromiseCache.has(normalized)) return storePromiseCache.get(normalized);
+
+  const promise = api(`/stores/${encodeURIComponent(normalized)}`)
+    .then((resp) => {
+      if (!resp.ok) return null;
+      return resp.json().catch(() => null);
+    })
+    .then((data) => {
+      if (data && data._id) {
+        storeCache.set(normalized, data);
+        return data;
+      }
+      return null;
+    })
+    .catch((error) => {
+      console.error('fetchStoreInfoById', error);
+      return null;
+    })
+    .finally(() => {
+      storePromiseCache.delete(normalized);
+    });
+
+  storePromiseCache.set(normalized, promise);
+  return promise;
+}
+
+async function buildKeywordReplacements() {
+  const replacements = {};
+  KEYWORD_GROUPS.forEach((group) => {
+    if (!group || !Array.isArray(group.items)) return;
+    group.items.forEach((item) => {
+      const token = typeof item?.token === 'string' ? item.token : '';
+      if (token && !(token in replacements)) {
+        replacements[token] = '';
+      }
+    });
+  });
+
+  try {
+    const tutor = state.selectedCliente || null;
+    const pet = getSelectedPet();
+    const agenda = state.agendaContext || {};
+    const consulta = getLatestConsultaWithData();
+    const now = new Date();
+
+    replacements['<NomeTutor>'] = pickFirst(
+      tutor?.nome,
+      tutor?.nomeCompleto,
+      tutor?.razaoSocial,
+      tutor?.nomeFantasia,
+      tutor?.nomeContato,
+      tutor?.apelido,
+      tutor?.displayName,
+    );
+    replacements['<EmailTutor>'] = pickFirst(tutor?.email);
+    const tutorPhone = pickFirst(
+      tutor?.celular,
+      tutor?.telefone,
+      tutor?.whatsapp,
+      tutor?.phone,
+      tutor?.mobile,
+    );
+    replacements['<TelefoneTutor>'] = tutorPhone ? formatPhone(tutorPhone) : '';
+    const tutorDocument = pickFirst(
+      formatDocumentNumber(tutor?.documento),
+      formatDocumentNumber(tutor?.documentoPrincipal),
+      formatDocumentNumber(tutor?.cpf),
+      formatDocumentNumber(tutor?.cpfCnpj),
+      formatDocumentNumber(tutor?.cnpj),
+      formatDocumentNumber(tutor?.inscricaoEstadual),
+    );
+    replacements['<DocumentoTutor>'] = tutorDocument;
+
+    replacements['<NomePet>'] = pickFirst(
+      pet?.nome,
+      pet?.nomePet,
+      pet?.apelido,
+    );
+    replacements['<EspeciePet>'] = pickFirst(
+      pet?.especie,
+      pet?.tipo,
+      pet?.tipoPet,
+      pet?.categoria,
+      pet?.porte,
+      pet?.especiePet,
+    );
+    replacements['<RacaPet>'] = pickFirst(
+      pet?.raca,
+      pet?.breed,
+      pet?.racaNome,
+      pet?.racaDescricao,
+      pet?.racaPrincipal,
+      pet?.racaOriginal,
+      pet?.racaPet,
+      pet?.racaLabel,
+      pet?.raca?.nome,
+      pet?.raca?.descricao,
+      pet?.raca?.label,
+    );
+    replacements['<SexoPet>'] = pet ? formatPetSex(pet.sexo) : '';
+
+    const nascimento = parseDateValue(pickFirst(pet?.dataNascimento, pet?.nascimento));
+    replacements['<NascimentoPet>'] = nascimento ? formatDateDisplay(nascimento) : '';
+    replacements['<IdadePet>'] = formatPetAge(pet);
+
+    const latestPeso = getLatestPetWeightValue();
+    const pesoFonte = latestPeso !== null ? latestPeso : pickFirst(pet?.pesoAtual, pet?.peso, pet?.ultimoPeso);
+    replacements['<PesoPet>'] =
+      pesoFonte !== null && pesoFonte !== undefined && pesoFonte !== ''
+        ? formatPetWeight(pesoFonte)
+        : '';
+
+    const microchip = pickFirst(pet?.microchip, pet?.microChip, pet?.chip);
+    replacements['<MicrochipPet>'] = microchip ? formatPetMicrochip(microchip) : '';
+
+    const atendimentoDate = getAgendaScheduledDate(agenda, consulta);
+    replacements['<DataAtendimento>'] = atendimentoDate ? formatDateDisplay(atendimentoDate) : '';
+    replacements['<HoraAtendimento>'] = atendimentoDate ? formatTimeDisplay(atendimentoDate) : '';
+
+    replacements['<NomeServico>'] = extractServiceName(consulta, agenda);
+
+    replacements['<MotivoConsulta>'] = pickFirst(
+      consulta?.anamnese,
+      agenda?.observacoes,
+      agenda?.observacao,
+      agenda?.nota,
+      agenda?.motivo,
+    );
+    replacements['<DiagnosticoConsulta>'] = pickFirst(consulta?.diagnostico);
+    replacements['<ExameFisicoConsulta>'] = pickFirst(consulta?.exameFisico);
+    replacements['<NomeVeterinario>'] = pickFirst(
+      agenda?.profissionalNome,
+      agenda?.veterinarioNome,
+      agenda?.profissional?.nome,
+      agenda?.profissional?.nomeCompleto,
+    );
+
+    const storeId = getAgendaStoreId({ persist: false });
+    const store = storeId ? await fetchStoreInfoById(storeId) : null;
+
+    replacements['<NomeClinica>'] = pickFirst(
+      agenda?.storeNome,
+      agenda?.lojaNome,
+      agenda?.filialNome,
+      agenda?.empresaNome,
+      agenda?.empresa,
+      store?.nome,
+    );
+    replacements['<EnderecoClinica>'] = pickFirst(
+      agenda?.storeEndereco,
+      agenda?.lojaEndereco,
+      agenda?.endereco,
+      store?.endereco,
+    );
+    const clinicPhone = pickFirst(agenda?.storeTelefone, agenda?.telefone, store?.telefone);
+    replacements['<TelefoneClinica>'] = clinicPhone ? formatPhone(clinicPhone) : '';
+    const clinicWhatsapp = pickFirst(agenda?.storeWhatsapp, agenda?.whatsapp, store?.whatsapp);
+    replacements['<WhatsappClinica>'] = clinicWhatsapp ? formatPhone(clinicWhatsapp) : '';
+
+    replacements['<DataAtual>'] = formatDateDisplay(now);
+    replacements['<HoraAtual>'] = formatTimeDisplay(now);
+    replacements['<DataHoraAtual>'] = formatDateTimeDisplay(now);
+  } catch (error) {
+    console.error('buildKeywordReplacements', error);
+  }
+
+  return replacements;
+}
+
+async function resolveReceitaContent(doc) {
+  const rawContent = typeof doc?.conteudo === 'string' ? doc.conteudo : '';
+  const replacements = await buildKeywordReplacements();
+  const html = applyKeywordReplacements(rawContent, replacements);
+  return { html, replacements };
+}
+
+function ensureReceitaModal() {
+  if (receitaModal.overlay) return receitaModal;
+
+  const overlay = document.createElement('div');
+  overlay.id = 'vet-receita-modal';
+  overlay.className = 'hidden fixed inset-0 z-50 flex items-center justify-center p-4';
+  overlay.style.backgroundColor = 'rgba(15, 23, 42, 0.5)';
+  overlay.setAttribute('aria-hidden', 'true');
+
+  const dialog = document.createElement('div');
+  dialog.className = 'w-full overflow-hidden rounded-xl bg-white shadow-2xl focus:outline-none';
+  dialog.style.maxWidth = '72rem';
+  dialog.style.maxHeight = 'calc(100vh - 2rem)';
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
+  dialog.tabIndex = -1;
+  overlay.appendChild(dialog);
+
+  const layout = document.createElement('div');
+  layout.className = 'flex flex-col overflow-hidden';
+  layout.style.maxHeight = '90vh';
+  dialog.appendChild(layout);
+
+  const header = document.createElement('div');
+  header.className = 'flex shrink-0 items-start justify-between gap-3 border-b border-gray-100 px-6 py-4';
+  layout.appendChild(header);
+
+  const titleWrap = document.createElement('div');
+  header.appendChild(titleWrap);
+
+  const title = document.createElement('h2');
+  title.className = 'text-lg font-semibold text-gray-900';
+  title.textContent = 'Gerar receita';
+  titleWrap.appendChild(title);
+
+  const subtitle = document.createElement('p');
+  subtitle.className = 'text-sm text-gray-600';
+  subtitle.textContent = 'Selecione uma receita salva para utilizar durante o atendimento.';
+  titleWrap.appendChild(subtitle);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.className = 'h-9 w-9 grid place-content-center rounded-lg bg-gray-100 text-gray-500 transition hover:bg-gray-200 hover:text-gray-700';
+  closeBtn.innerHTML = '<i class="fas fa-xmark"></i>';
+  closeBtn.addEventListener('click', () => closeReceitaModal());
+  header.appendChild(closeBtn);
+
+  const content = document.createElement('div');
+  content.className = 'flex flex-1 flex-col overflow-y-auto px-6 py-5';
+  content.style.minHeight = '0';
+  layout.appendChild(content);
+
+  const bodyWrapper = document.createElement('div');
+  bodyWrapper.className = 'flex flex-1 flex-col gap-5 lg:flex-row';
+  bodyWrapper.style.minHeight = '0';
+  content.appendChild(bodyWrapper);
+
+  const leftColumn = document.createElement('div');
+  leftColumn.className = 'flex min-w-0 flex-1 flex-col gap-4';
+  leftColumn.style.minHeight = '0';
+  bodyWrapper.appendChild(leftColumn);
+
+  const rightColumn = document.createElement('div');
+  rightColumn.className = 'flex flex-1 flex-col';
+  rightColumn.style.minHeight = '0';
+  bodyWrapper.appendChild(rightColumn);
+
+  const selectCard = document.createElement('div');
+  selectCard.className = 'rounded-xl border border-slate-200 bg-white p-4 shadow-sm';
+  leftColumn.appendChild(selectCard);
+
+  const selectField = document.createElement('div');
+  selectField.className = 'space-y-2';
+  selectCard.appendChild(selectField);
+
+  const selectLabel = document.createElement('label');
+  selectLabel.className = 'text-sm font-medium text-gray-700';
+  selectLabel.textContent = 'Receita salva';
+  selectLabel.setAttribute('for', 'vet-receita-select');
+  selectField.appendChild(selectLabel);
+
+  const select = document.createElement('select');
+  select.id = 'vet-receita-select';
+  select.className = 'w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200';
+  select.addEventListener('change', () => handleSelectChange());
+  selectField.appendChild(select);
+
+  const selectHelp = document.createElement('p');
+  selectHelp.className = 'text-xs text-gray-500';
+  selectHelp.textContent = 'Os modelos utilizam palavras-chave que serão substituídas automaticamente pelos dados do tutor, pet e atendimento.';
+  selectField.appendChild(selectHelp);
+
+  const loadingState = document.createElement('div');
+  loadingState.className = 'hidden rounded-xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-600 shadow-inner';
+  loadingState.textContent = 'Carregando receitas salvas...';
+  leftColumn.appendChild(loadingState);
+
+  const emptyState = document.createElement('div');
+  emptyState.className = 'hidden rounded-xl border border-dashed border-slate-300 bg-white px-4 py-3 text-sm text-slate-600 shadow-sm';
+  emptyState.textContent = 'Nenhuma receita salva foi encontrada.';
+  leftColumn.appendChild(emptyState);
+
+  const previewCard = document.createElement('div');
+  previewCard.className = 'flex min-w-0 flex-1 flex-col overflow-hidden rounded-xl border border-slate-200 bg-slate-50 shadow-inner';
+  previewCard.style.minHeight = '260px';
+  leftColumn.appendChild(previewCard);
+
+  const previewBar = document.createElement('div');
+  previewBar.className = 'flex items-center gap-2 border-b border-slate-200 bg-slate-100 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600';
+  previewBar.innerHTML = '<i class="fas fa-eye text-sky-600"></i><span>Pré-visualização</span>';
+  previewCard.appendChild(previewBar);
+
+  const previewTitle = document.createElement('p');
+  previewTitle.className = 'px-4 py-2 text-sm font-semibold text-slate-700';
+  previewTitle.textContent = 'Nenhuma receita selecionada.';
+  previewCard.appendChild(previewTitle);
+
+  const previewWrapper = document.createElement('div');
+  previewWrapper.className = 'relative flex-1 bg-white';
+  previewWrapper.style.minHeight = '0';
+  previewCard.appendChild(previewWrapper);
+
+  const previewFrame = document.createElement('iframe');
+  previewFrame.className = 'block h-full w-full bg-white';
+  previewFrame.style.minHeight = '260px';
+  previewFrame.id = 'vet-receita-preview-frame';
+  previewFrame.setAttribute('loading', 'lazy');
+  previewWrapper.appendChild(previewFrame);
+
+  const previewEmpty = document.createElement('div');
+  previewEmpty.className = 'absolute inset-0 flex items-center justify-center px-6 text-center text-sm text-slate-500';
+  previewEmpty.textContent = 'Selecione uma receita para visualizar com as palavras-chave atualizadas.';
+  previewEmpty.dataset.defaultMessage = previewEmpty.textContent;
+  previewWrapper.appendChild(previewEmpty);
+
+  const keywordsSection = document.createElement('div');
+  keywordsSection.className = 'flex flex-1 flex-col rounded-xl border border-dashed border-slate-300 bg-white p-4 shadow-sm';
+  keywordsSection.style.minHeight = '0';
+  rightColumn.appendChild(keywordsSection);
+
+  const keywordsTitle = document.createElement('h3');
+  keywordsTitle.className = 'text-sm font-semibold text-slate-700';
+  keywordsTitle.textContent = 'Palavras-chave disponíveis';
+  keywordsSection.appendChild(keywordsTitle);
+
+  const keywordsHelp = document.createElement('p');
+  keywordsHelp.className = 'mt-1 text-xs text-slate-500';
+  keywordsHelp.textContent = 'As palavras abaixo são substituídas automaticamente pelos dados atuais do atendimento.';
+  keywordsSection.appendChild(keywordsHelp);
+
+  const keywordsScroll = document.createElement('div');
+  keywordsScroll.className = 'mt-3 flex-1 overflow-y-auto pr-2';
+  keywordsScroll.style.minHeight = '0';
+  keywordsSection.appendChild(keywordsScroll);
+
+  const keywordsContainer = document.createElement('div');
+  keywordsContainer.className = 'grid gap-2 md:grid-cols-2';
+  keywordsScroll.appendChild(keywordsContainer);
+
+  const footer = document.createElement('div');
+  footer.className = 'flex shrink-0 flex-wrap items-center justify-between gap-3 border-t border-gray-200 bg-slate-50 px-6 py-4';
+  layout.appendChild(footer);
+
+  const footerInfo = document.createElement('p');
+  footerInfo.className = 'text-xs text-slate-500';
+  footerInfo.textContent = 'Salve para registrar a receita na aba de consultas ou imprima imediatamente.';
+  footer.appendChild(footerInfo);
+
+  const footerActions = document.createElement('div');
+  footerActions.className = 'flex flex-wrap items-center gap-2';
+  footer.appendChild(footerActions);
+
+  const printBtn = document.createElement('button');
+  printBtn.type = 'button';
+  printBtn.className = 'inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200';
+  printBtn.innerHTML = '<i class="fas fa-print"></i><span>Imprimir</span>';
+  printBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    const result = handlePrint();
+    if (result && typeof result.catch === 'function') {
+      result.catch(() => {});
+    }
+  });
+  footerActions.appendChild(printBtn);
+
+  const saveBtn = document.createElement('button');
+  saveBtn.type = 'button';
+  saveBtn.className = 'inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-300';
+  saveBtn.innerHTML = '<i class="fas fa-save"></i><span>Salvar receita no atendimento</span>';
+  saveBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    const result = handleSave();
+    if (result && typeof result.catch === 'function') {
+      result.catch(() => {});
+    }
+  });
+  footerActions.appendChild(saveBtn);
+
+  overlay.addEventListener('click', (event) => {
+    if (event.target === overlay) {
+      closeReceitaModal();
+    }
+  });
+
+  receitaModal.overlay = overlay;
+  receitaModal.dialog = dialog;
+  receitaModal.select = select;
+  receitaModal.previewFrame = previewFrame;
+  receitaModal.previewTitle = previewTitle;
+  receitaModal.previewEmpty = previewEmpty;
+  receitaModal.previewDefaultMessage = previewEmpty.textContent || '';
+  receitaModal.loadingState = loadingState;
+  receitaModal.emptyState = emptyState;
+  receitaModal.saveBtn = saveBtn;
+  receitaModal.printBtn = printBtn;
+  receitaModal.keywordContainer = keywordsContainer;
+  receitaModal.keywordItems = [];
+  receitaModal.templates = [];
+  receitaModal.selectedId = '';
+  receitaModal.isLoading = false;
+  receitaModal.isGenerating = false;
+
+  renderKeywordReference();
+  document.body.appendChild(overlay);
+  return receitaModal;
+}
+
+function getSelectedReceita() {
+  const id = String(receitaModal.selectedId || '').trim();
+  if (!id) return null;
+  return receitaModal.templates.find((doc) => doc.id === id) || null;
+}
+
+function populateReceitaOptions() {
+  if (!receitaModal.select) return;
+
+  const docs = Array.isArray(receitaModal.templates) ? receitaModal.templates : [];
+  receitaModal.select.innerHTML = '';
+
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = docs.length ? 'Selecione uma receita salva' : 'Nenhuma receita encontrada';
+  placeholder.disabled = !!docs.length;
+  placeholder.selected = true;
+  receitaModal.select.appendChild(placeholder);
+
+  docs.forEach((doc) => {
+    const option = document.createElement('option');
+    option.value = doc.id;
+    option.textContent = doc.descricao || 'Receita';
+    receitaModal.select.appendChild(option);
+  });
+
+  if (receitaModal.emptyState) {
+    receitaModal.emptyState.classList.toggle('hidden', docs.length > 0);
+  }
+
+  if (docs.length) {
+    const hasPreviousSelection = docs.some((doc) => doc.id === receitaModal.selectedId);
+    const targetId = hasPreviousSelection ? receitaModal.selectedId : docs[0].id;
+    receitaModal.selectedId = targetId;
+    receitaModal.select.value = targetId;
+    updatePreview().catch(() => {});
+  } else {
+    receitaModal.selectedId = '';
+    updatePreview().catch(() => {});
+  }
+
+  updateButtonsState();
+}
+
+async function updatePreview() {
+  const doc = getSelectedReceita();
+  const previewFrame = receitaModal.previewFrame;
+  const previewTitle = receitaModal.previewTitle;
+  const previewEmpty = receitaModal.previewEmpty;
+  const defaultMessage = receitaModal.previewDefaultMessage
+    || previewEmpty?.dataset?.defaultMessage
+    || 'Selecione uma receita para visualizar com as palavras-chave atualizadas.';
+
+  if (!doc) {
+    if (previewTitle) {
+      previewTitle.textContent = 'Nenhuma receita selecionada.';
+    }
+    if (previewEmpty) {
+      previewEmpty.textContent = defaultMessage;
+      previewEmpty.classList.remove('hidden');
+    }
+    if (previewFrame) {
+      renderPreviewFrameContent(previewFrame, '', { minHeight: 260, background: '#f8fafc' });
+    }
+    highlightKeywords('');
+    receitaModal.isGenerating = false;
+    updateButtonsState();
+    return;
+  }
+
+  if (previewTitle) {
+    previewTitle.textContent = doc.descricao || 'Receita salva';
+  }
+  highlightKeywords(doc.conteudo || '');
+  if (previewEmpty) {
+    previewEmpty.textContent = PREVIEW_LOADING_MESSAGE;
+    previewEmpty.classList.remove('hidden');
+  }
+  if (previewFrame) {
+    renderPreviewFrameContent(previewFrame, '', { minHeight: 260, background: '#f8fafc' });
+  }
+
+  const requestId = ++previewUpdateToken;
+  receitaModal.isGenerating = true;
+  updateButtonsState();
+
+  try {
+    const { html } = await resolveReceitaContent(doc);
+    if (requestId !== previewUpdateToken) return;
+    if (previewFrame) {
+      renderPreviewFrameContent(previewFrame, html, { minHeight: 260, background: '#f8fafc' });
+    }
+    if (previewEmpty) {
+      previewEmpty.textContent = defaultMessage;
+      previewEmpty.classList.add('hidden');
+    }
+  } catch (error) {
+    console.error('updatePreview', error);
+    if (requestId !== previewUpdateToken) return;
+    if (previewEmpty) {
+      previewEmpty.textContent = PREVIEW_ERROR_MESSAGE;
+      previewEmpty.classList.remove('hidden');
+    }
+    if (previewFrame) {
+      renderPreviewFrameContent(previewFrame, '', { minHeight: 260, background: '#f8fafc' });
+    }
+  } finally {
+    if (requestId === previewUpdateToken) {
+      receitaModal.isGenerating = false;
+      updateButtonsState();
+    }
+  }
+}
+
+function handleSelectChange() {
+  if (!receitaModal.select) return;
+  receitaModal.selectedId = receitaModal.select.value || '';
+  updatePreview().catch(() => {});
+}
+
+async function loadReceitas({ force = false } = {}) {
+  const modal = ensureReceitaModal();
+  if (modal.isLoading) return;
+  if (!force && Array.isArray(modal.templates) && modal.templates.length) {
+    populateReceitaOptions();
+    return;
+  }
+
+  setModalLoading(true);
+  try {
+    const resp = await api('/func/vet/receitas');
+    const payload = await resp.json().catch(() => (resp.ok ? [] : {}));
+    if (!resp.ok) {
+      const message = typeof payload?.message === 'string' ? payload.message : 'Erro ao carregar receitas.';
+      throw new Error(message);
+    }
+
+    const docs = Array.isArray(payload) ? payload : [];
+    const normalized = docs.map(normalizeRecipeTemplate).filter(Boolean);
+    normalized.sort((a, b) => {
+      const aTime = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+      const bTime = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+      return bTime - aTime;
+    });
+
+    modal.templates = normalized;
+    populateReceitaOptions();
+  } catch (error) {
+    console.error('loadReceitas', error);
+    notify(error.message || 'Erro ao carregar receitas salvas.', 'error');
+    modal.templates = [];
+    populateReceitaOptions();
+  } finally {
+    setModalLoading(false);
+  }
+}
+
+export async function loadReceitasFromServer(options = {}) {
+  const { force = false } = options || {};
+  const clienteId = normalizeId(state.selectedCliente?._id);
+  const petId = normalizeId(state.selectedPetId);
+
+  if (!(clienteId && petId)) {
+    state.receitas = [];
+    state.receitasLoadKey = null;
+    state.receitasLoading = false;
+    updateConsultaAgendaCard();
+    return;
+  }
+
+  const key = getConsultasKey(clienteId, petId);
+  if (!force && key && state.receitasLoadKey === key) return;
+
+  state.receitasLoading = true;
+  updateConsultaAgendaCard();
+
+  try {
+    const params = new URLSearchParams({ clienteId, petId });
+    const appointmentId = normalizeId(state.agendaContext?.appointmentId);
+    if (appointmentId) params.set('appointmentId', appointmentId);
+
+    const resp = await api(`/func/vet/receitas-registros?${params.toString()}`);
+    const payload = await resp.json().catch(() => (resp.ok ? [] : {}));
+    if (!resp.ok) {
+      const message = typeof payload?.message === 'string' ? payload.message : 'Erro ao carregar receitas do atendimento.';
+      throw new Error(message);
+    }
+
+    setReceitaRegistrosInState(Array.isArray(payload) ? payload : []);
+  } catch (error) {
+    console.error('loadReceitasFromServer', error);
+    state.receitas = [];
+    state.receitasLoadKey = null;
+    notify(error.message || 'Erro ao carregar receitas do atendimento.', 'error');
+  } finally {
+    state.receitasLoading = false;
+    updateConsultaAgendaCard();
+  }
+}
+
+function prepareReceitaRecordPayload(doc, resolvedHtml = '') {
+  if (!doc || typeof doc !== 'object') return null;
+  const docId = normalizeId(doc.id || doc._id);
+  if (!docId) return null;
+  const finalHtml = typeof resolvedHtml === 'string' ? resolvedHtml : '';
+  const previewSource = finalHtml || (typeof doc.conteudo === 'string' ? doc.conteudo : '');
+  return {
+    receitaId: docId,
+    descricao: typeof doc.descricao === 'string' && doc.descricao.trim()
+      ? doc.descricao.trim()
+      : 'Receita',
+    conteudo: finalHtml,
+    conteudoOriginal: typeof doc.conteudo === 'string' ? doc.conteudo : '',
+    preview: getPreviewText(previewSource),
+  };
+}
+
+function normalizeReceitaRegistroRecord(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const id = normalizeId(raw.id || raw._id);
+  if (!id) return null;
+
+  const receitaId = normalizeId(raw.receitaId || raw.receita);
+  const descricao = typeof raw.descricao === 'string' ? raw.descricao.trim() : '';
+  const conteudo = typeof raw.conteudo === 'string' ? raw.conteudo : '';
+  const conteudoOriginal = typeof raw.conteudoOriginal === 'string' ? raw.conteudoOriginal : '';
+  const previewSource = typeof raw.preview === 'string' && raw.preview
+    ? raw.preview
+    : getPreviewText(conteudo || conteudoOriginal);
+
+  const clienteId = normalizeId(raw.clienteId || raw.cliente);
+  const petId = normalizeId(raw.petId || raw.pet);
+  const appointmentId = normalizeId(raw.appointmentId || raw.appointment);
+
+  const createdAtDate = parseDateValue(raw.createdAt || raw.criadoEm || raw.dataCriacao);
+  const updatedAtDate = parseDateValue(raw.updatedAt || raw.atualizadoEm || raw.dataAtualizacao) || createdAtDate;
+  const createdAt = createdAtDate ? createdAtDate.toISOString() : null;
+  const updatedAt = updatedAtDate ? updatedAtDate.toISOString() : createdAt;
+
+  return {
+    id,
+    _id: id,
+    receitaId,
+    descricao,
+    conteudo,
+    conteudoOriginal,
+    preview: previewSource,
+    createdAt,
+    updatedAt,
+    clienteId,
+    petId,
+    appointmentId,
+  };
+}
+
+function upsertReceitaRegistroInState(record) {
+  const normalized = normalizeReceitaRegistroRecord(record);
+  if (!normalized) return null;
+
+  const list = Array.isArray(state.receitas) ? [...state.receitas] : [];
+  const targetId = normalizeId(normalized.id || normalized._id);
+  const existingIdx = list.findIndex((item) => normalizeId(item?.id || item?._id) === targetId);
+
+  if (existingIdx >= 0) {
+    list[existingIdx] = { ...list[existingIdx], ...normalized };
+  } else {
+    list.unshift(normalized);
+  }
+
+  list.sort((a, b) => {
+    const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return bTime - aTime;
+  });
+
+  state.receitas = list;
+  const key = getConsultasKey(state.selectedCliente?._id, state.selectedPetId);
+  if (key) state.receitasLoadKey = key;
+
+  return list.find((item) => normalizeId(item?.id || item?._id) === targetId) || normalized;
+}
+
+function setReceitaRegistrosInState(records) {
+  const list = Array.isArray(records)
+    ? records.map(normalizeReceitaRegistroRecord).filter(Boolean)
+    : [];
+
+  list.sort((a, b) => {
+    const aTime = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const bTime = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return bTime - aTime;
+  });
+
+  state.receitas = list;
+  const key = getConsultasKey(state.selectedCliente?._id, state.selectedPetId);
+  if (key) state.receitasLoadKey = key;
+
+  return list;
+}
+
+export async function deleteReceitaRegistro(target, options = {}) {
+  const { suppressNotify = false } = options;
+  const targetId = normalizeId(
+    target && typeof target === 'object' ? target.id || target._id : target,
+  );
+  if (!targetId) return false;
+
+  const current = Array.isArray(state.receitas) ? state.receitas : [];
+  const filtered = current.filter((item) => normalizeId(item?.id || item?._id) !== targetId);
+  const hadEntry = filtered.length !== current.length;
+
+  try {
+    const resp = await api(`/func/vet/receitas-registros/${encodeURIComponent(targetId)}`, {
+      method: 'DELETE',
+    });
+
+    if (!resp.ok) {
+      if (resp.status === 404 && hadEntry) {
+        state.receitas = filtered;
+        if (!suppressNotify) {
+          notify('Receita removida com sucesso.', 'success');
+        }
+        updateConsultaAgendaCard();
+        return true;
+      }
+
+      const payload = await resp.json().catch(() => ({}));
+      const message = typeof payload?.message === 'string'
+        ? payload.message
+        : 'Não foi possível remover a receita.';
+      throw new Error(message);
+    }
+
+    state.receitas = filtered;
+    if (!suppressNotify) {
+      notify('Receita removida com sucesso.', 'success');
+    }
+    updateConsultaAgendaCard();
+    return true;
+  } catch (error) {
+    console.error('deleteReceitaRegistro', error);
+    notify(error.message || 'Não foi possível remover a receita.', 'error');
+    return false;
+  }
+}
+
+state.deleteReceita = deleteReceitaRegistro;
+
+async function handleSave() {
+  if (receitaModal.isLoading || receitaModal.isGenerating) return;
+  const doc = getSelectedReceita();
+  if (!doc) {
+    notify('Selecione uma receita salva para registrar.', 'warning');
+    return;
+  }
+
+  const clienteId = normalizeId(state.selectedCliente?._id);
+  const petId = normalizeId(state.selectedPetId);
+  if (!(clienteId && petId)) {
+    notify('Selecione um tutor e um pet para registrar a receita no atendimento.', 'warning');
+    return;
+  }
+
+  receitaModal.isGenerating = true;
+  updateButtonsState();
+
+  try {
+    const { html } = await resolveReceitaContent(doc);
+    const finalHtml = typeof html === 'string' ? html : (doc.conteudo || '');
+    const recordPayload = prepareReceitaRecordPayload(doc, finalHtml);
+    if (!recordPayload) {
+      throw new Error('Não foi possível preparar os dados da receita.');
+    }
+
+    const payload = {
+      ...recordPayload,
+      clienteId,
+      petId,
+    };
+
+    const appointmentId = normalizeId(state.agendaContext?.appointmentId);
+    if (appointmentId) {
+      payload.appointmentId = appointmentId;
+    }
+
+    const resp = await api('/func/vet/receitas-registros', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    const data = await resp.json().catch(() => null);
+    if (!resp.ok) {
+      const message = typeof data?.message === 'string' ? data.message : 'Não foi possível salvar a receita.';
+      throw new Error(message);
+    }
+
+    const fallbackRecord = {
+      ...recordPayload,
+      id: normalizeId(data?.id || data?._id) || `rec-reg-${Date.now()}-${Math.floor(Math.random() * 1e6)}`,
+      _id: data?._id,
+      createdAt: data?.createdAt || new Date().toISOString(),
+      updatedAt: data?.updatedAt || data?.createdAt || new Date().toISOString(),
+      clienteId,
+      petId,
+      appointmentId,
+    };
+
+    const saved = upsertReceitaRegistroInState(data || fallbackRecord);
+    if (!saved && fallbackRecord) {
+      upsertReceitaRegistroInState(fallbackRecord);
+    }
+
+    notify('Receita adicionada na aba de consultas.', 'success');
+    closeReceitaModal();
+    updateConsultaAgendaCard();
+  } catch (error) {
+    console.error('handleSave', error);
+    notify(error.message || 'Não foi possível preparar a receita para salvar.', 'error');
+  } finally {
+    receitaModal.isGenerating = false;
+    updateButtonsState();
+  }
+}
+
+async function handlePrint() {
+  if (receitaModal.isLoading || receitaModal.isGenerating) return;
+  const doc = getSelectedReceita();
+  if (!doc) {
+    notify('Selecione uma receita salva para imprimir.', 'warning');
+    return;
+  }
+
+  receitaModal.isGenerating = true;
+  updateButtonsState();
+
+  try {
+    const { html } = await resolveReceitaContent(doc);
+    const finalHtml = typeof html === 'string' && html.length ? html : (doc.conteudo || '');
+    const success = openDocumentPrintWindow(finalHtml, { title: doc.descricao || 'Receita' });
+    if (!success) {
+      notify('Não foi possível abrir a impressão. Verifique se o navegador bloqueou pop-ups.', 'error');
+    }
+  } catch (error) {
+    console.error('handlePrint', error);
+    notify('Não foi possível preparar a receita para impressão.', 'error');
+  } finally {
+    receitaModal.isGenerating = false;
+    updateButtonsState();
+  }
+}
+
+export function closeReceitaModal() {
+  if (!receitaModal.overlay) return;
+  receitaModal.overlay.classList.add('hidden');
+  receitaModal.overlay.setAttribute('aria-hidden', 'true');
+  receitaModal.isGenerating = false;
+  updateButtonsState();
+  if (receitaModal.keydownHandler) {
+    document.removeEventListener('keydown', receitaModal.keydownHandler);
+    receitaModal.keydownHandler = null;
+  }
+}
+
+export function openReceitaModal() {
+  if (!ensureTutorAndPetSelected()) return;
+
+  const modal = ensureReceitaModal();
+  modal.overlay.classList.remove('hidden');
+  modal.overlay.setAttribute('aria-hidden', 'false');
+  try {
+    modal.dialog.focus({ preventScroll: true });
+  } catch (_) {
+    modal.dialog.focus();
+  }
+
+  if (!modal.keydownHandler) {
+    modal.keydownHandler = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeReceitaModal();
+      }
+    };
+    document.addEventListener('keydown', modal.keydownHandler);
+  }
+
+  loadReceitas({ force: true });
+  updateButtonsState();
+}

--- a/scripts/funcionarios/vet/ficha-clinica/tutor.js
+++ b/scripts/funcionarios/vet/ficha-clinica/tutor.js
@@ -18,6 +18,7 @@ import { loadExamesForSelection } from './exames.js';
 import { loadObservacoesForSelection } from './observacoes.js';
 import { loadPesosFromServer } from './pesos.js';
 import { loadDocumentosFromServer } from './documentos.js';
+import { loadReceitasFromServer } from './receitas.js';
 import { updateCardDisplay, updatePageVisibility, setCardMode } from './ui.js';
 
 function hideSugestoes() {
@@ -150,6 +151,11 @@ export async function onSelectCliente(cli, opts = {}) {
   state.pesosLoadKey = null;
   state.pesosLoading = false;
   state.documentos = [];
+  state.documentosLoadKey = null;
+  state.documentosLoading = false;
+  state.receitas = [];
+  state.receitasLoadKey = null;
+  state.receitasLoading = false;
 
   if (state.agendaContext) {
     const contextTutorId = normalizeId(state.agendaContext.tutorId);
@@ -259,6 +265,9 @@ export async function onSelectPet(petId, opts = {}) {
   state.documentos = [];
   state.documentosLoadKey = null;
   state.documentosLoading = false;
+  state.receitas = [];
+  state.receitasLoadKey = null;
+  state.receitasLoading = false;
   loadVacinasForSelection();
   loadAnexosForSelection();
   loadExamesForSelection();
@@ -274,6 +283,7 @@ export async function onSelectPet(petId, opts = {}) {
     loadAnexosFromServer({ force: true }),
     loadPesosFromServer({ force: true }),
     loadDocumentosFromServer({ force: true }),
+    loadReceitasFromServer({ force: true }),
   ]);
 }
 
@@ -299,6 +309,9 @@ export function clearCliente() {
   state.documentos = [];
   state.documentosLoadKey = null;
   state.documentosLoading = false;
+  state.receitas = [];
+  state.receitasLoadKey = null;
+  state.receitasLoading = false;
   persistAgendaContext(null);
   if (els.cliInput) els.cliInput.value = '';
   hideSugestoes();
@@ -332,6 +345,9 @@ export function clearPet() {
   state.documentos = [];
   state.documentosLoadKey = null;
   state.documentosLoading = false;
+  state.receitas = [];
+  state.receitasLoadKey = null;
+  state.receitasLoading = false;
   updateCardDisplay();
   updatePageVisibility();
 }

--- a/scripts/funcionarios/vet/receitas.js
+++ b/scripts/funcionarios/vet/receitas.js
@@ -1,0 +1,1023 @@
+import {
+  KEYWORD_GROUPS,
+  sanitizeDocumentHtml,
+  extractPlainText,
+  getPreviewText,
+  renderPreviewFrameContent,
+} from './document-utils.js';
+
+const state = {
+  recipes: [],
+  editingId: null,
+  isLoading: false,
+  isSaving: false,
+};
+
+let form;
+let descriptionInput;
+let editorContainer;
+let formTitleEl;
+let saveBtn;
+let cancelBtn;
+let listEl;
+let emptyEl;
+let loadingEl;
+let errorEl;
+let countBadge;
+let quill = null;
+let fallbackTextarea = null;
+let isRedirecting = false;
+let keywordsContainer;
+let keywordButtons = [];
+let modeToggle = null;
+let modeButtons = [];
+let codeTextarea = null;
+let editorMode = 'visual';
+let previewContainer = null;
+let previewFrame = null;
+let visualMode = 'editor';
+let previewHtml = '';
+let previewModeKeywordNoticeShown = false;
+
+function getAuthToken() {
+  try {
+    const cached = JSON.parse(localStorage.getItem('loggedInUser') || 'null');
+    return cached?.token || null;
+  } catch (err) {
+    console.error('Erro ao recuperar token do usuário logado.', err);
+    return null;
+  }
+}
+
+function request(path, options = {}) {
+  const token = getAuthToken();
+  const headers = { Accept: 'application/json', ...(options.headers || {}) };
+  if (options.body && !(options.body instanceof FormData) && !headers['Content-Type']) {
+    headers['Content-Type'] = 'application/json';
+  }
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return fetch(`${API_CONFIG.BASE_URL}${path}`, {
+    ...options,
+    headers,
+  });
+}
+
+function handleUnauthorized(response) {
+  if (response.status === 401 || response.status === 403) {
+    if (!isRedirecting) {
+      isRedirecting = true;
+      showToastMessage('Sua sessão expirou. Faça login novamente.', 'warning');
+      setTimeout(() => {
+        window.location.replace('/pages/login.html');
+      }, 1500);
+    }
+    return true;
+  }
+  return false;
+}
+
+function showToastMessage(message, type = 'info') {
+  const text = String(message || '').trim();
+  if (!text) return;
+  if (typeof window.showToast === 'function') {
+    window.showToast(text, type);
+  } else if (typeof window.alert === 'function') {
+    window.alert(text);
+  } else {
+    console.log(text);
+  }
+}
+
+function showError(message) {
+  if (!errorEl) return;
+  const text = String(message || '').trim() || 'Ocorreu um erro inesperado.';
+  errorEl.textContent = text;
+  errorEl.classList.remove('hidden');
+}
+
+function clearError() {
+  if (!errorEl) return;
+  errorEl.textContent = '';
+  errorEl.classList.add('hidden');
+}
+
+function setListLoading(value) {
+  state.isLoading = !!value;
+  if (loadingEl) {
+    loadingEl.classList.toggle('hidden', !state.isLoading);
+  }
+  if (listEl) {
+    listEl.classList.toggle('opacity-50', state.isLoading);
+    listEl.classList.toggle('pointer-events-none', state.isLoading);
+  }
+  updateEmptyState();
+}
+
+function updateEmptyState() {
+  if (!emptyEl) return;
+  if (state.isLoading) {
+    emptyEl.classList.add('hidden');
+    return;
+  }
+  emptyEl.classList.toggle('hidden', state.recipes.length > 0);
+}
+
+function updateCount() {
+  if (!countBadge) return;
+  countBadge.textContent = String(state.recipes.length);
+}
+
+function normalizeIso(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function normalizeUserRef(raw) {
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    const id = raw.trim();
+    return id ? { id, nome: '', email: '' } : null;
+  }
+  if (typeof raw === 'object') {
+    const id = String(raw.id || raw._id || '').trim();
+    if (!id) return null;
+    const nome = typeof raw.nome === 'string' ? raw.nome.trim() : '';
+    const email = typeof raw.email === 'string' ? raw.email.trim() : '';
+    return { id, nome, email };
+  }
+  return null;
+}
+
+function normalizeRecipe(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const id = String(raw.id || raw._id || '').trim();
+  if (!id) return null;
+  const descricao = typeof raw.descricao === 'string' ? raw.descricao.trim() : '';
+  const conteudo = typeof raw.conteudo === 'string' ? raw.conteudo : '';
+  const createdAt = normalizeIso(raw.createdAt);
+  const updatedAt = normalizeIso(raw.updatedAt) || createdAt;
+  const createdBy = normalizeUserRef(raw.createdBy);
+  const updatedBy = normalizeUserRef(raw.updatedBy);
+  return { id, descricao, conteudo, createdAt, updatedAt, createdBy, updatedBy };
+}
+
+function getRecipeTime(doc) {
+  const updated = doc?.updatedAt ? new Date(doc.updatedAt).getTime() : 0;
+  if (Number.isFinite(updated) && updated > 0) {
+    return updated;
+  }
+  const created = doc?.createdAt ? new Date(doc.createdAt).getTime() : 0;
+  return Number.isFinite(created) ? created : 0;
+}
+
+function sortRecipes() {
+  state.recipes.sort((a, b) => getRecipeTime(b) - getRecipeTime(a));
+}
+
+function formatUserDisplay(user) {
+  if (!user) return '';
+  return (user.nome || user.email || '').trim();
+}
+
+function formatDateTime(value) {
+  if (!value) return '';
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  const datePart = date.toLocaleDateString('pt-BR');
+  const timePart = date.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
+  return `${datePart} às ${timePart}`;
+}
+
+function escapeHtml(value) {
+  return String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function formatCodeEditorValue(html) {
+  if (!html) return '';
+  const value = String(html)
+    .replace(/\r?\n/g, '\n')
+    .replace(/></g, '>\n<')
+    .replace(/&nbsp;/g, ' ');
+  return value.replace(/\n{3,}/g, '\n\n');
+}
+
+function setCodeEditorContent(html) {
+  if (!codeTextarea) return;
+  const value = typeof html === 'string' ? html : '';
+  codeTextarea.value = value ? formatCodeEditorValue(value) : '';
+}
+
+function getCodeEditorValue() {
+  return codeTextarea ? codeTextarea.value || '' : '';
+}
+
+function syncCodeEditorFromVisual() {
+  if (!codeTextarea) return;
+  setCodeEditorContent(getVisualEditorHtml());
+}
+
+function updateModeToggleButtons() {
+  if (!modeButtons.length) return;
+  modeButtons.forEach((button) => {
+    if (!button) return;
+    const mode = button.dataset.mode === 'code' ? 'code' : 'visual';
+    const isActive = mode === editorMode;
+    button.classList.toggle('vet-rec-mode-btn-active', isActive);
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
+}
+
+function setModeToggleDisabled(disabled) {
+  if (!modeButtons.length) return;
+  modeButtons.forEach((button) => {
+    if (!button) return;
+    button.disabled = !!disabled;
+  });
+}
+
+function updateEditorModeVisibility() {
+  const showCode = editorMode === 'code';
+  const showPreview = editorMode === 'visual' && visualMode === 'preview';
+  const showEditor = editorMode === 'visual' && visualMode !== 'preview';
+
+  if (editorContainer) {
+    editorContainer.classList.toggle('hidden', !showEditor);
+  }
+  if (previewContainer) {
+    previewContainer.classList.toggle('hidden', !showPreview);
+  }
+  if (codeTextarea) {
+    codeTextarea.classList.toggle('hidden', !showCode);
+  }
+}
+
+function focusCurrentEditor() {
+  if (state.isSaving) return;
+  if (editorMode === 'code') {
+    if (codeTextarea && !codeTextarea.disabled) {
+      const length = codeTextarea.value.length;
+      codeTextarea.focus();
+      try {
+        codeTextarea.setSelectionRange(length, length);
+      } catch (_) {
+        /* ignore selection errors */
+      }
+    }
+    return;
+  }
+  if (editorMode === 'visual' && visualMode === 'preview') {
+    if (previewContainer) {
+      if (!previewContainer.hasAttribute('tabindex')) {
+        previewContainer.setAttribute('tabindex', '-1');
+      }
+      try {
+        previewContainer.focus({ preventScroll: true });
+      } catch (_) {
+        previewContainer.focus();
+      }
+    }
+    return;
+  }
+  if (quill) {
+    quill.focus();
+    return;
+  }
+  if (fallbackTextarea && !fallbackTextarea.disabled) {
+    fallbackTextarea.focus();
+    try {
+      const length = fallbackTextarea.value.length;
+      fallbackTextarea.setSelectionRange(length, length);
+    } catch (_) {
+      /* ignore selection errors */
+    }
+  }
+}
+
+function setEditorMode(mode, { focus = true, sync = true } = {}) {
+  const target = mode === 'code' ? 'code' : 'visual';
+  if (target === editorMode) {
+    if (target === 'code' && sync) {
+      syncCodeEditorFromVisual();
+    }
+    updateEditorModeVisibility();
+    updateModeToggleButtons();
+    setEditorDisabled(state.isSaving);
+    if (focus) focusCurrentEditor();
+    return;
+  }
+
+  if (target === 'code' && sync) {
+    syncCodeEditorFromVisual();
+  }
+
+  if (target === 'visual' && sync) {
+    const codeValue = getCodeEditorValue();
+    applyVisualEditorContent(codeValue);
+    syncCodeEditorFromVisual();
+  }
+
+  editorMode = target;
+  updateEditorModeVisibility();
+  updateModeToggleButtons();
+  setEditorDisabled(state.isSaving);
+  if (focus) focusCurrentEditor();
+}
+
+function initEditorModeToggle() {
+  if (!modeToggle) return;
+  modeButtons = Array.from(modeToggle.querySelectorAll('[data-mode]')).filter(Boolean);
+  modeButtons.forEach((button) => {
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      if (state.isSaving) return;
+      const targetMode = button.dataset.mode === 'code' ? 'code' : 'visual';
+      setEditorMode(targetMode);
+    });
+  });
+  updateModeToggleButtons();
+  updateEditorModeVisibility();
+}
+
+function insertIntoCodeEditor(text) {
+  if (!codeTextarea) return;
+  const textarea = codeTextarea;
+  const value = textarea.value || '';
+  const start = typeof textarea.selectionStart === 'number' ? textarea.selectionStart : value.length;
+  const end = typeof textarea.selectionEnd === 'number' ? textarea.selectionEnd : start;
+  const before = value.slice(0, start);
+  const after = value.slice(end);
+  const scroll = textarea.scrollTop;
+  textarea.value = `${before}${text}${after}`;
+  const cursor = start + text.length;
+  try {
+    textarea.focus();
+    textarea.setSelectionRange(cursor, cursor);
+  } catch (_) {
+    /* ignore selection errors */
+  }
+  textarea.scrollTop = scroll;
+}
+
+function insertKeyword(token) {
+  const text = typeof token === 'string' ? token : String(token || '');
+  if (!text || state.isSaving) return;
+
+  if (visualMode === 'preview' && codeTextarea) {
+    if (editorMode !== 'code') {
+      setEditorMode('code');
+      if (!previewModeKeywordNoticeShown) {
+        showToastMessage(
+          'Esta receita possui um layout avançado. Inserimos a palavra-chave diretamente no modo Código.',
+          'info'
+        );
+        previewModeKeywordNoticeShown = true;
+      }
+    }
+    insertIntoCodeEditor(text);
+    return;
+  }
+
+  if (editorMode === 'code' && codeTextarea) {
+    insertIntoCodeEditor(text);
+    return;
+  }
+
+  if (quill) {
+    quill.focus();
+    let range = quill.getSelection(true);
+    if (!range) {
+      const length = Math.max(quill.getLength(), 0);
+      range = { index: length, length: 0 };
+    }
+    if (range.length > 0) {
+      quill.deleteText(range.index, range.length, 'user');
+    }
+    quill.insertText(range.index, text, 'user');
+    quill.setSelection(range.index + text.length, 0, 'silent');
+    return;
+  }
+
+  if (fallbackTextarea) {
+    const value = fallbackTextarea.value || '';
+    const start = typeof fallbackTextarea.selectionStart === 'number'
+      ? fallbackTextarea.selectionStart
+      : value.length;
+    const end = typeof fallbackTextarea.selectionEnd === 'number'
+      ? fallbackTextarea.selectionEnd
+      : start;
+    const before = value.slice(0, start);
+    const after = value.slice(end);
+    fallbackTextarea.value = `${before}${text}${after}`;
+    const cursor = start + text.length;
+    fallbackTextarea.focus();
+    fallbackTextarea.setSelectionRange(cursor, cursor);
+  }
+}
+
+function setKeywordsDisabled(disabled) {
+  if (!keywordButtons.length) return;
+  keywordButtons.forEach((button) => {
+    if (!button) return;
+    button.disabled = !!disabled;
+    button.classList.toggle('opacity-60', !!disabled);
+    button.classList.toggle('cursor-not-allowed', !!disabled);
+  });
+}
+
+function renderKeywords() {
+  if (!keywordsContainer) return;
+  keywordsContainer.innerHTML = '';
+  keywordButtons = [];
+
+  KEYWORD_GROUPS.forEach((group) => {
+    if (!group || !Array.isArray(group.items) || !group.items.length) return;
+
+    const section = document.createElement('div');
+    section.className = 'space-y-2';
+
+    const heading = document.createElement('h3');
+    heading.className = 'text-xs font-semibold uppercase tracking-wide text-primary';
+    heading.textContent = group.title;
+    section.appendChild(heading);
+
+    const list = document.createElement('div');
+    list.className = 'grid gap-2 sm:grid-cols-2';
+
+    group.items.forEach((item) => {
+      const token = typeof item?.token === 'string' ? item.token.trim() : '';
+      if (!token) return;
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.dataset.token = token;
+      button.className = 'flex w-full flex-col rounded-lg border border-primary/30 bg-white px-3 py-2 text-left text-sm text-primary shadow-sm transition hover:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-primary/40';
+      const description = typeof item.description === 'string' ? item.description : '';
+      button.innerHTML = `
+        <span class="font-mono text-xs font-semibold tracking-tight text-primary/90">${escapeHtml(token)}</span>
+        ${description ? `<span class="mt-1 text-xs text-slate-500">${escapeHtml(description)}</span>` : ''}
+      `;
+      button.addEventListener('click', () => insertKeyword(token));
+      keywordButtons.push(button);
+      list.appendChild(button);
+    });
+
+    if (list.children.length > 0) {
+      section.appendChild(list);
+      keywordsContainer.appendChild(section);
+    }
+  });
+
+  setKeywordsDisabled(state.isSaving);
+}
+
+function shouldRenderAsPreview(html) {
+  if (!html || typeof html !== 'string') return false;
+  const value = html.trim();
+  if (!value) return false;
+  if (/<style[\s>]/i.test(value)) return true;
+  if (/(class|id|style)=/i.test(value)) return true;
+  if (/<(table|section|article|aside|header|footer|nav|figure|figcaption|canvas|svg|iframe|video|audio|form|input|textarea|button|select|option|label|fieldset)/i.test(value)) {
+    return true;
+  }
+  return false;
+}
+
+function initEditor() {
+  if (!editorContainer) return;
+  if (window.Quill) {
+    quill = new window.Quill(editorContainer, {
+      theme: 'snow',
+      placeholder: 'Escreva o conteúdo da receita...',
+      modules: {
+        toolbar: [
+          [{ header: [1, 2, 3, false] }],
+          ['bold', 'italic', 'underline', 'strike'],
+          [{ color: [] }, { background: [] }],
+          [{ list: 'ordered' }, { list: 'bullet' }],
+          [{ align: [] }, { indent: '-1' }, { indent: '+1' }],
+          ['blockquote', 'code-block'],
+          ['link'],
+          ['clean'],
+        ],
+      },
+    });
+    return;
+  }
+  editorContainer.innerHTML = '';
+  const textarea = document.createElement('textarea');
+  textarea.id = 'vet-rec-editor-fallback';
+  textarea.className = 'vet-rec-textarea';
+  textarea.placeholder = 'Editor avançado indisponível. Utilize este campo para redigir a receita.';
+  editorContainer.appendChild(textarea);
+  fallbackTextarea = textarea;
+  showToastMessage('Editor avançado não pôde ser carregado. Utilizando editor simples.', 'warning');
+}
+
+function applyVisualEditorContent(html) {
+  const value = typeof html === 'string' ? html : '';
+  const trimmed = value.trim();
+  const canPreview = shouldRenderAsPreview(value) && !!previewFrame;
+
+  if (!trimmed) {
+    visualMode = 'editor';
+    previewHtml = '';
+    previewModeKeywordNoticeShown = false;
+    if (quill) {
+      quill.setText('', 'silent');
+    }
+    if (fallbackTextarea) {
+      fallbackTextarea.value = '';
+    }
+    if (previewFrame) {
+      renderPreviewFrameContent(previewFrame, '', { minHeight: 320 });
+    }
+    return;
+  }
+
+  if (canPreview) {
+    visualMode = 'preview';
+    previewModeKeywordNoticeShown = false;
+    previewHtml = renderPreviewFrameContent(previewFrame, value, { minHeight: 320 });
+    if (quill) {
+      quill.setText('', 'silent');
+    }
+    if (fallbackTextarea) {
+      fallbackTextarea.value = extractPlainText(previewHtml);
+      fallbackTextarea.disabled = true;
+    }
+    return;
+  }
+
+  visualMode = 'editor';
+  previewHtml = '';
+  previewModeKeywordNoticeShown = false;
+  if (quill) {
+    const delta = quill.clipboard.convert(value);
+    quill.setContents(delta, 'silent');
+  } else if (fallbackTextarea) {
+    fallbackTextarea.value = extractPlainText(value);
+  }
+  if (previewFrame) {
+    renderPreviewFrameContent(previewFrame, '', { minHeight: 320 });
+  }
+}
+
+function setEditorContent(html) {
+  applyVisualEditorContent(html);
+  syncCodeEditorFromVisual();
+  updateEditorModeVisibility();
+  setEditorDisabled(state.isSaving);
+}
+
+function clearEditor() {
+  setEditorContent('');
+}
+
+function getVisualEditorHtml() {
+  if (visualMode === 'preview') {
+    return previewHtml || '';
+  }
+  if (quill) {
+    return quill.root.innerHTML;
+  }
+  if (fallbackTextarea) {
+    const value = fallbackTextarea.value || '';
+    if (!value.trim()) return '';
+    return escapeHtml(value).replace(/\r?\n/g, '<br>');
+  }
+  return '';
+}
+
+function getEditorHtml() {
+  if (editorMode === 'code' && codeTextarea) {
+    return getCodeEditorValue();
+  }
+  return getVisualEditorHtml();
+}
+
+function getEditorPlainText() {
+  if (editorMode === 'code' && codeTextarea) {
+    return (codeTextarea.value || '').trim();
+  }
+  if (visualMode === 'preview') {
+    return extractPlainText(previewHtml).trim();
+  }
+  if (quill) {
+    return quill.getText().trim();
+  }
+  if (fallbackTextarea) {
+    return (fallbackTextarea.value || '').trim();
+  }
+  return '';
+}
+
+function setEditorDisabled(disabled) {
+  if (quill) {
+    const shouldEnable = !disabled && editorMode === 'visual' && visualMode !== 'preview';
+    quill.enable(shouldEnable);
+  }
+  if (fallbackTextarea) {
+    fallbackTextarea.disabled = !!disabled || editorMode === 'code' || visualMode === 'preview';
+  }
+  if (codeTextarea) {
+    codeTextarea.disabled = !!disabled || editorMode !== 'code';
+  }
+  if (previewContainer) {
+    previewContainer.classList.toggle('opacity-60', !!disabled);
+    previewContainer.classList.toggle('pointer-events-none', !!disabled);
+  }
+  setModeToggleDisabled(disabled);
+}
+
+function updateSaveButton() {
+  if (!saveBtn) return;
+  if (state.isSaving) {
+    saveBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i><span>' + (state.editingId ? 'Atualizando...' : 'Salvando...') + '</span>';
+  } else {
+    saveBtn.innerHTML = '<i class="fas fa-save"></i><span>' + (state.editingId ? 'Atualizar receita' : 'Salvar receita') + '</span>';
+  }
+}
+
+function updateFormMode() {
+  if (formTitleEl) {
+    formTitleEl.textContent = state.editingId ? 'Editar receita' : 'Nova receita';
+  }
+  if (cancelBtn) {
+    cancelBtn.classList.toggle('hidden', !state.editingId);
+  }
+  if (form) {
+    form.dataset.mode = state.editingId ? 'edit' : 'create';
+  }
+  updateSaveButton();
+}
+
+function setFormBusy(busy) {
+  state.isSaving = !!busy;
+  updateSaveButton();
+  if (saveBtn) {
+    saveBtn.disabled = state.isSaving;
+    saveBtn.classList.toggle('opacity-60', state.isSaving);
+    saveBtn.classList.toggle('cursor-not-allowed', state.isSaving);
+  }
+  if (cancelBtn) {
+    cancelBtn.disabled = state.isSaving;
+    cancelBtn.classList.toggle('opacity-60', state.isSaving);
+    cancelBtn.classList.toggle('cursor-not-allowed', state.isSaving);
+  }
+  if (descriptionInput) {
+    descriptionInput.disabled = state.isSaving;
+  }
+  setEditorDisabled(state.isSaving);
+  setKeywordsDisabled(state.isSaving);
+}
+
+function resetForm() {
+  state.editingId = null;
+  if (form) form.reset();
+  clearEditor();
+  updateFormMode();
+}
+
+function setButtonBusy(button, busy) {
+  if (!button) return;
+  if (busy) {
+    if (!button.dataset.originalHtml) {
+      button.dataset.originalHtml = button.innerHTML;
+    }
+    button.disabled = true;
+    button.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
+    button.classList.add('opacity-60', 'cursor-not-allowed');
+  } else {
+    button.disabled = false;
+    if (button.dataset.originalHtml) {
+      button.innerHTML = button.dataset.originalHtml;
+      delete button.dataset.originalHtml;
+    }
+    button.classList.remove('opacity-60', 'cursor-not-allowed');
+  }
+}
+
+function createRecipeCard(doc) {
+  if (!doc) return null;
+  const article = document.createElement('article');
+  article.className = 'vet-rec-card rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition hover:border-gray-300';
+  article.dataset.docId = doc.id;
+  if (state.editingId === doc.id) {
+    article.classList.add('ring-2', 'ring-primary/60', 'bg-primary/5');
+  }
+
+  const preview = getPreviewText(doc.conteudo);
+  const metaParts = [];
+  const author = formatUserDisplay(doc.createdBy);
+  if (author) metaParts.push(`Por ${author}`);
+  const createdText = formatDateTime(doc.createdAt);
+  if (createdText) metaParts.push(`Criado em ${createdText}`);
+  const updatedText = formatDateTime(doc.updatedAt);
+  if (updatedText && updatedText !== createdText) {
+    metaParts.push(`Atualizado em ${updatedText}`);
+  }
+  const metaHtml = metaParts.length ? `<p class="mt-1 text-xs text-gray-500">${escapeHtml(metaParts.join(' · '))}</p>` : '';
+  const previewHtml = preview ? `<p class="mt-3 text-sm text-gray-600 leading-relaxed">${escapeHtml(preview)}</p>` : '';
+  const detailsHtml = doc.conteudo
+    ? `<details class="mt-3">
+         <summary class="flex items-center gap-2 text-sm font-medium text-primary">
+           <i class="fas fa-chevron-down vet-rec-summary-icon transition-transform duration-200"></i>
+           <span>Visualizar conteúdo</span>
+         </summary>
+         <div class="mt-3 rounded-lg border border-gray-100 bg-gray-50 vet-rec-body" data-doc-body>
+           <div class="vet-rec-preview-bar">
+             <i class="fas fa-eye"></i>
+             <span>Pré-visualização da receita</span>
+           </div>
+           <iframe class="vet-rec-preview-embed" data-doc-preview title="Pré-visualização da receita" loading="lazy"></iframe>
+         </div>
+       </details>`
+    : '';
+
+  article.innerHTML = `
+    <div class="flex items-start gap-4">
+      <div class="flex-1 min-w-0">
+        <div class="flex items-start gap-3">
+          <div class="hidden h-10 w-10 place-items-center rounded-lg bg-primary/10 text-primary sm:grid">
+            <i class="fas fa-file-alt"></i>
+          </div>
+          <div class="flex-1 min-w-0">
+            <h3 class="break-words text-base font-semibold text-gray-800">${escapeHtml(doc.descricao || 'Receita')}</h3>
+            ${metaHtml}
+          </div>
+        </div>
+        ${previewHtml}
+        ${detailsHtml}
+      </div>
+      <div class="flex shrink-0 flex-col items-end gap-2">
+        <button type="button" class="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50" data-action="edit">
+          <i class="fas fa-pen"></i>
+          <span>Editar</span>
+        </button>
+        <button type="button" class="inline-flex items-center gap-2 rounded-lg border border-red-200 px-3 py-2 text-sm font-medium text-red-600 hover:bg-red-50" data-action="delete">
+          <i class="fas fa-trash"></i>
+          <span>Excluir</span>
+        </button>
+      </div>
+    </div>
+  `;
+
+  const previewFrameEl = article.querySelector('[data-doc-preview]');
+  if (previewFrameEl) {
+    renderPreviewFrameContent(previewFrameEl, doc.conteudo || '', { minHeight: 280, padding: 16, background: '#f8fafc' });
+  }
+
+  const editBtn = article.querySelector('[data-action="edit"]');
+  if (editBtn) {
+    editBtn.addEventListener('click', () => startEditing(doc.id));
+  }
+
+  const deleteBtn = article.querySelector('[data-action="delete"]');
+  if (deleteBtn) {
+    deleteBtn.addEventListener('click', () => handleDelete(doc.id, deleteBtn));
+  }
+
+  return article;
+}
+
+function renderList() {
+  if (!listEl) return;
+  listEl.innerHTML = '';
+  if (!state.recipes.length) {
+    updateEmptyState();
+    return;
+  }
+  state.recipes.forEach((doc) => {
+    const card = createRecipeCard(doc);
+    if (card) listEl.appendChild(card);
+  });
+  updateEmptyState();
+}
+
+function confirmAction(title, message, confirmText = 'Excluir') {
+  return new Promise((resolve) => {
+    if (typeof window.showModal === 'function') {
+      window.showModal({
+        title: title || 'Confirmação',
+        message: message || 'Deseja prosseguir?',
+        confirmText,
+        cancelText: 'Cancelar',
+        onConfirm: () => resolve(true),
+        onCancel: () => resolve(false),
+      });
+      return;
+    }
+    const ok = window.confirm(message || title || 'Confirmar?');
+    resolve(ok);
+  });
+}
+
+async function handleDelete(id, button) {
+  const doc = state.recipes.find((item) => item.id === id);
+  if (!doc) return;
+  const confirmed = await confirmAction(
+    'Excluir receita',
+    `Tem certeza de que deseja excluir "${doc.descricao || 'Receita'}"?`,
+    'Excluir'
+  );
+  if (!confirmed) return;
+
+  clearError();
+  setButtonBusy(button, true);
+  try {
+    const resp = await request(`/func/vet/receitas/${encodeURIComponent(id)}`, { method: 'DELETE' });
+    if (handleUnauthorized(resp)) return;
+    if (!resp.ok) {
+      const payload = await resp.json().catch(() => null);
+      throw new Error(payload?.message || 'Erro ao remover receita.');
+    }
+    state.recipes = state.recipes.filter((item) => item.id !== id);
+    if (state.editingId === id) {
+      resetForm();
+    }
+    renderList();
+    updateCount();
+    updateEmptyState();
+    showToastMessage('Receita removida com sucesso.', 'success');
+  } catch (error) {
+    console.error('Excluir receita', error);
+    showToastMessage(error.message || 'Erro ao remover receita.', 'error');
+  } finally {
+    setButtonBusy(button, false);
+  }
+}
+
+function startEditing(id) {
+  const doc = state.recipes.find((item) => item.id === id);
+  if (!doc) return;
+  state.editingId = id;
+  if (descriptionInput) {
+    descriptionInput.value = doc.descricao || '';
+  }
+  setEditorContent(doc.conteudo || '');
+  updateFormMode();
+  renderList();
+  clearError();
+  if (descriptionInput) {
+    try {
+      descriptionInput.focus({ preventScroll: true });
+    } catch (_) {
+      descriptionInput.focus();
+    }
+  }
+  if (form) {
+    const top = form.getBoundingClientRect().top + window.scrollY;
+    window.scrollTo({ top: Math.max(0, top - 100), behavior: 'smooth' });
+  }
+}
+
+async function onSubmit(event) {
+  event.preventDefault();
+  if (state.isSaving) return;
+
+  const descricao = (descriptionInput?.value || '').trim();
+  if (!descricao) {
+    showToastMessage('Informe a descrição da receita.', 'warning');
+    if (descriptionInput) descriptionInput.focus();
+    return;
+  }
+
+  const plainContent = getEditorPlainText();
+  if (!plainContent) {
+    showToastMessage('Escreva o conteúdo da receita antes de salvar.', 'warning');
+    return;
+  }
+
+  const conteudoHtml = getEditorHtml();
+  const editingId = state.editingId;
+  const wasEditing = !!editingId;
+  const payload = { descricao, conteudo: conteudoHtml };
+
+  clearError();
+  setFormBusy(true);
+  try {
+    const endpoint = wasEditing
+      ? `/func/vet/receitas/${encodeURIComponent(editingId)}`
+      : '/func/vet/receitas';
+    const method = wasEditing ? 'PUT' : 'POST';
+    const resp = await request(endpoint, {
+      method,
+      body: JSON.stringify(payload),
+    });
+    if (handleUnauthorized(resp)) return;
+    const data = await resp.json().catch(() => null);
+    if (!resp.ok) {
+      throw new Error(data?.message || 'Erro ao salvar receita.');
+    }
+    const doc = normalizeRecipe(data);
+    if (!doc) {
+      throw new Error('Resposta inesperada do servidor.');
+    }
+    const existingIndex = state.recipes.findIndex((item) => item.id === doc.id);
+    if (existingIndex >= 0) {
+      state.recipes.splice(existingIndex, 1, doc);
+    } else {
+      state.recipes.unshift(doc);
+    }
+    sortRecipes();
+    resetForm();
+    renderList();
+    updateCount();
+    updateEmptyState();
+    showToastMessage(wasEditing ? 'Receita atualizada com sucesso.' : 'Receita salva com sucesso.', 'success');
+  } catch (error) {
+    console.error('Salvar receita', error);
+    showToastMessage(error.message || 'Erro ao salvar receita.', 'error');
+  } finally {
+    setFormBusy(false);
+  }
+}
+
+async function loadRecipes() {
+  clearError();
+  setListLoading(true);
+  try {
+    const resp = await request('/func/vet/receitas');
+    if (handleUnauthorized(resp)) return;
+    const payload = await resp.json().catch(() => null);
+    if (!resp.ok) {
+      throw new Error(payload?.message || 'Erro ao listar receitas.');
+    }
+    const docs = Array.isArray(payload) ? payload : [];
+    state.recipes = docs.map(normalizeRecipe).filter(Boolean);
+    sortRecipes();
+    renderList();
+    updateCount();
+    updateEmptyState();
+  } catch (error) {
+    console.error('Listar receitas', error);
+    state.recipes = [];
+    renderList();
+    updateCount();
+    updateEmptyState();
+    showError(error.message || 'Erro ao carregar receitas.');
+  } finally {
+    setListLoading(false);
+  }
+}
+
+function init() {
+  form = document.getElementById('vet-rec-form');
+  descriptionInput = document.getElementById('vet-rec-descricao');
+  editorContainer = document.getElementById('vet-rec-editor');
+  formTitleEl = document.getElementById('vet-rec-form-title');
+  saveBtn = document.getElementById('vet-rec-save');
+  cancelBtn = document.getElementById('vet-rec-cancel-edit');
+  listEl = document.getElementById('vet-rec-list');
+  emptyEl = document.getElementById('vet-rec-empty');
+  loadingEl = document.getElementById('vet-rec-loading');
+  errorEl = document.getElementById('vet-rec-error');
+  countBadge = document.getElementById('vet-rec-count');
+  keywordsContainer = document.getElementById('vet-rec-keywords');
+  modeToggle = document.getElementById('vet-rec-mode-toggle');
+  codeTextarea = document.getElementById('vet-rec-code');
+  previewContainer = document.getElementById('vet-rec-preview');
+  previewFrame = document.getElementById('vet-rec-preview-frame');
+  if (previewFrame) {
+    previewFrame.setAttribute('loading', 'lazy');
+  }
+
+  if (!form || !descriptionInput || !editorContainer || !listEl) {
+    console.error('Elementos essenciais não encontrados na página de receitas.');
+    return;
+  }
+
+  updateFormMode();
+  updateEmptyState();
+  initEditor();
+  syncCodeEditorFromVisual();
+  initEditorModeToggle();
+  setEditorMode(editorMode, { focus: false, sync: true });
+  setEditorDisabled(state.isSaving);
+  renderKeywords();
+
+  form.addEventListener('submit', onSubmit);
+  if (cancelBtn) {
+    cancelBtn.addEventListener('click', () => {
+      resetForm();
+      renderList();
+      updateEmptyState();
+    });
+  }
+
+  loadRecipes();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/servidor/models/VetRecipe.js
+++ b/servidor/models/VetRecipe.js
@@ -1,0 +1,30 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const VetRecipeSchema = new Schema({
+  descricao: {
+    type: String,
+    required: true,
+    trim: true,
+    maxlength: 180,
+  },
+  conteudo: {
+    type: String,
+    default: '',
+  },
+  createdBy: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+  },
+  updatedBy: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    default: null,
+  },
+}, { timestamps: true });
+
+VetRecipeSchema.index({ descricao: 1, createdAt: -1 });
+
+module.exports = mongoose.model('VetRecipe', VetRecipeSchema);

--- a/servidor/models/VetRecipeRecord.js
+++ b/servidor/models/VetRecipeRecord.js
@@ -1,0 +1,62 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const VetRecipeRecordSchema = new Schema({
+  cliente: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: true,
+    index: true,
+  },
+  pet: {
+    type: Schema.Types.ObjectId,
+    ref: 'Pet',
+    required: true,
+    index: true,
+  },
+  receita: {
+    type: Schema.Types.ObjectId,
+    ref: 'VetRecipe',
+    default: null,
+  },
+  appointment: {
+    type: Schema.Types.ObjectId,
+    ref: 'Appointment',
+    default: null,
+  },
+  descricao: {
+    type: String,
+    trim: true,
+    default: '',
+    maxlength: 180,
+  },
+  conteudo: {
+    type: String,
+    required: true,
+  },
+  conteudoOriginal: {
+    type: String,
+    default: '',
+  },
+  preview: {
+    type: String,
+    default: '',
+    maxlength: 2000,
+  },
+  createdBy: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    default: null,
+  },
+  updatedBy: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    default: null,
+  },
+}, { timestamps: true });
+
+VetRecipeRecordSchema.index({ cliente: 1, pet: 1, createdAt: -1 });
+VetRecipeRecordSchema.index({ appointment: 1 });
+
+module.exports = mongoose.model('VetRecipeRecord', VetRecipeRecordSchema);


### PR DESCRIPTION
## Summary
- duplicar a página de receitas dos funcionários com o mesmo layout avançado dos documentos
- adicionar módulo JavaScript para listar, criar, editar e excluir receitas usando as rotas /func/vet/receitas
- atualizar o menu flutuante do veterinário para marcar Receitas como disponível

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cda4b40b18832383fc126c6487a7db