### PR TITLE
Melhora layout do documento assinado na ficha clínica

### DIFF
--- a/src/output.css
+++ b/src/output.css
@@ -52,6 +52,7 @@
     --color-emerald-500: oklch(69.6% 0.17 162.48);
     --color-emerald-600: oklch(59.6% 0.145 163.225);
     --color-emerald-700: oklch(50.8% 0.118 165.612);
+    --color-emerald-800: oklch(43.2% 0.095 166.913);
     --color-sky-50: oklch(97.7% 0.013 236.62);
     --color-sky-100: oklch(95.1% 0.026 236.824);
     --color-sky-200: oklch(90.1% 0.058 230.902);
@@ -668,6 +669,9 @@
   }
   .h-10 {
     height: calc(var(--spacing) * 10);
+  }
+  .h-11 {
+    height: calc(var(--spacing) * 11);
   }
   .h-12 {
     height: calc(var(--spacing) * 12);
@@ -2035,6 +2039,9 @@
   }
   .text-emerald-700 {
     color: var(--color-emerald-700);
+  }
+  .text-emerald-800 {
+    color: var(--color-emerald-800);
   }
   .text-gray-300 {
     color: var(--color-gray-300);


### PR DESCRIPTION
## Resumo
- reorganiza o cartão de documento assinado para destacar nome, metadados e ações de forma mais limpa
- adiciona estilos utilitários necessários no CSS gerado para suportar os novos elementos

## Testes
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceb8f4820c8323a581883a37680c13