### PR TITLE
Permitir edição de anexos através do modal

### DIFF
--- a/scripts/funcionarios/vet/ficha-clinica/consultas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/consultas.js
@@ -26,6 +26,7 @@ import {
 } from './core.js';
 import { openDocumentPrintWindow } from '../document-utils.js';
 import { openObservacaoModal } from './observacoes.js';
+import { openAnexoModal } from './anexos.js';
 
 function normalizeConsultaRecord(raw) {
   if (!raw || typeof raw !== 'object') return null;
@@ -604,6 +605,31 @@ function createAnexoCard(anexo) {
     }
     if (hasAction) {
       item.appendChild(actions);
+    }
+  });
+
+  const openModal = () => {
+    openAnexoModal({ anexo });
+  };
+
+  card.classList.add('cursor-pointer', 'transition', 'hover:border-indigo-300', 'hover:shadow-md');
+  card.setAttribute('role', 'button');
+  card.setAttribute('tabindex', '0');
+  card.setAttribute('aria-label', 'Editar anexos');
+
+  card.addEventListener('click', (event) => {
+    if (event.defaultPrevented) return;
+    const interactive = event.target.closest('a, button');
+    if (interactive) return;
+    event.preventDefault();
+    openModal();
+  });
+
+  card.addEventListener('keydown', (event) => {
+    if (event.target !== card) return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      openModal();
     }
   });
 

--- a/scripts/funcionarios/vet/ficha-clinica/consultas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/consultas.js
@@ -27,6 +27,9 @@ import {
 import { openDocumentPrintWindow } from '../document-utils.js';
 import { openObservacaoModal } from './observacoes.js';
 import { openAnexoModal } from './anexos.js';
+import { openExameModal } from './exames.js';
+import { openPesoModal } from './pesos.js';
+import { openDocumentoModal } from './documentos.js';
 
 function normalizeConsultaRecord(raw) {
   if (!raw || typeof raw !== 'object') return null;
@@ -739,6 +742,31 @@ function createDocumentoRegistroCard(entry) {
 
   card.appendChild(removeBtn);
 
+  const openModal = () => {
+    openDocumentoModal({ documentoRegistro: entry });
+  };
+
+  card.classList.add('cursor-pointer', 'transition', 'hover:border-emerald-300', 'hover:shadow-md');
+  card.setAttribute('role', 'button');
+  card.setAttribute('tabindex', '0');
+  card.setAttribute('aria-label', 'Editar documento salvo');
+
+  card.addEventListener('click', (event) => {
+    if (event.defaultPrevented) return;
+    const interactive = event.target.closest('button, a');
+    if (interactive) return;
+    event.preventDefault();
+    openModal();
+  });
+
+  card.addEventListener('keydown', (event) => {
+    if (event.target !== card) return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      openModal();
+    }
+  });
+
   return card;
 }
 
@@ -1295,10 +1323,36 @@ function createExameCard(exame) {
     card.appendChild(attachmentsSection);
   }
 
+  const openModal = () => {
+    openExameModal({ exame });
+  };
+
+  card.classList.add('cursor-pointer', 'transition', 'hover:border-rose-300', 'hover:shadow-md');
+  card.setAttribute('role', 'button');
+  card.setAttribute('tabindex', '0');
+  card.setAttribute('aria-label', 'Editar registro de exame');
+
+  card.addEventListener('click', (event) => {
+    if (event.defaultPrevented) return;
+    const interactive = event.target.closest('a, button');
+    if (interactive) return;
+    event.preventDefault();
+    openModal();
+  });
+
+  card.addEventListener('keydown', (event) => {
+    if (event.target !== card) return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      openModal();
+    }
+  });
+
   return card;
 }
 
-function createPesoCard(peso, baseline, previous) {
+function createPesoCard(peso, baseline, previous, options = {}) {
+  const { isLatest = false } = options || {};
   if (!peso) return null;
 
   const card = document.createElement('article');
@@ -1424,6 +1478,33 @@ function createPesoCard(peso, baseline, previous) {
       }
       details.appendChild(diffPrevEl);
     }
+  }
+
+  if (!peso.isInitial && isLatest) {
+    const openModal = () => {
+      openPesoModal({ peso });
+    };
+
+    card.classList.add('cursor-pointer', 'transition', 'hover:border-orange-300', 'hover:shadow-md');
+    card.setAttribute('role', 'button');
+    card.setAttribute('tabindex', '0');
+    card.setAttribute('aria-label', 'Editar atualização de peso');
+
+    card.addEventListener('click', (event) => {
+      if (event.defaultPrevented) return;
+      const interactive = event.target.closest('button');
+      if (interactive) return;
+      event.preventDefault();
+      openModal();
+    });
+
+    card.addEventListener('keydown', (event) => {
+      if (event.target !== card) return;
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        openModal();
+      }
+    });
   }
 
   return card;
