### PR TITLE
Ensure vet uploads remain under Ficha Clinica root folder

### DIFF
--- a/servidor/routes/funcVet.js
+++ b/servidor/routes/funcVet.js
@@ -1418,7 +1418,13 @@ router.post(
         ) || sanitizeFolderSegment(petFallbackSegment) || petFallbackSegment;
 
       const typeFolderName = sanitizeFolderSegment('Documentos') || 'Documentos';
-      const folderPath = [tutorFolderName, petFolderName, appointmentFolderName, typeFolderName];
+      const folderPath = [
+        sanitizeFolderSegment('Ficha Clinica') || 'Ficha Clinica',
+        tutorFolderName,
+        petFolderName,
+        appointmentFolderName,
+        typeFolderName,
+      ];
 
       const providedName = typeof req.body.nome === 'string' ? req.body.nome : '';
       const sanitizedProvided = sanitizeFileName(providedName);
@@ -1814,7 +1820,13 @@ router.post(
         ) || sanitizeFolderSegment(petFallbackSegment) || petFallbackSegment;
 
       const typeFolderName = sanitizeFolderSegment('Receitas') || 'Receitas';
-      const folderPath = [tutorFolderName, petFolderName, appointmentFolderName, typeFolderName];
+      const folderPath = [
+        sanitizeFolderSegment('Ficha Clinica') || 'Ficha Clinica',
+        tutorFolderName,
+        petFolderName,
+        appointmentFolderName,
+        typeFolderName,
+      ];
 
       const providedName = typeof req.body.nome === 'string' ? req.body.nome : '';
       const sanitizedProvided = sanitizeFileName(providedName);
@@ -2403,7 +2415,13 @@ router.post('/vet/anexos', authMiddleware, requireStaff, handleAnexoUpload, asyn
 
     const typeFolderName = sanitizeFolderSegment(isExameAttachment ? 'Exame' : 'Anexo')
       || (isExameAttachment ? 'Exame' : 'Anexo');
-    const folderPath = [tutorFolderName, petFolderName, appointmentFolderName, typeFolderName];
+    const folderPath = [
+      sanitizeFolderSegment('Ficha Clinica') || 'Ficha Clinica',
+      tutorFolderName,
+      petFolderName,
+      appointmentFolderName,
+      typeFolderName,
+    ];
 
     const rawNames = req.body['nomes[]'];
     const providedNames = Array.isArray(rawNames)
@@ -2633,7 +2651,13 @@ router.put('/vet/anexos/:id', authMiddleware, requireStaff, handleAnexoUpload, a
     const isExameAttachment = observacaoRaw.startsWith(EXAME_ATTACHMENT_OBSERVACAO_PREFIX);
     const typeFolderName = sanitizeFolderSegment(isExameAttachment ? 'Exame' : 'Anexo')
       || (isExameAttachment ? 'Exame' : 'Anexo');
-    const folderPath = [tutorFolderName, petFolderName, appointmentFolderName, typeFolderName];
+    const folderPath = [
+      sanitizeFolderSegment('Ficha Clinica') || 'Ficha Clinica',
+      tutorFolderName,
+      petFolderName,
+      appointmentFolderName,
+      typeFolderName,
+    ];
 
     const rawNames = req.body['nomes[]'];
     const providedNames = Array.isArray(rawNames)


### PR DESCRIPTION
## Summary
- prefix all vet upload folder paths with the sanitized "Ficha Clinica" segment so Google Drive uploads stay under the correct root even when the base folder id changes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cee4ba237c83239eba3eedf85b2c67