### PR TITLE
Implement atendimento finalization history workflow

### DIFF
--- a/pages/funcionarios/vet-ficha-clinica.html
+++ b/pages/funcionarios/vet-ficha-clinica.html
@@ -95,9 +95,9 @@
                                 class="px-3 py-1.5 rounded-md text-[13px] bg-sky-600 text-white">Consulta</button>
                         </div>
                         <div class="ml-auto flex items-center gap-2">
-                            <button
+                            <button id="vet-clear-consulta"
                                 class="px-3 py-1.5 rounded-md text-[13px] text-red-600 border border-red-200 hover:bg-red-50">Limpar</button>
-                            <button
+                            <button id="vet-finalizar-atendimento"
                                 class="px-3 py-1.5 rounded-md text-[13px] bg-emerald-600 text-white hover:bg-emerald-700">Finalizar
                                 atendimento</button>
                         </div>
@@ -105,10 +105,14 @@
 
                     <!-- Corpo com “quadro” e coluna LOG à direita -->
                     <div class="relative">
-                        <div class="p-4 lg:p-6 min-h-[520px] bg-gray-50 rounded-b-xl">
+                        <div class="p-4 lg:p-6 min-h-[520px] bg-gray-50 rounded-b-xl space-y-4">
                             <div id="vet-consulta-area"
                                 class="h-[420px] rounded-lg bg-white border border-dashed border-gray-300 flex flex-col items-center justify-center text-sm text-gray-500 text-center px-6">
                                 Selecione um agendamento na agenda para carregar os serviços veterinários.
+                            </div>
+                            <div id="vet-historico-area"
+                                class="hidden h-[420px] rounded-lg bg-white border border-dashed border-gray-300 flex flex-col items-center justify-center text-sm text-gray-500 text-center px-6">
+                                Nenhum atendimento finalizado para exibir.
                             </div>
                         </div>
 

--- a/scripts/funcionarios/vet/ficha-clinica/atendimento.js
+++ b/scripts/funcionarios/vet/ficha-clinica/atendimento.js
@@ -1,0 +1,310 @@
+// Atendimento actions for finalizar and reabrir fluxos
+import {
+  state,
+  els,
+  api,
+  notify,
+  persistAgendaContext,
+  normalizeId,
+  VACINA_STORAGE_PREFIX,
+  ANEXO_STORAGE_PREFIX,
+  EXAME_STORAGE_PREFIX,
+  OBSERVACAO_STORAGE_PREFIX,
+} from './core.js';
+import { getConsultasKey, updateConsultaAgendaCard, updateMainTabLayout } from './consultas.js';
+import {
+  addHistoricoEntry,
+  removeHistoricoEntry,
+  renderHistoricoArea,
+  getHistoricoEntryById,
+  setHistoricoReopenHandler,
+  setActiveMainTab,
+} from './historico.js';
+
+function deepClone(value) {
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return null;
+  }
+}
+
+function buildHistoricoEntryFromState() {
+  const clienteId = normalizeId(state.selectedCliente?._id);
+  const petId = normalizeId(state.selectedPetId);
+  const appointmentId = normalizeId(state.agendaContext?.appointmentId);
+  if (!(clienteId && petId && appointmentId)) return null;
+  const now = new Date().toISOString();
+  return {
+    id: `hist-${Date.now()}-${Math.floor(Math.random() * 1e6)}`,
+    clienteId,
+    petId,
+    appointmentId,
+    finalizadoEm: now,
+    agenda: deepClone(state.agendaContext) || {},
+    consultas: deepClone(state.consultas) || [],
+    vacinas: deepClone(state.vacinas) || [],
+    anexos: deepClone(state.anexos) || [],
+    exames: deepClone(state.exames) || [],
+    pesos: deepClone(state.pesos) || [],
+    observacoes: deepClone(state.observacoes) || [],
+    documentos: deepClone(state.documentos) || [],
+    receitas: deepClone(state.receitas) || [],
+  };
+}
+
+function clearLocalStoredDataForSelection(clienteId, petId) {
+  const base = getConsultasKey(clienteId, petId);
+  if (!base) return;
+  try {
+    localStorage.removeItem(`${VACINA_STORAGE_PREFIX}${base}`);
+  } catch {}
+  try {
+    localStorage.removeItem(`${ANEXO_STORAGE_PREFIX}${base}`);
+  } catch {}
+  try {
+    localStorage.removeItem(`${EXAME_STORAGE_PREFIX}${base}`);
+  } catch {}
+  try {
+    localStorage.removeItem(`${OBSERVACAO_STORAGE_PREFIX}${base}`);
+  } catch {}
+}
+
+function persistLocalDataForSelection(clienteId, petId) {
+  const base = getConsultasKey(clienteId, petId);
+  if (!base) return;
+  try {
+    if (Array.isArray(state.vacinas) && state.vacinas.length) {
+      localStorage.setItem(`${VACINA_STORAGE_PREFIX}${base}`, JSON.stringify(state.vacinas));
+    } else {
+      localStorage.removeItem(`${VACINA_STORAGE_PREFIX}${base}`);
+    }
+  } catch {}
+  try {
+    if (Array.isArray(state.anexos) && state.anexos.length) {
+      localStorage.setItem(`${ANEXO_STORAGE_PREFIX}${base}`, JSON.stringify(state.anexos));
+    } else {
+      localStorage.removeItem(`${ANEXO_STORAGE_PREFIX}${base}`);
+    }
+  } catch {}
+  try {
+    if (Array.isArray(state.exames) && state.exames.length) {
+      localStorage.setItem(`${EXAME_STORAGE_PREFIX}${base}`, JSON.stringify(state.exames));
+    } else {
+      localStorage.removeItem(`${EXAME_STORAGE_PREFIX}${base}`);
+    }
+  } catch {}
+  try {
+    if (Array.isArray(state.observacoes) && state.observacoes.length) {
+      localStorage.setItem(`${OBSERVACAO_STORAGE_PREFIX}${base}`, JSON.stringify(state.observacoes));
+    } else {
+      localStorage.removeItem(`${OBSERVACAO_STORAGE_PREFIX}${base}`);
+    }
+  } catch {}
+}
+
+function resetConsultaState() {
+  state.consultas = [];
+  state.consultasLoading = false;
+  state.consultasLoadKey = null;
+  state.vacinas = [];
+  state.anexos = [];
+  state.exames = [];
+  state.pesos = [];
+  state.observacoes = [];
+  state.documentos = [];
+  state.receitas = [];
+}
+
+let isProcessingFinalizacao = false;
+
+export async function finalizarAtendimento() {
+  if (isProcessingFinalizacao) return;
+  const clienteId = normalizeId(state.selectedCliente?._id);
+  const petId = normalizeId(state.selectedPetId);
+  const appointmentId = normalizeId(state.agendaContext?.appointmentId);
+  if (!(clienteId && petId)) {
+    notify('Selecione um tutor e um pet antes de finalizar o atendimento.', 'warning');
+    return;
+  }
+  if (!appointmentId) {
+    notify('Abra a ficha pela agenda para finalizar o atendimento.', 'warning');
+    return;
+  }
+
+  const entry = buildHistoricoEntryFromState();
+  if (!entry) {
+    notify('Não foi possível coletar os dados do atendimento atual.', 'error');
+    return;
+  }
+
+  let confirmed = true;
+  if (typeof window !== 'undefined' && typeof window.confirm === 'function') {
+    confirmed = window.confirm('Finalizar o atendimento? Os registros serão movidos para o histórico.');
+  }
+  if (!confirmed) return;
+
+  isProcessingFinalizacao = true;
+  if (els.finalizarAtendimentoBtn) {
+    els.finalizarAtendimentoBtn.disabled = true;
+    els.finalizarAtendimentoBtn.classList.add('opacity-60', 'cursor-not-allowed');
+  }
+
+  try {
+    const response = await api(`/func/agendamentos/${appointmentId}`, {
+      method: 'PUT',
+      body: JSON.stringify({ status: 'finalizado' }),
+    });
+    const data = await response.json().catch(() => (response.ok ? {} : {}));
+    if (!response.ok) {
+      const message = typeof data?.message === 'string' ? data.message : 'Erro ao atualizar status do agendamento.';
+      throw new Error(message);
+    }
+
+    if (!state.agendaContext || typeof state.agendaContext !== 'object') {
+      state.agendaContext = {};
+    }
+    state.agendaContext.status = 'finalizado';
+    if (data && typeof data === 'object') {
+      if (Array.isArray(data.servicos)) {
+        state.agendaContext.servicos = data.servicos;
+      }
+      if (typeof data.valor === 'number') {
+        state.agendaContext.valor = Number(data.valor);
+      }
+      if (data.profissional) {
+        state.agendaContext.profissionalNome = data.profissional;
+      }
+    }
+    persistAgendaContext(state.agendaContext);
+
+    addHistoricoEntry(entry);
+
+    clearLocalStoredDataForSelection(clienteId, petId);
+    resetConsultaState();
+
+    state.activeMainTab = 'historico';
+    updateMainTabLayout();
+    renderHistoricoArea();
+    updateConsultaAgendaCard();
+
+    notify('Atendimento finalizado com sucesso.', 'success');
+  } catch (error) {
+    console.error('finalizarAtendimento', error);
+    notify(error.message || 'Erro ao finalizar atendimento.', 'error');
+  } finally {
+    isProcessingFinalizacao = false;
+    if (els.finalizarAtendimentoBtn) {
+      els.finalizarAtendimentoBtn.disabled = false;
+      els.finalizarAtendimentoBtn.classList.remove('opacity-60', 'cursor-not-allowed');
+    }
+  }
+}
+
+async function reopenHistoricoEntry(entry, closeModal) {
+  if (!entry) return;
+  const clienteId = normalizeId(entry.clienteId);
+  const petId = normalizeId(entry.petId);
+  const appointmentId = normalizeId(entry.appointmentId);
+  if (!(clienteId && petId && appointmentId)) {
+    notify('Não foi possível identificar o atendimento selecionado.', 'error');
+    return;
+  }
+
+  let confirmed = true;
+  if (typeof window !== 'undefined' && typeof window.confirm === 'function') {
+    confirmed = window.confirm('Reabrir o atendimento para edição? Ele retornará para a aba Consulta.');
+  }
+  if (!confirmed) return;
+
+  try {
+    const response = await api(`/func/agendamentos/${appointmentId}`, {
+      method: 'PUT',
+      body: JSON.stringify({ status: 'em_atendimento' }),
+    });
+    const data = await response.json().catch(() => (response.ok ? {} : {}));
+    if (!response.ok) {
+      const message = typeof data?.message === 'string' ? data.message : 'Erro ao atualizar status do agendamento.';
+      throw new Error(message);
+    }
+
+    removeHistoricoEntry(entry.id);
+
+    state.consultas = Array.isArray(entry.consultas) ? entry.consultas : [];
+    state.vacinas = Array.isArray(entry.vacinas) ? entry.vacinas : [];
+    state.anexos = Array.isArray(entry.anexos) ? entry.anexos : [];
+    state.exames = Array.isArray(entry.exames) ? entry.exames : [];
+    state.pesos = Array.isArray(entry.pesos) ? entry.pesos : [];
+    state.observacoes = Array.isArray(entry.observacoes) ? entry.observacoes : [];
+    state.documentos = Array.isArray(entry.documentos) ? entry.documentos : [];
+    state.receitas = Array.isArray(entry.receitas) ? entry.receitas : [];
+
+    persistLocalDataForSelection(clienteId, petId);
+
+    const agendaSnapshot = entry.agenda && typeof entry.agenda === 'object' ? { ...entry.agenda } : {};
+    if (!state.agendaContext || typeof state.agendaContext !== 'object') {
+      state.agendaContext = {};
+    }
+    state.agendaContext = {
+      ...agendaSnapshot,
+      ...state.agendaContext,
+      status: 'em_atendimento',
+      appointmentId,
+    };
+    persistAgendaContext(state.agendaContext);
+
+    state.activeMainTab = 'consulta';
+    updateMainTabLayout();
+    updateConsultaAgendaCard();
+    renderHistoricoArea();
+
+    if (typeof closeModal === 'function') {
+      closeModal();
+    }
+
+    notify('Atendimento reaberto para edição.', 'success');
+  } catch (error) {
+    console.error('reopenHistoricoEntry', error);
+    notify(error.message || 'Erro ao reabrir atendimento.', 'error');
+  }
+}
+
+setHistoricoReopenHandler((entry, closeModal) => {
+  const fullEntry = typeof entry === 'string' ? getHistoricoEntryById(entry) : entry;
+  return reopenHistoricoEntry(fullEntry || getHistoricoEntryById(entry?.id), closeModal);
+});
+
+export function initAtendimentoActions() {
+  if (els.finalizarAtendimentoBtn) {
+    els.finalizarAtendimentoBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      finalizarAtendimento();
+    });
+  }
+  if (els.limparConsultaBtn) {
+    els.limparConsultaBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      const clienteId = normalizeId(state.selectedCliente?._id);
+      const petId = normalizeId(state.selectedPetId);
+      let confirmed = true;
+      if (typeof window !== 'undefined' && typeof window.confirm === 'function') {
+        confirmed = window.confirm('Limpar os registros atuais da consulta? Esta ação não altera o histórico.');
+      }
+      if (!confirmed) return;
+      clearLocalStoredDataForSelection(clienteId, petId);
+      resetConsultaState();
+      updateConsultaAgendaCard();
+      notify('Registros da consulta atual foram limpos.', 'info');
+    });
+  }
+}
+
+export function activateHistoricoTab() {
+  setActiveMainTab('historico');
+  renderHistoricoArea();
+}
+
+export function activateConsultaTab() {
+  setActiveMainTab('consulta');
+  updateConsultaAgendaCard();
+}