@@ -2044,7 +2125,7 @@ export function updateConsultaAgendaCard() {
 
     orderedVetPesos.forEach((peso, index) => {
       const previous = orderedVetPesos[index + 1] || null;
-      const card = createPesoCard(peso, baselinePeso, previous);
+      const card = createPesoCard(peso, baselinePeso, previous, { isLatest: index === 0 });
       if (card) pushRestCard(card);
     });
   } else if (isLoadingPesos) {

--- a/scripts/funcionarios/vet/ficha-clinica/consultas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/consultas.js
@@ -30,6 +30,7 @@ import { openAnexoModal } from './anexos.js';
 import { openExameModal } from './exames.js';
 import { openPesoModal } from './pesos.js';
 import { openDocumentoModal } from './documentos.js';
+import { openVacinaModal } from './vacinas.js';
 
 function normalizeConsultaRecord(raw) {
   if (!raw || typeof raw !== 'object') return null;
@@ -1115,6 +1116,39 @@ function createVacinaCard(vacina) {
   grid.appendChild(createVacinaDetail('Data de aplicação', aplicacao || '—'));
   const renovacao = vacina.renovacao ? formatDateDisplay(vacina.renovacao) : '';
   grid.appendChild(createVacinaDetail('Data de renovação', renovacao || '—'));
+
+  const openModal = () => {
+    openVacinaModal({ vacina });
+  };
+
+  card.classList.add(
+    'cursor-pointer',
+    'transition',
+    'hover:border-emerald-300',
+    'hover:shadow-md',
+    'focus-visible:outline-none',
+    'focus-visible:ring-2',
+    'focus-visible:ring-emerald-300',
+  );
+  card.setAttribute('role', 'button');
+  card.setAttribute('tabindex', '0');
+  card.setAttribute('aria-label', 'Editar aplicação de vacina');
+
+  card.addEventListener('click', (event) => {
+    if (event.defaultPrevented) return;
+    const interactive = event.target.closest('a, button');
+    if (interactive) return;
+    event.preventDefault();
+    openModal();
+  });
+
+  card.addEventListener('keydown', (event) => {
+    if (event.target !== card) return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      openModal();
+    }
+  });
 
   return card;
 }

--- a/scripts/funcionarios/vet/ficha-clinica/core.js
+++ b/scripts/funcionarios/vet/ficha-clinica/core.js
@@ -193,6 +193,11 @@ export const exameModal = {
   isSubmitting: false,
   keydownHandler: null,
   searchAbortController: null,
+  mode: 'create',
+  editingId: null,
+  editingRecord: null,
+  existingFiles: [],
+  removedFileIds: [],
 };
 
 export const anexoModal = {
@@ -232,6 +237,7 @@ export const pesoModal = {
   form: null,
   submitBtn: null,
   submitBtnOriginalHtml: '',
+  submitBtnEditHtml: '',
   cancelBtn: null,
   closeBtn: null,
   input: null,
@@ -241,6 +247,9 @@ export const pesoModal = {
   summary: null,
   isSubmitting: false,
   keydownHandler: null,
+  mode: 'create',
+  editingId: null,
+  editingRecord: null,
 };
 
 export const STORAGE_KEYS = {

--- a/scripts/funcionarios/vet/ficha-clinica/core.js
+++ b/scripts/funcionarios/vet/ficha-clinica/core.js
@@ -165,6 +165,11 @@ export const vacinaModal = {
   isSubmitting: false,
   keydownHandler: null,
   searchAbortController: null,
+  mode: 'create',
+  editingId: null,
+  editingRecord: null,
+  submitBtnOriginalText: '',
+  submitBtnEditText: '',
 };
 
 export const exameModal = {

--- a/src/output.css
+++ b/src/output.css
@@ -17,6 +17,7 @@
     --color-orange-50: oklch(98% 0.016 73.684);
     --color-orange-100: oklch(95.4% 0.038 75.164);
     --color-orange-200: oklch(90.1% 0.076 70.697);
+    --color-orange-300: oklch(83.7% 0.128 66.29);
     --color-orange-500: oklch(70.5% 0.213 47.604);
     --color-orange-600: oklch(64.6% 0.222 41.116);
     --color-orange-700: oklch(55.3% 0.195 38.402);
@@ -415,9 +416,6 @@
   .left-0 {
     left: calc(var(--spacing) * 0);
   }
-  .left-1 {
-    left: calc(var(--spacing) * 1);
-  }
   .left-1\/2 {
     left: calc(1/2 * 100%);
   }
@@ -510,9 +508,6 @@
   }
   .\!mt-6 {
     margin-top: calc(var(--spacing) * 6) !important;
-  }
-  .mt-0 {
-    margin-top: calc(var(--spacing) * 0);
   }
   .mt-0\.5 {
     margin-top: calc(var(--spacing) * 0.5);
@@ -733,6 +728,9 @@
   .h-full {
     height: 100%;
   }
+  .h-px {
+    height: 1px;
+  }
   .max-h-40 {
     max-height: calc(var(--spacing) * 40);
   }
@@ -778,9 +776,6 @@
   .min-h-\[64px\] {
     min-height: 64px;
   }
-  .min-h-\[120px\] {
-    min-height: 120px;
-  }
   .min-h-\[140px\] {
     min-height: 140px;
   }
@@ -798,9 +793,6 @@
   }
   .w-0 {
     width: calc(var(--spacing) * 0);
-  }
-  .w-1 {
-    width: calc(var(--spacing) * 1);
   }
   .w-1\/2 {
     width: calc(1/2 * 100%);
@@ -979,10 +971,6 @@
   .border-collapse {
     border-collapse: collapse;
   }
-  .-translate-x-1 {
-    --tw-translate-x: calc(var(--spacing) * -1);
-    translate: var(--tw-translate-x) var(--tw-translate-y);
-  }
   .-translate-x-1\/2 {
     --tw-translate-x: calc(calc(1/2 * 100%) * -1);
     translate: var(--tw-translate-x) var(--tw-translate-y);
@@ -997,10 +985,6 @@
   }
   .translate-x-full {
     --tw-translate-x: 100%;
-    translate: var(--tw-translate-x) var(--tw-translate-y);
-  }
-  .-translate-y-1 {
-    --tw-translate-y: calc(var(--spacing) * -1);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .-translate-y-1\/2 {
@@ -1223,9 +1207,6 @@
       margin-inline-end: calc(calc(var(--spacing) * 6) * calc(1 - var(--tw-space-x-reverse)));
     }
   }
-  .gap-y-0 {
-    row-gap: calc(var(--spacing) * 0);
-  }
   .gap-y-0\.5 {
     row-gap: calc(var(--spacing) * 0.5);
   }
@@ -1390,9 +1371,6 @@
   .border-blue-500 {
     border-color: var(--color-blue-500);
   }
-  .border-emerald-100 {
-    border-color: var(--color-emerald-100);
-  }
   .border-emerald-200 {
     border-color: var(--color-emerald-200);
   }
@@ -1425,9 +1403,6 @@
   }
   .border-indigo-300 {
     border-color: var(--color-indigo-300);
-  }
-  .border-indigo-400 {
-    border-color: var(--color-indigo-400);
   }
   .border-indigo-500 {
     border-color: var(--color-indigo-500);
@@ -1576,12 +1551,6 @@
   .bg-indigo-50 {
     background-color: var(--color-indigo-50);
   }
-  .bg-indigo-50\/60 {
-    background-color: color-mix(in srgb, oklch(96.2% 0.018 272.314) 60%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-indigo-50) 60%, transparent);
-    }
-  }
   .bg-indigo-50\/70 {
     background-color: color-mix(in srgb, oklch(96.2% 0.018 272.314) 70%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -1649,6 +1618,12 @@
     background-color: color-mix(in srgb, oklch(96.9% 0.015 12.422) 70%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-rose-50) 70%, transparent);
+    }
+  }
+  .bg-rose-50\/80 {
+    background-color: color-mix(in srgb, oklch(96.9% 0.015 12.422) 80%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-rose-50) 80%, transparent);
     }
   }
   .bg-rose-100 {
@@ -1768,9 +1743,6 @@
   .px-6 {
     padding-inline: calc(var(--spacing) * 6);
   }
-  .py-0 {
-    padding-block: calc(var(--spacing) * 0);
-  }
   .py-0\.5 {
     padding-block: calc(var(--spacing) * 0.5);
   }
@@ -1809,9 +1781,6 @@
   }
   .py-\[1px\] {
     padding-block: 1px;
-  }
-  .pt-0 {
-    padding-top: calc(var(--spacing) * 0);
   }
   .pt-0\.5 {
     padding-top: calc(var(--spacing) * 0.5);
@@ -2086,9 +2055,6 @@
   .text-green-800 {
     color: var(--color-green-800);
   }
-  .text-indigo-400 {
-    color: var(--color-indigo-400);
-  }
   .text-indigo-500 {
     color: var(--color-indigo-500);
   }
@@ -2262,9 +2228,6 @@
   .ring-amber-100 {
     --tw-ring-color: var(--color-amber-100);
   }
-  .ring-black {
-    --tw-ring-color: var(--color-black);
-  }
   .ring-black\/5 {
     --tw-ring-color: color-mix(in srgb, #000 5%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -2298,9 +2261,6 @@
   .ring-orange-100 {
     --tw-ring-color: var(--color-orange-100);
   }
-  .ring-primary {
-    --tw-ring-color: var(--color-primary);
-  }
   .ring-primary\/60 {
     --tw-ring-color: color-mix(in srgb, #7A9A55 60%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -2331,10 +2291,6 @@
   }
   .backdrop-blur-sm {
     --tw-backdrop-blur: blur(var(--blur-sm));
-    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
-    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
-  }
-  .backdrop-filter {
     -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
     backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }
@@ -2578,6 +2534,13 @@
       }
     }
   }
+  .hover\:border-emerald-300 {
+    &:hover {
+      @media (hover: hover) {
+        border-color: var(--color-emerald-300);
+      }
+    }
+  }
   .hover\:border-gray-300 {
     &:hover {
       @media (hover: hover) {
@@ -2592,10 +2555,17 @@
       }
     }
   }
-  .hover\:border-indigo-400 {
+  .hover\:border-indigo-300 {
     &:hover {
       @media (hover: hover) {
-        border-color: var(--color-indigo-400);
+        border-color: var(--color-indigo-300);
+      }
+    }
+  }
+  .hover\:border-orange-300 {
+    &:hover {
+      @media (hover: hover) {
+        border-color: var(--color-orange-300);
       }
     }
   }
@@ -2613,6 +2583,13 @@
         @supports (color: color-mix(in lab, red, red)) {
           border-color: color-mix(in oklab, var(--color-primary) 50%, transparent);
         }
+      }
+    }
+  }
+  .hover\:border-rose-300 {
+    &:hover {
+      @media (hover: hover) {
+        border-color: var(--color-rose-300);
       }
     }
   }
@@ -2728,6 +2705,13 @@
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-green-700);
+      }
+    }
+  }
+  .hover\:bg-indigo-50 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-indigo-50);
       }
     }
   }
@@ -2956,13 +2940,6 @@
       }
     }
   }
-  .hover\:text-indigo-600 {
-    &:hover {
-      @media (hover: hover) {
-        color: var(--color-indigo-600);
-      }
-    }
-  }
   .hover\:text-primary {
     &:hover {
       @media (hover: hover) {
@@ -2998,13 +2975,6 @@
     &:hover {
       @media (hover: hover) {
         color: var(--color-red-800);
-      }
-    }
-  }
-  .hover\:text-rose-700 {
-    &:hover {
-      @media (hover: hover) {
-        color: var(--color-rose-700);
       }
     }
   }
@@ -3055,6 +3025,14 @@
     &:hover {
       @media (hover: hover) {
         --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 4px 6px -4px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+        box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+      }
+    }
+  }
+  .hover\:shadow-md {
+    &:hover {
+      @media (hover: hover) {
+        --tw-shadow: 0 4px 6px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 2px 4px -2px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
         box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
       }
     }
@@ -3244,6 +3222,23 @@
       outline-style: none;
     }
   }
+  .focus-visible\:ring-2 {
+    &:focus-visible {
+      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+  .focus-visible\:ring-emerald-300 {
+    &:focus-visible {
+      --tw-ring-color: var(--color-emerald-300);
+    }
+  }
+  .focus-visible\:outline-none {
+    &:focus-visible {
+      --tw-outline-style: none;
+      outline-style: none;
+    }
+  }
   .disabled\:cursor-not-allowed {
     &:disabled {
       cursor: not-allowed;
@@ -3257,11 +3252,6 @@
   .disabled\:opacity-50 {
     &:disabled {
       opacity: 50%;
-    }
-  }
-  .disabled\:opacity-60 {
-    &:disabled {
-      opacity: 60%;
     }
   }
   .disabled\:opacity-75 {


### PR DESCRIPTION
## Resumo
- Permite reabrir o modal de anexos carregando arquivos existentes para edição, inclusive com marcação e envio de remoções ao backend.
- Ajusta o card de anexos na ficha clínica para abrir o modal ao clique, mantendo acessibilidade e evitando conflito com botões/links internos.

## Testes
- Não aplicável

------
https://chatgpt.com/codex/tasks/task_e_68ce10be35008323ae270bbd9b53d9c2