--- a/scripts/funcionarios/vet/ficha-clinica/consultas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/consultas.js
@@ -20,6 +20,7 @@ import {
   CONSULTA_PLACEHOLDER_CLASSNAMES,
   CONSULTA_CARD_CLASSNAMES,
   CONSULTA_PLACEHOLDER_TEXT,
+  CONSULTA_FINALIZADA_PLACEHOLDER_TEXT,
   consultaModal,
   getSelectedPet,
   formatFileSize,
@@ -2511,13 +2512,15 @@ export function updateConsultaAgendaCard() {
   const selectedTutorId = normalizeId(state.selectedCliente?._id);
   const contextPetId = normalizeId(context?.petId);
   const contextTutorId = normalizeId(context?.tutorId);
+  const agendaStatus = normalizeForCompare(context?.status);
+  const agendaFinalizado = agendaStatus === 'finalizado';
 
   let agendaElement = null;
   let hasAgendaContent = false;
 
   const contextMatches = !!(context && selectedPetId && selectedTutorId && contextPetId && contextTutorId && contextPetId === selectedPetId && contextTutorId === selectedTutorId);
 
-  if (contextMatches) {
+  if (contextMatches && !agendaFinalizado) {
     const allServices = Array.isArray(context.servicos) ? context.servicos : [];
     const vetServices = getVetServices(allServices);
     const filteredOut = Math.max(allServices.length - vetServices.length, 0);
@@ -2640,6 +2643,9 @@ export function updateConsultaAgendaCard() {
     hasObservacoes ||
     hasDocumentos;
   const shouldShowPlaceholder = !hasAnyContent;
+  const placeholderText = agendaFinalizado
+    ? CONSULTA_FINALIZADA_PLACEHOLDER_TEXT
+    : CONSULTA_PLACEHOLDER_TEXT;
 
   if ((isLoadingConsultas || isLoadingAnexos || isLoadingPesos || isLoadingExames) && !hasAnyContent) {
     area.className = CONSULTA_PLACEHOLDER_CLASSNAMES;
@@ -2654,7 +2660,7 @@ export function updateConsultaAgendaCard() {
     area.className = CONSULTA_PLACEHOLDER_CLASSNAMES;
     area.innerHTML = '';
     const paragraph = document.createElement('p');
-    paragraph.textContent = CONSULTA_PLACEHOLDER_TEXT;
+    paragraph.textContent = placeholderText;
     area.appendChild(paragraph);
     return;
   }

--- a/scripts/funcionarios/vet/ficha-clinica/consultas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/consultas.js
@@ -2446,21 +2446,42 @@ async function handleConsultaSubmit() {
   }
 }
 
-function setConsultaTabActive() {
+export function updateMainTabLayout() {
+  const activeTab = state.activeMainTab === 'historico' ? 'historico' : 'consulta';
+  const consultaActiveClasses = ['bg-sky-600', 'text-white'];
+  const consultaInactiveClasses = ['bg-gray-100', 'text-gray-700', 'hover:bg-gray-50'];
+
   if (els.consultaTab) {
-    els.consultaTab.classList.remove('bg-gray-100', 'text-gray-700', 'hover:bg-gray-50');
-    els.consultaTab.classList.add('bg-sky-600', 'text-white');
+    els.consultaTab.classList.remove(...consultaActiveClasses, ...consultaInactiveClasses);
+    els.consultaTab.classList.add(...(activeTab === 'consulta' ? consultaActiveClasses : consultaInactiveClasses));
   }
+
   if (els.historicoTab) {
-    els.historicoTab.classList.remove('bg-sky-600', 'text-white');
-    els.historicoTab.classList.add('bg-gray-100', 'text-gray-700', 'hover:bg-gray-50');
+    els.historicoTab.classList.remove(...consultaActiveClasses, ...consultaInactiveClasses);
+    els.historicoTab.classList.add(...(activeTab === 'historico' ? consultaActiveClasses : consultaInactiveClasses));
+  }
+
+  if (els.consultaArea) {
+    if (activeTab === 'consulta') {
+      els.consultaArea.classList.remove('hidden');
+    } else {
+      els.consultaArea.classList.add('hidden');
+    }
+  }
+
+  if (els.historicoArea) {
+    if (activeTab === 'historico') {
+      els.historicoArea.classList.remove('hidden');
+    } else {
+      els.historicoArea.classList.add('hidden');
+    }
   }
 }
 
 export function updateConsultaAgendaCard() {
   const area = els.consultaArea;
   if (!area) return;
-  setConsultaTabActive();
+  updateMainTabLayout();
 
   const consultas = Array.isArray(state.consultas) ? state.consultas : [];
   const manualConsultas = consultas.filter((consulta) => !!normalizeId(consulta?.id || consulta?._id));

--- a/scripts/funcionarios/vet/ficha-clinica/consultas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/consultas.js
@@ -2492,6 +2492,14 @@ export function updateMainTabLayout() {
 export function updateConsultaAgendaCard() {
   const area = els.consultaArea;
   if (!area) return;
+  const isConsultaTabActive = state.activeMainTab === 'consulta';
+
+  const setAreaClassNames = (classNames) => {
+    area.className = classNames;
+    if (!isConsultaTabActive) {
+      area.classList.add('hidden');
+    }
+  };
   updateMainTabLayout();
 
   const consultas = Array.isArray(state.consultas) ? state.consultas : [];
@@ -2658,7 +2666,7 @@ export function updateConsultaAgendaCard() {
     : CONSULTA_PLACEHOLDER_TEXT;
 
   if ((isLoadingConsultas || isLoadingAnexos || isLoadingPesos || isLoadingExames) && !hasAnyContent) {
-    area.className = CONSULTA_PLACEHOLDER_CLASSNAMES;
+    setAreaClassNames(CONSULTA_PLACEHOLDER_CLASSNAMES);
     area.innerHTML = '';
     const paragraph = document.createElement('p');
     paragraph.textContent = 'Carregando registros...';
@@ -2667,7 +2675,7 @@ export function updateConsultaAgendaCard() {
   }
 
   if (shouldShowPlaceholder) {
-    area.className = CONSULTA_PLACEHOLDER_CLASSNAMES;
+    setAreaClassNames(CONSULTA_PLACEHOLDER_CLASSNAMES);
     area.innerHTML = '';
     const paragraph = document.createElement('p');
     paragraph.textContent = placeholderText;
@@ -2675,7 +2683,7 @@ export function updateConsultaAgendaCard() {
     return;
   }
 
-  area.className = CONSULTA_CARD_CLASSNAMES;
+  setAreaClassNames(CONSULTA_CARD_CLASSNAMES);
   area.innerHTML = '';
 
   const scroll = document.createElement('div');

--- a/scripts/funcionarios/vet/ficha-clinica/consultas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/consultas.js
@@ -24,6 +24,7 @@ import {
   consultaModal,
   getSelectedPet,
   formatFileSize,
+  isFinalizadoSelection,
 } from './core.js';
 import { openDocumentPrintWindow } from '../document-utils.js';
 import { openObservacaoModal } from './observacoes.js';
@@ -224,6 +225,15 @@ export async function loadConsultasFromServer(options = {}) {
   }
 
   const key = getConsultasKey(clienteId, petId);
+
+  if (isFinalizadoSelection(clienteId, petId)) {
+    state.consultas = [];
+    state.consultasLoadKey = key;
+    state.consultasLoading = false;
+    updateConsultaAgendaCard();
+    return;
+  }
+
   if (!force && key && state.consultasLoadKey === key) return;
 
   state.consultasLoading = true;

--- a/scripts/funcionarios/vet/ficha-clinica/core.js
+++ b/scripts/funcionarios/vet/ficha-clinica/core.js
@@ -388,6 +388,24 @@ export function sanitizeObjectId(value) {
   return OBJECT_ID_REGEX.test(cleaned) ? cleaned : '';
 }
 
+export function isAgendaContextFinalizado(context = state.agendaContext) {
+  const status = normalizeForCompare(context?.status);
+  return status === 'finalizado';
+}
+
+export function isFinalizadoSelection(clienteId, petId, context = state.agendaContext) {
+  if (!context || typeof context !== 'object') return false;
+  if (!isAgendaContextFinalizado(context)) return false;
+  const appointmentId = normalizeId(context.appointmentId);
+  if (!appointmentId) return false;
+  const tutorId = normalizeId(context.tutorId);
+  const petContextId = normalizeId(context.petId);
+  const targetTutorId = normalizeId(clienteId);
+  const targetPetId = normalizeId(petId);
+  if (!(tutorId && petContextId && targetTutorId && targetPetId)) return false;
+  return tutorId === targetTutorId && petContextId === targetPetId;
+}
+
 export function capitalize(value) {
   const str = String(value || '').trim();
   if (!str) return '';

--- a/scripts/funcionarios/vet/ficha-clinica/core.js
+++ b/scripts/funcionarios/vet/ficha-clinica/core.js
@@ -299,6 +299,7 @@ export const CARD_BUTTON_DISABLED_CLASSES = ['opacity-50', 'cursor-not-allowed']
 export const CONSULTA_PLACEHOLDER_CLASSNAMES = 'h-[420px] rounded-lg bg-white border border-dashed border-gray-300 flex flex-col items-center justify-center text-sm text-gray-500 text-center px-6';
 export const CONSULTA_CARD_CLASSNAMES = 'h-[420px] rounded-lg bg-white border border-gray-200 shadow-sm overflow-hidden';
 export const CONSULTA_PLACEHOLDER_TEXT = 'Selecione um agendamento na agenda para carregar os serviços veterinários.';
+export const CONSULTA_FINALIZADA_PLACEHOLDER_TEXT = 'Nenhum agendamento para iniciar uma consulta.';
 
 export const STATUS_LABELS = {
   agendado: 'Agendado',

--- a/scripts/funcionarios/vet/ficha-clinica/core.js
+++ b/scripts/funcionarios/vet/ficha-clinica/core.js
@@ -57,6 +57,21 @@ export function formatPhone(value) {
   return digits || '';
 }
 
+export function getCurrentUserRole() {
+  try {
+    const cached = JSON.parse(localStorage.getItem('loggedInUser') || 'null');
+    const role = typeof cached?.role === 'string' ? cached.role : '';
+    return role || '';
+  } catch {
+    return '';
+  }
+}
+
+export function isAdminRole(role = getCurrentUserRole()) {
+  const normalized = String(role || '').toLowerCase();
+  return normalized === 'admin' || normalized === 'admin_master';
+}
+
 export const els = {
   cliInput: document.getElementById('vet-cli-input'),
   cliSug: document.getElementById('vet-cli-sug'),
@@ -93,6 +108,7 @@ export const els = {
   togglePet: document.getElementById('vet-card-show-pet'),
   pageContent: document.getElementById('vet-ficha-content'),
   consultaArea: document.getElementById('vet-consulta-area'),
+  historicoArea: document.getElementById('vet-historico-area'),
   historicoTab: document.getElementById('vet-tab-historico'),
   consultaTab: document.getElementById('vet-tab-consulta'),
   addConsultaBtn: document.getElementById('vet-add-consulta-btn'),
@@ -103,6 +119,8 @@ export const els = {
   addExameBtn: document.getElementById('vet-add-exame-btn'),
   addPesoBtn: document.getElementById('vet-add-peso-btn'),
   addObservacaoBtn: document.getElementById('vet-add-observacao-btn'),
+  finalizarAtendimentoBtn: document.getElementById('vet-finalizar-atendimento'),
+  limparConsultaBtn: document.getElementById('vet-clear-consulta'),
 };
 
 export const state = {
@@ -131,6 +149,9 @@ export const state = {
   receitas: [],
   receitasLoading: false,
   receitasLoadKey: null,
+  historicos: [],
+  historicosLoadKey: null,
+  activeMainTab: 'consulta',
 };
 
 export const consultaModal = {
@@ -268,6 +289,7 @@ export const ANEXO_STORAGE_PREFIX = 'vetFichaAnexos:';
 export const EXAME_STORAGE_PREFIX = 'vetFichaExames:';
 export const OBSERVACAO_STORAGE_PREFIX = 'vetFichaObservacoes:';
 export const EXAME_ATTACHMENT_OBSERVACAO_PREFIX = '__vet_exame__:';
+export const HISTORICO_STORAGE_PREFIX = 'vetFichaHistorico:';
 export const OBJECT_ID_REGEX = /^[0-9a-fA-F]{24}$/;
 
 export const CARD_TUTOR_ACTIVE_CLASSES = ['bg-sky-100', 'text-sky-700'];

--- a/scripts/funcionarios/vet/ficha-clinica/documentos.js
+++ b/scripts/funcionarios/vet/ficha-clinica/documentos.js
@@ -17,6 +17,7 @@ import {
   ANEXO_ALLOWED_EXTENSIONS,
   getFileExtension,
   formatFileSize,
+  isFinalizadoSelection,
 } from './core.js';
 import { ensureTutorAndPetSelected, updateConsultaAgendaCard, getConsultasKey } from './consultas.js';
 import {
@@ -1051,6 +1052,13 @@ export async function loadDocumentosFromServer(options = {}) {
   }
 
   const key = getConsultasKey(clienteId, petId);
+  if (isFinalizadoSelection(clienteId, petId)) {
+    state.documentos = [];
+    state.documentosLoadKey = key;
+    state.documentosLoading = false;
+    updateConsultaAgendaCard();
+    return;
+  }
   if (!force && key && state.documentosLoadKey === key) return;
 
   state.documentosLoading = true;

--- a/scripts/funcionarios/vet/ficha-clinica/exames.js
+++ b/scripts/funcionarios/vet/ficha-clinica/exames.js
@@ -19,6 +19,7 @@ import {
   ANEXO_ALLOWED_EXTENSIONS,
   ANEXO_ALLOWED_MIME_TYPES,
   getAuthToken,
+  isFinalizadoSelection,
 } from './core.js';
 import { getConsultasKey, ensureTutorAndPetSelected, updateConsultaAgendaCard } from './consultas.js';
 import { loadAnexosFromServer, deleteAnexo } from './anexos.js';
@@ -998,10 +999,22 @@ async function persistExameAttachmentsChanges({
 }
 
 export function loadExamesForSelection() {
-  const key = getExameStorageKey(state.selectedCliente?._id, state.selectedPetId);
+  const clienteId = state.selectedCliente?._id;
+  const petId = state.selectedPetId;
+  const key = getExameStorageKey(clienteId, petId);
   if (!key) {
     state.exames = [];
     state.examesLoadKey = null;
+    return;
+  }
+  if (isFinalizadoSelection(clienteId, petId)) {
+    state.exames = [];
+    state.examesLoadKey = key;
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // ignore storage errors
+    }
     return;
   }
   try {

--- a/scripts/funcionarios/vet/ficha-clinica/historico.js
+++ b/scripts/funcionarios/vet/ficha-clinica/historico.js
@@ -1,0 +1,730 @@
+// Histórico management and rendering for the Vet ficha clínica
+import {
+  state,
+  els,
+  pickFirst,
+  normalizeId,
+  formatDateDisplay,
+  formatDateTimeDisplay,
+  formatMoney,
+  getStatusLabel,
+  HISTORICO_STORAGE_PREFIX,
+  CONSULTA_PLACEHOLDER_CLASSNAMES,
+  CONSULTA_CARD_CLASSNAMES,
+  isAdminRole,
+} from './core.js';
+import { updateMainTabLayout } from './consultas.js';
+
+const historicoHandlers = {
+  onReopen: null,
+};
+
+export function setHistoricoReopenHandler(handler) {
+  historicoHandlers.onReopen = typeof handler === 'function' ? handler : null;
+}
+
+function getHistoricoStorageKey(clienteId, petId) {
+  const tutor = normalizeId(clienteId);
+  const pet = normalizeId(petId);
+  if (!(tutor && pet)) return null;
+  return `${HISTORICO_STORAGE_PREFIX}${tutor}|${pet}`;
+}
+
+function safeClone(value) {
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return null;
+  }
+}
+
+function normalizeHistoricoEntry(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const id = normalizeId(raw.id || raw._id || raw.key);
+  const clienteId = normalizeId(raw.clienteId || raw.cliente);
+  const petId = normalizeId(raw.petId || raw.pet);
+  const appointmentId = normalizeId(raw.appointmentId || raw.appointment);
+  if (!(id && clienteId && petId)) return null;
+
+  const finalizadoEm = (() => {
+    const value = raw.finalizadoEm || raw.createdAt || raw.updatedAt;
+    if (!value) return new Date().toISOString();
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return new Date().toISOString();
+    return date.toISOString();
+  })();
+
+  const agenda = raw.agenda && typeof raw.agenda === 'object' ? safeClone(raw.agenda) || {} : {};
+  const consultas = Array.isArray(raw.consultas) ? safeClone(raw.consultas) || [] : [];
+  const vacinas = Array.isArray(raw.vacinas) ? safeClone(raw.vacinas) || [] : [];
+  const anexos = Array.isArray(raw.anexos) ? safeClone(raw.anexos) || [] : [];
+  const exames = Array.isArray(raw.exames) ? safeClone(raw.exames) || [] : [];
+  const pesos = Array.isArray(raw.pesos) ? safeClone(raw.pesos) || [] : [];
+  const observacoes = Array.isArray(raw.observacoes) ? safeClone(raw.observacoes) || [] : [];
+  const documentos = Array.isArray(raw.documentos) ? safeClone(raw.documentos) || [] : [];
+  const receitas = Array.isArray(raw.receitas) ? safeClone(raw.receitas) || [] : [];
+
+  return {
+    id,
+    clienteId,
+    petId,
+    appointmentId,
+    finalizadoEm,
+    agenda,
+    consultas,
+    vacinas,
+    anexos,
+    exames,
+    pesos,
+    observacoes,
+    documentos,
+    receitas,
+  };
+}
+
+function sortHistoricoEntries(entries) {
+  if (!Array.isArray(entries)) return [];
+  const sorted = [...entries];
+  sorted.sort((a, b) => {
+    const aTime = a?.finalizadoEm ? new Date(a.finalizadoEm).getTime() : 0;
+    const bTime = b?.finalizadoEm ? new Date(b.finalizadoEm).getTime() : 0;
+    return bTime - aTime;
+  });
+  return sorted;
+}
+
+function persistHistoricoForSelection() {
+  const key = getHistoricoStorageKey(state.selectedCliente?._id, state.selectedPetId);
+  state.historicosLoadKey = key;
+  if (!key) return;
+  try {
+    if (Array.isArray(state.historicos) && state.historicos.length) {
+      localStorage.setItem(key, JSON.stringify(state.historicos));
+    } else {
+      localStorage.removeItem(key);
+    }
+  } catch {
+    // ignore persistence errors
+  }
+}
+
+export function loadHistoricoForSelection() {
+  const key = getHistoricoStorageKey(state.selectedCliente?._id, state.selectedPetId);
+  state.historicosLoadKey = key;
+  if (!key) {
+    state.historicos = [];
+    renderHistoricoArea();
+    return;
+  }
+
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) {
+      state.historicos = [];
+      renderHistoricoArea();
+      return;
+    }
+    const parsed = JSON.parse(raw);
+    const normalized = Array.isArray(parsed)
+      ? parsed.map(normalizeHistoricoEntry).filter(Boolean)
+      : [];
+    state.historicos = sortHistoricoEntries(normalized);
+  } catch {
+    state.historicos = [];
+  }
+  renderHistoricoArea();
+}
+
+export function addHistoricoEntry(entry) {
+  const normalized = normalizeHistoricoEntry(entry);
+  if (!normalized) return;
+  const existing = Array.isArray(state.historicos) ? [...state.historicos] : [];
+  const filtered = existing.filter((item) => normalizeId(item?.id) !== normalized.id);
+  state.historicos = sortHistoricoEntries([normalized, ...filtered]);
+  persistHistoricoForSelection();
+  renderHistoricoArea();
+}
+
+export function removeHistoricoEntry(entryId) {
+  const targetId = normalizeId(entryId);
+  const next = (Array.isArray(state.historicos) ? state.historicos : []).filter(
+    (entry) => normalizeId(entry?.id) !== targetId,
+  );
+  state.historicos = next;
+  persistHistoricoForSelection();
+  renderHistoricoArea();
+}
+
+export function getHistoricoEntryById(entryId) {
+  const targetId = normalizeId(entryId);
+  if (!targetId) return null;
+  return (state.historicos || []).find((entry) => normalizeId(entry?.id) === targetId) || null;
+}
+
+const TAG_STYLE_MAP = {
+  consulta: 'border-sky-200 bg-sky-50 text-sky-700',
+  vacina: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  exame: 'border-rose-200 bg-rose-50 text-rose-700',
+  anexo: 'border-indigo-200 bg-indigo-50 text-indigo-700',
+  observacao: 'border-amber-200 bg-amber-50 text-amber-700',
+  peso: 'border-orange-200 bg-orange-50 text-orange-700',
+  documento: 'border-teal-200 bg-teal-50 text-teal-700',
+  receita: 'border-blue-200 bg-blue-50 text-blue-700',
+  default: 'border-gray-200 bg-gray-100 text-gray-700',
+};
+
+function createTag(label, type) {
+  const span = document.createElement('span');
+  span.className = `inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium ${TAG_STYLE_MAP[type] || TAG_STYLE_MAP.default}`;
+  span.textContent = label;
+  return span;
+}
+
+function collectEntryTags(entry) {
+  const tags = [];
+  const pushTag = (label, type) => {
+    const text = String(label || '').trim();
+    if (!text) return;
+    tags.push({ label: text, type });
+  };
+
+  (entry.consultas || []).forEach((consulta) => {
+    pushTag(pickFirst(consulta?.servicoNome), 'consulta');
+  });
+  (entry.vacinas || []).forEach((vacina) => {
+    pushTag(pickFirst(vacina?.servicoNome), 'vacina');
+  });
+  (entry.exames || []).forEach((exame) => {
+    pushTag(pickFirst(exame?.servicoNome), 'exame');
+  });
+  (entry.anexos || []).forEach((anexo) => {
+    const arquivos = Array.isArray(anexo?.arquivos) ? anexo.arquivos : [];
+    arquivos.forEach((arquivo) => {
+      pushTag(pickFirst(arquivo?.nome, arquivo?.originalName), 'anexo');
+    });
+  });
+  (entry.observacoes || []).forEach((obs) => {
+    pushTag(pickFirst(obs?.titulo, 'Observação'), 'observacao');
+  });
+  (entry.pesos || []).forEach((peso) => {
+    if (peso?.peso) {
+      const texto = `${peso.peso} kg`;
+      pushTag(texto, 'peso');
+    }
+  });
+  (entry.documentos || []).forEach((doc) => {
+    pushTag(pickFirst(doc?.titulo, doc?.nome), 'documento');
+  });
+  (entry.receitas || []).forEach((rec) => {
+    pushTag(pickFirst(rec?.titulo, rec?.nome, rec?.modeloNome), 'receita');
+  });
+
+  return tags;
+}
+
+function createHistoricoCard(entry) {
+  const card = document.createElement('article');
+  card.className = 'group relative cursor-pointer rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition hover:border-sky-300 focus:outline-none focus:ring-2 focus:ring-sky-400';
+  card.tabIndex = 0;
+  card.dataset.historicoId = entry.id;
+
+  const header = document.createElement('div');
+  header.className = 'flex items-start justify-between gap-3';
+  card.appendChild(header);
+
+  const info = document.createElement('div');
+  info.className = 'space-y-1';
+  header.appendChild(info);
+
+  const title = document.createElement('h3');
+  title.className = 'text-sm font-semibold text-gray-800';
+  title.textContent = 'Atendimento finalizado';
+  info.appendChild(title);
+
+  const when = formatDateTimeDisplay(entry.finalizadoEm);
+  if (when) {
+    const whenEl = document.createElement('p');
+    whenEl.className = 'text-xs text-gray-500';
+    whenEl.textContent = `Finalizado em ${when}`;
+    info.appendChild(whenEl);
+  }
+
+  const professional = pickFirst(entry.agenda?.profissionalNome, entry.agenda?.profissional);
+  if (professional) {
+    const profEl = document.createElement('p');
+    profEl.className = 'text-xs text-gray-500';
+    profEl.textContent = `Profissional: ${professional}`;
+    info.appendChild(profEl);
+  }
+
+  const statusLabel = getStatusLabel(entry.agenda?.status || 'finalizado');
+  const statusBadge = document.createElement('span');
+  statusBadge.className = 'inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700';
+  statusBadge.textContent = statusLabel || 'Finalizado';
+  header.appendChild(statusBadge);
+
+  const tags = collectEntryTags(entry);
+  if (tags.length) {
+    const tagList = document.createElement('div');
+    tagList.className = 'mt-3 flex flex-wrap gap-2';
+    tags.slice(0, 12).forEach((tag) => {
+      tagList.appendChild(createTag(tag.label, tag.type));
+    });
+    if (tags.length > 12) {
+      const remaining = tags.length - 12;
+      tagList.appendChild(createTag(`+${remaining}`, 'default'));
+    }
+    card.appendChild(tagList);
+  } else {
+    const emptyInfo = document.createElement('p');
+    emptyInfo.className = 'mt-3 text-xs text-gray-500';
+    emptyInfo.textContent = 'Nenhum registro adicional foi associado ao atendimento.';
+    card.appendChild(emptyInfo);
+  }
+
+  const openModal = (event) => {
+    event.preventDefault();
+    openHistoricoEntryModal(entry.id);
+  };
+
+  card.addEventListener('click', openModal);
+  card.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      openModal(event);
+    }
+  });
+
+  return card;
+}
+
+export function renderHistoricoArea() {
+  const area = els.historicoArea;
+  if (!area) return;
+
+  const historicos = Array.isArray(state.historicos) ? state.historicos : [];
+  const hasEntries = historicos.length > 0;
+
+  if (!hasEntries) {
+    area.className = CONSULTA_PLACEHOLDER_CLASSNAMES;
+    area.innerHTML = '';
+    const paragraph = document.createElement('p');
+    paragraph.textContent = 'Nenhum atendimento finalizado para exibir.';
+    area.appendChild(paragraph);
+    updateMainTabLayout();
+    return;
+  }
+
+  area.className = CONSULTA_CARD_CLASSNAMES;
+  area.innerHTML = '';
+
+  const scroll = document.createElement('div');
+  scroll.className = 'h-full w-full overflow-y-auto p-5 space-y-4';
+  area.appendChild(scroll);
+
+  historicos.forEach((entry) => {
+    const card = createHistoricoCard(entry);
+    if (card) scroll.appendChild(card);
+  });
+  updateMainTabLayout();
+}
+
+function createDetailRow(label, value) {
+  const row = document.createElement('div');
+  row.className = 'flex flex-col';
+  const labelEl = document.createElement('span');
+  labelEl.className = 'text-xs font-semibold uppercase tracking-wide text-gray-500';
+  labelEl.textContent = label;
+  row.appendChild(labelEl);
+  const valueEl = document.createElement('p');
+  valueEl.className = 'text-sm text-gray-800 whitespace-pre-wrap break-words';
+  valueEl.textContent = value || '—';
+  row.appendChild(valueEl);
+  return row;
+}
+
+function appendSection(container, title) {
+  const section = document.createElement('section');
+  section.className = 'rounded-xl border border-gray-200 bg-gray-50 p-4 space-y-3';
+  const heading = document.createElement('h3');
+  heading.className = 'text-sm font-semibold text-gray-800';
+  heading.textContent = title;
+  section.appendChild(heading);
+  container.appendChild(section);
+  return section;
+}
+
+function renderListSection(container, title, items, renderItem) {
+  if (!Array.isArray(items) || !items.length) return;
+  const section = appendSection(container, title);
+  const list = document.createElement('div');
+  list.className = 'space-y-3';
+  items.forEach((item, index) => {
+    const node = renderItem(item, index);
+    if (node) list.appendChild(node);
+  });
+  if (list.children.length) {
+    section.appendChild(list);
+  } else {
+    const empty = document.createElement('p');
+    empty.className = 'text-sm text-gray-600';
+    empty.textContent = 'Sem registros.';
+    section.appendChild(empty);
+  }
+}
+
+function renderConsultasSection(container, consultas) {
+  renderListSection(container, 'Consultas', consultas, (consulta) => {
+    const card = document.createElement('article');
+    card.className = 'rounded-lg border border-sky-200 bg-white p-3 space-y-2';
+    const title = document.createElement('div');
+    title.className = 'flex items-center justify-between';
+    const name = document.createElement('h4');
+    name.className = 'text-sm font-semibold text-sky-700';
+    name.textContent = pickFirst(consulta?.servicoNome) || 'Registro de consulta';
+    title.appendChild(name);
+    if (consulta?.createdAt) {
+      const when = document.createElement('span');
+      when.className = 'text-xs text-gray-500';
+      when.textContent = formatDateTimeDisplay(consulta.createdAt);
+      title.appendChild(when);
+    }
+    card.appendChild(title);
+
+    card.appendChild(createDetailRow('Anamnese', consulta?.anamnese));
+    card.appendChild(createDetailRow('Exame físico', consulta?.exameFisico));
+    card.appendChild(createDetailRow('Diagnóstico', consulta?.diagnostico));
+    return card;
+  });
+}
+
+function renderVacinasSection(container, vacinas) {
+  renderListSection(container, 'Vacinas aplicadas', vacinas, (vacina) => {
+    const card = document.createElement('article');
+    card.className = 'rounded-lg border border-emerald-200 bg-white p-3 space-y-2';
+    const header = document.createElement('div');
+    header.className = 'flex items-center justify-between';
+    const name = document.createElement('h4');
+    name.className = 'text-sm font-semibold text-emerald-700';
+    name.textContent = pickFirst(vacina?.servicoNome) || 'Vacina';
+    header.appendChild(name);
+    if (vacina?.aplicacao) {
+      const date = document.createElement('span');
+      date.className = 'text-xs text-gray-500';
+      date.textContent = `Aplicação: ${formatDateDisplay(vacina.aplicacao)}`;
+      header.appendChild(date);
+    }
+    card.appendChild(header);
+
+    const details = document.createElement('div');
+    details.className = 'grid gap-2 sm:grid-cols-2';
+    details.appendChild(createDetailRow('Quantidade', String(vacina?.quantidade || 0)));
+    details.appendChild(createDetailRow('Valor total', formatMoney(vacina?.valorTotal || 0)));
+    if (vacina?.validade) details.appendChild(createDetailRow('Validade', formatDateDisplay(vacina.validade)));
+    if (vacina?.renovacao) details.appendChild(createDetailRow('Reaplicação', formatDateDisplay(vacina.renovacao)));
+    if (vacina?.lote) details.appendChild(createDetailRow('Lote', vacina.lote));
+    card.appendChild(details);
+    return card;
+  });
+}
+
+function renderExamesSection(container, exames) {
+  renderListSection(container, 'Exames solicitados', exames, (exame) => {
+    const card = document.createElement('article');
+    card.className = 'rounded-lg border border-rose-200 bg-white p-3 space-y-2';
+    const header = document.createElement('div');
+    header.className = 'flex items-center justify-between';
+    const name = document.createElement('h4');
+    name.className = 'text-sm font-semibold text-rose-700';
+    name.textContent = pickFirst(exame?.servicoNome) || 'Exame';
+    header.appendChild(name);
+    if (exame?.createdAt) {
+      const when = document.createElement('span');
+      when.className = 'text-xs text-gray-500';
+      when.textContent = formatDateTimeDisplay(exame.createdAt);
+      header.appendChild(when);
+    }
+    card.appendChild(header);
+
+    if (exame?.observacao) {
+      card.appendChild(createDetailRow('Observação', exame.observacao));
+    }
+
+    const arquivos = Array.isArray(exame?.arquivos) ? exame.arquivos : [];
+    if (arquivos.length) {
+      const filesWrapper = document.createElement('div');
+      filesWrapper.className = 'space-y-1';
+      const label = document.createElement('span');
+      label.className = 'text-xs font-semibold uppercase tracking-wide text-gray-500';
+      label.textContent = 'Arquivos';
+      filesWrapper.appendChild(label);
+      const list = document.createElement('ul');
+      list.className = 'space-y-1 text-sm text-gray-700';
+      arquivos.forEach((arquivo) => {
+        const item = document.createElement('li');
+        const link = document.createElement('a');
+        link.className = 'text-sky-600 hover:underline';
+        link.textContent = pickFirst(arquivo?.nome, arquivo?.originalName) || 'Arquivo';
+        const url = pickFirst(arquivo?.url);
+        if (url) {
+          link.href = url;
+          link.target = '_blank';
+          link.rel = 'noopener noreferrer';
+        } else {
+          link.href = '#';
+          link.addEventListener('click', (event) => event.preventDefault());
+        }
+        item.appendChild(link);
+        list.appendChild(item);
+      });
+      filesWrapper.appendChild(list);
+      card.appendChild(filesWrapper);
+    }
+    return card;
+  });
+}
+
+function renderAnexosSection(container, anexos) {
+  renderListSection(container, 'Anexos do atendimento', anexos, (anexo) => {
+    const card = document.createElement('article');
+    card.className = 'rounded-lg border border-indigo-200 bg-white p-3 space-y-2';
+    if (anexo?.observacao) {
+      card.appendChild(createDetailRow('Observação', anexo.observacao));
+    }
+    const arquivos = Array.isArray(anexo?.arquivos) ? anexo.arquivos : [];
+    if (arquivos.length) {
+      const list = document.createElement('ul');
+      list.className = 'space-y-1 text-sm text-gray-700';
+      arquivos.forEach((arquivo) => {
+        const item = document.createElement('li');
+        const link = document.createElement('a');
+        link.className = 'text-indigo-600 hover:underline';
+        link.textContent = pickFirst(arquivo?.nome, arquivo?.originalName) || 'Arquivo';
+        const url = pickFirst(arquivo?.url);
+        if (url) {
+          link.href = url;
+          link.target = '_blank';
+          link.rel = 'noopener noreferrer';
+        } else {
+          link.href = '#';
+          link.addEventListener('click', (event) => event.preventDefault());
+        }
+        item.appendChild(link);
+        list.appendChild(item);
+      });
+      card.appendChild(list);
+    }
+    return card;
+  });
+}
+
+function renderObservacoesSection(container, observacoes) {
+  renderListSection(container, 'Observações adicionais', observacoes, (obs) => {
+    const card = document.createElement('article');
+    card.className = 'rounded-lg border border-amber-200 bg-white p-3 space-y-2';
+    const title = pickFirst(obs?.titulo);
+    if (title) {
+      const heading = document.createElement('h4');
+      heading.className = 'text-sm font-semibold text-amber-700';
+      heading.textContent = title;
+      card.appendChild(heading);
+    }
+    card.appendChild(createDetailRow('Observação', obs?.observacao));
+    if (obs?.createdAt) {
+      const when = document.createElement('p');
+      when.className = 'text-xs text-gray-500';
+      when.textContent = formatDateTimeDisplay(obs.createdAt);
+      card.appendChild(when);
+    }
+    return card;
+  });
+}
+
+function renderPesosSection(container, pesos) {
+  renderListSection(container, 'Pesagens registradas', pesos, (peso) => {
+    const card = document.createElement('article');
+    card.className = 'rounded-lg border border-orange-200 bg-white p-3 space-y-2';
+    card.appendChild(createDetailRow('Peso (kg)', String(peso?.peso || '—')));
+    if (peso?.createdAt) {
+      card.appendChild(createDetailRow('Registrado em', formatDateTimeDisplay(peso.createdAt)));
+    }
+    if (peso?.observacao) {
+      card.appendChild(createDetailRow('Observação', peso.observacao));
+    }
+    return card;
+  });
+}
+
+function renderDocumentosSection(container, documentos) {
+  renderListSection(container, 'Documentos gerados', documentos, (doc) => {
+    const card = document.createElement('article');
+    card.className = 'rounded-lg border border-teal-200 bg-white p-3 space-y-2';
+    card.appendChild(createDetailRow('Documento', pickFirst(doc?.titulo, doc?.nome)));
+    if (doc?.createdAt) {
+      card.appendChild(createDetailRow('Registrado em', formatDateTimeDisplay(doc.createdAt)));
+    }
+    if (doc?.observacao) {
+      card.appendChild(createDetailRow('Observação', doc.observacao));
+    }
+    return card;
+  });
+}
+
+function renderReceitasSection(container, receitas) {
+  renderListSection(container, 'Receitas emitidas', receitas, (rec) => {
+    const card = document.createElement('article');
+    card.className = 'rounded-lg border border-blue-200 bg-white p-3 space-y-2';
+    card.appendChild(createDetailRow('Receita', pickFirst(rec?.titulo, rec?.nome, rec?.modeloNome)));
+    if (rec?.createdAt) {
+      card.appendChild(createDetailRow('Registrado em', formatDateTimeDisplay(rec.createdAt)));
+    }
+    if (rec?.observacao) {
+      card.appendChild(createDetailRow('Observação', rec.observacao));
+    }
+    return card;
+  });
+}
+
+function buildHistoricoModal(entry) {
+  const overlay = document.createElement('div');
+  overlay.className = 'fixed inset-0 z-[60] flex items-start justify-center bg-black/50 p-4 overflow-y-auto';
+
+  const dialog = document.createElement('div');
+  dialog.className = 'relative w-full max-w-4xl rounded-2xl bg-white shadow-xl';
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
+  dialog.tabIndex = -1;
+  overlay.appendChild(dialog);
+
+  const header = document.createElement('header');
+  header.className = 'flex items-start justify-between gap-4 border-b border-gray-200 px-6 py-4';
+  dialog.appendChild(header);
+
+  const titleWrapper = document.createElement('div');
+  titleWrapper.className = 'space-y-1';
+  header.appendChild(titleWrapper);
+
+  const title = document.createElement('h2');
+  title.className = 'text-lg font-semibold text-gray-800';
+  title.textContent = 'Detalhes do atendimento finalizado';
+  titleWrapper.appendChild(title);
+
+  const subtitleParts = [];
+  const when = formatDateTimeDisplay(entry.finalizadoEm);
+  if (when) subtitleParts.push(`Finalizado em ${when}`);
+  const profissional = pickFirst(entry.agenda?.profissionalNome, entry.agenda?.profissional);
+  if (profissional) subtitleParts.push(`Profissional: ${profissional}`);
+  if (subtitleParts.length) {
+    const subtitle = document.createElement('p');
+    subtitle.className = 'text-sm text-gray-500';
+    subtitle.textContent = subtitleParts.join(' · ');
+    titleWrapper.appendChild(subtitle);
+  }
+
+  const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
+  closeBtn.className = 'rounded-full bg-gray-100 p-2 text-gray-600 hover:bg-gray-200';
+  closeBtn.innerHTML = '<i class="fas fa-xmark"></i>';
+  header.appendChild(closeBtn);
+
+  const body = document.createElement('div');
+  body.className = 'space-y-4 px-6 py-5';
+  dialog.appendChild(body);
+
+  const resumo = appendSection(body, 'Resumo do atendimento');
+  const resumoContent = document.createElement('div');
+  resumoContent.className = 'grid gap-3 sm:grid-cols-2';
+  resumoContent.appendChild(createDetailRow('Status do agendamento', getStatusLabel(entry.agenda?.status || 'finalizado')));
+  if (entry.agenda?.scheduledAt) {
+    resumoContent.appendChild(createDetailRow('Atendimento agendado', formatDateTimeDisplay(entry.agenda.scheduledAt)));
+  }
+  if (entry.agenda?.valor != null) {
+    resumoContent.appendChild(createDetailRow('Valor total', formatMoney(entry.agenda.valor)));
+  }
+  if (entry.agenda?.observacao) {
+    resumoContent.appendChild(createDetailRow('Observações do agendamento', entry.agenda.observacao));
+  }
+  resumo.appendChild(resumoContent);
+
+  renderConsultasSection(body, entry.consultas);
+  renderVacinasSection(body, entry.vacinas);
+  renderExamesSection(body, entry.exames);
+  renderAnexosSection(body, entry.anexos);
+  renderPesosSection(body, entry.pesos);
+  renderObservacoesSection(body, entry.observacoes);
+  renderDocumentosSection(body, entry.documentos);
+  renderReceitasSection(body, entry.receitas);
+
+  const footer = document.createElement('footer');
+  footer.className = 'flex flex-col gap-2 border-t border-gray-200 px-6 py-4 sm:flex-row sm:items-center sm:justify-end';
+  dialog.appendChild(footer);
+
+  if (isAdminRole() && typeof historicoHandlers.onReopen === 'function') {
+    const editBtn = document.createElement('button');
+    editBtn.type = 'button';
+    editBtn.className = 'inline-flex items-center justify-center gap-2 rounded-lg bg-sky-600 px-4 py-2 text-sm font-semibold text-white hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-400';
+    editBtn.innerHTML = '<i class="fas fa-pen"></i><span>Editar atendimento</span>';
+    editBtn.addEventListener('click', async () => {
+      if (editBtn.disabled) return;
+      editBtn.disabled = true;
+      editBtn.classList.add('opacity-60', 'cursor-not-allowed');
+      try {
+        await Promise.resolve(historicoHandlers.onReopen(entry, () => overlay.remove()));
+      } catch (error) {
+        console.error('historico:onReopen', error);
+      } finally {
+        editBtn.disabled = false;
+        editBtn.classList.remove('opacity-60', 'cursor-not-allowed');
+      }
+    });
+    footer.appendChild(editBtn);
+  }
+
+  const closeAction = document.createElement('button');
+  closeAction.type = 'button';
+  closeAction.className = 'inline-flex items-center justify-center rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-300';
+  closeAction.textContent = 'Fechar';
+  closeAction.addEventListener('click', () => overlay.remove());
+  footer.appendChild(closeAction);
+
+  closeBtn.addEventListener('click', () => overlay.remove());
+
+  overlay.addEventListener('click', (event) => {
+    if (event.target === overlay) {
+      overlay.remove();
+    }
+  });
+
+  document.addEventListener(
+    'keydown',
+    (event) => {
+      if (event.key === 'Escape') {
+        overlay.remove();
+      }
+    },
+    { once: true },
+  );
+
+  return overlay;
+}
+
+export function openHistoricoEntryModal(entryId) {
+  const entry = getHistoricoEntryById(entryId);
+  if (!entry) {
+    return;
+  }
+  const modal = buildHistoricoModal(entry);
+  if (modal) {
+    document.body.appendChild(modal);
+  }
+}
+
+export function setActiveMainTab(tab) {
+  const normalized = tab === 'historico' ? 'historico' : 'consulta';
+  if (state.activeMainTab === normalized) {
+    updateMainTabLayout();
+    return;
+  }
+  state.activeMainTab = normalized;
+  updateMainTabLayout();
+}

--- a/scripts/funcionarios/vet/ficha-clinica/init.js
+++ b/scripts/funcionarios/vet/ficha-clinica/init.js
@@ -17,6 +17,11 @@ import {
   restorePersistedSelection,
 } from './tutor.js';
 import { updateCardDisplay, updatePageVisibility, setCardMode } from './ui.js';
+import {
+  initAtendimentoActions,
+  activateHistoricoTab,
+  activateConsultaTab,
+} from './atendimento.js';
 
 export function initFichaClinica() {
   if (els.cliInput) {
@@ -124,6 +129,21 @@ export function initFichaClinica() {
     });
   }
 
+  if (els.consultaTab) {
+    els.consultaTab.addEventListener('click', (event) => {
+      event.preventDefault();
+      activateConsultaTab();
+    });
+  }
+
+  if (els.historicoTab) {
+    els.historicoTab.addEventListener('click', (event) => {
+      event.preventDefault();
+      activateHistoricoTab();
+    });
+  }
+
+  initAtendimentoActions();
   updateCardDisplay();
   restorePersistedSelection();
   updatePageVisibility();

--- a/scripts/funcionarios/vet/ficha-clinica/observacoes.js
+++ b/scripts/funcionarios/vet/ficha-clinica/observacoes.js
@@ -6,6 +6,7 @@ import {
   normalizeId,
   toIsoOrNull,
   OBSERVACAO_STORAGE_PREFIX,
+  isFinalizadoSelection,
 } from './core.js';
 import { getConsultasKey, updateConsultaAgendaCard } from './consultas.js';
 
@@ -76,9 +77,20 @@ function persistObservacoesForSelection() {
 }
 
 export function loadObservacoesForSelection() {
-  const key = getObservacaoStorageKey(state.selectedCliente?._id, state.selectedPetId);
+  const clienteId = state.selectedCliente?._id;
+  const petId = state.selectedPetId;
+  const key = getObservacaoStorageKey(clienteId, petId);
   if (!key) {
     state.observacoes = [];
+    return;
+  }
+  if (isFinalizadoSelection(clienteId, petId)) {
+    state.observacoes = [];
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // ignore storage errors
+    }
     return;
   }
   try {

--- a/scripts/funcionarios/vet/ficha-clinica/pesos.js
+++ b/scripts/funcionarios/vet/ficha-clinica/pesos.js
@@ -13,6 +13,7 @@ import {
   formatWeightDelta,
   pesoModal,
   sanitizeObjectId,
+  isFinalizadoSelection,
 } from './core.js';
 import { ensureTutorAndPetSelected, updateConsultaAgendaCard } from './consultas.js';
 import { updateCardDisplay } from './ui.js';
@@ -433,6 +434,16 @@ export async function loadPesosFromServer(options = {}) {
   }
 
   const key = getPesosKey(clienteId, petId);
+  if (isFinalizadoSelection(clienteId, petId)) {
+    state.pesos = [];
+    state.pesosLoadKey = key;
+    state.pesosLoading = false;
+    if (pesoModal.overlay && !pesoModal.overlay.classList.contains('hidden')) {
+      renderPesoList();
+    }
+    updateConsultaAgendaCard();
+    return;
+  }
   if (!force && key && state.pesosLoadKey === key && Array.isArray(state.pesos) && state.pesos.length) {
     return;
   }

--- a/scripts/funcionarios/vet/ficha-clinica/receitas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/receitas.js
@@ -16,6 +16,7 @@ import {
   getAuthToken,
   ANEXO_ALLOWED_EXTENSIONS,
   getFileExtension,
+  isFinalizadoSelection,
 } from './core.js';
 import { ensureTutorAndPetSelected, updateConsultaAgendaCard, getConsultasKey } from './consultas.js';
 import {
@@ -1055,6 +1056,13 @@ export async function loadReceitasFromServer(options = {}) {
   }
 
   const key = getConsultasKey(clienteId, petId);
+  if (isFinalizadoSelection(clienteId, petId)) {
+    state.receitas = [];
+    state.receitasLoadKey = key;
+    state.receitasLoading = false;
+    updateConsultaAgendaCard();
+    return;
+  }
   if (!force && key && state.receitasLoadKey === key) return;
 
   state.receitasLoading = true;

--- a/scripts/funcionarios/vet/ficha-clinica/tutor.js
+++ b/scripts/funcionarios/vet/ficha-clinica/tutor.js
@@ -20,6 +20,7 @@ import { loadPesosFromServer } from './pesos.js';
 import { loadDocumentosFromServer } from './documentos.js';
 import { loadReceitasFromServer } from './receitas.js';
 import { updateCardDisplay, updatePageVisibility, setCardMode } from './ui.js';
+import { loadHistoricoForSelection, setActiveMainTab } from './historico.js';
 
 function hideSugestoes() {
   if (els.cliSug) {
@@ -316,6 +317,7 @@ export async function onSelectPet(petId, opts = {}) {
   if (!skipPersistPet) {
     persistPetId(state.selectedPetId);
   }
+  setActiveMainTab('consulta');
   state.consultas = [];
   state.consultasLoadKey = null;
   state.consultasLoading = false;
@@ -339,6 +341,7 @@ export async function onSelectPet(petId, opts = {}) {
   loadAnexosForSelection();
   loadExamesForSelection();
   loadObservacoesForSelection();
+  loadHistoricoForSelection();
   updateCardDisplay();
   updatePageVisibility();
   if (!state.selectedPetId) {
@@ -379,12 +382,16 @@ export function clearCliente() {
   state.receitas = [];
   state.receitasLoadKey = null;
   state.receitasLoading = false;
+  state.historicos = [];
+  state.historicosLoadKey = null;
   persistAgendaContext(null);
   if (els.cliInput) els.cliInput.value = '';
   hideSugestoes();
   if (els.petSelect) {
     els.petSelect.innerHTML = `<option value="">Selecione o tutor para listar os pets</option>`;
   }
+  setActiveMainTab('consulta');
+  loadHistoricoForSelection();
   setCardMode('tutor');
   if (els.tutorNome) els.tutorNome.textContent = 'Nome Tutor';
   if (els.tutorEmail) els.tutorEmail.textContent = '—';
@@ -415,6 +422,10 @@ export function clearPet() {
   state.receitas = [];
   state.receitasLoadKey = null;
   state.receitasLoading = false;
+  state.historicos = [];
+  state.historicosLoadKey = null;
+  setActiveMainTab('consulta');
+  loadHistoricoForSelection();
   updateCardDisplay();
   updatePageVisibility();
 }

--- a/scripts/funcionarios/vet/ficha-clinica/tutor.js
+++ b/scripts/funcionarios/vet/ficha-clinica/tutor.js
@@ -10,6 +10,7 @@ import {
   persistPetId,
   persistAgendaContext,
   getPersistedState,
+  isFinalizadoSelection,
 } from './core.js';
 import { loadConsultasFromServer, updateConsultaAgendaCard } from './consultas.js';
 import { loadVacinasForSelection } from './vacinas.js';
@@ -317,7 +318,8 @@ export async function onSelectPet(petId, opts = {}) {
   if (!skipPersistPet) {
     persistPetId(state.selectedPetId);
   }
-  setActiveMainTab('consulta');
+  const defaultToHistorico = isFinalizadoSelection(state.selectedCliente?._id, state.selectedPetId);
+  setActiveMainTab(defaultToHistorico ? 'historico' : 'consulta');
   state.consultas = [];
   state.consultasLoadKey = null;
   state.consultasLoading = false;

--- a/scripts/funcionarios/vet/ficha-clinica/vacinas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/vacinas.js
@@ -14,6 +14,7 @@ import {
   getAgendaStoreId,
   getPetPriceCriteria,
   persistAgendaContext,
+  isFinalizadoSelection,
 } from './core.js';
 import { getConsultasKey, ensureTutorAndPetSelected, updateConsultaAgendaCard } from './consultas.js';
 
@@ -106,9 +107,20 @@ function persistVacinasForSelection() {
 }
 
 export function loadVacinasForSelection() {
-  const key = getVacinaStorageKey(state.selectedCliente?._id, state.selectedPetId);
+  const clienteId = state.selectedCliente?._id;
+  const petId = state.selectedPetId;
+  const key = getVacinaStorageKey(clienteId, petId);
   if (!key) {
     state.vacinas = [];
+    return;
+  }
+  if (isFinalizadoSelection(clienteId, petId)) {
+    state.vacinas = [];
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // ignore storage errors
+    }
     return;
   }
   try {


### PR DESCRIPTION
## Summary
- add dedicated controls to toggle between consulta and histórico tabs and display finalized appointments
- track finalized atendimentos locally with new historico management module and modal visualization
- orchestrate finalizar and reabrir flows, updating agenda status, clearing/persisting state, and wiring new actions into init/tutor logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceecd73180832392771bc54c3ef8ab