### PR TITLE
feat: enable real-time sync for ficha clínica

### DIFF
--- a/scripts/funcionarios/vet/ficha-clinica/atendimento.js
+++ b/scripts/funcionarios/vet/ficha-clinica/atendimento.js
@@ -23,6 +23,7 @@ import {
   setActiveMainTab,
   persistHistoricoEntry,
 } from './historico.js';
+import { emitFichaClinicaUpdate } from './real-time.js';
 
 function deepClone(value) {
   try {
@@ -214,6 +215,12 @@ export async function finalizarAtendimento() {
     renderHistoricoArea();
     updateConsultaAgendaCard();
 
+    emitFichaClinicaUpdate({
+      scope: 'atendimento',
+      action: 'finalizar',
+      appointmentId,
+    }).catch(() => {});
+
     notify('Atendimento finalizado com sucesso.', 'success');
   } catch (error) {
     console.error('finalizarAtendimento', error);
@@ -305,6 +312,12 @@ async function reopenHistoricoEntry(entry, closeModal) {
     if (typeof closeModal === 'function') {
       closeModal();
     }
+
+    emitFichaClinicaUpdate({
+      scope: 'atendimento',
+      action: 'reabrir',
+      appointmentId,
+    }).catch(() => {});
 
     notify('Atendimento reaberto para edição.', 'success');
   } catch (error) {

--- a/scripts/funcionarios/vet/ficha-clinica/consultas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/consultas.js
@@ -44,6 +44,7 @@ import {
   removeReceitaAssinada,
 } from './receitas.js';
 import { openVacinaModal } from './vacinas.js';
+import { emitFichaClinicaUpdate } from './real-time.js';
 
 function normalizeConsultaRecord(raw) {
   if (!raw || typeof raw !== 'object') return null;

--- a/scripts/funcionarios/vet/ficha-clinica/consultas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/consultas.js
@@ -455,6 +455,7 @@ async function deleteConsulta(record, options = {}) {
     });
     state.consultas = nextConsultas;
     notify('Consulta removida com sucesso.', 'success');
+    emitFichaClinicaUpdate({ scope: 'consulta', action: 'delete', consultaId }).catch(() => {});
     return true;
   } catch (error) {
     console.error('deleteConsulta', error);
@@ -2455,6 +2456,16 @@ async function handleConsultaSubmit() {
     }
 
     const wasEdit = isEdit;
+    const savedRecordId = normalizeId(
+      (saved && (saved.id || saved._id))
+        || (data && (data.id || data._id))
+        || modal.editingId,
+    );
+    emitFichaClinicaUpdate({
+      scope: 'consulta',
+      action: wasEdit ? 'update' : 'create',
+      consultaId: savedRecordId || null,
+    }).catch(() => {});
     closeConsultaModal();
     notify(wasEdit ? 'Consulta atualizada com sucesso.' : 'Consulta registrada com sucesso.', 'success');
   } catch (error) {

--- a/scripts/funcionarios/vet/ficha-clinica/exames.js
+++ b/scripts/funcionarios/vet/ficha-clinica/exames.js
@@ -58,6 +58,71 @@ function sanitizeAttachmentName(value) {
     .trim();
 }
 
+function safeClone(value) {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    if (Array.isArray(value)) {
+      return value.map((item) => (item && typeof item === 'object' ? { ...item } : item));
+    }
+    if (value && typeof value === 'object') {
+      return { ...value };
+    }
+    return value;
+  }
+}
+
+function buildExameEventPayload(extra = {}) {
+  const event = { ...extra };
+  const clienteId = normalizeId(state.selectedCliente?._id);
+  const petId = normalizeId(state.selectedPetId);
+  const appointmentId = normalizeId(state.agendaContext?.appointmentId);
+  if (clienteId) event.clienteId = clienteId;
+  if (petId) event.petId = petId;
+  if (appointmentId) event.appointmentId = appointmentId;
+  if (state.agendaContext && typeof state.agendaContext === 'object') {
+    if (Array.isArray(state.agendaContext.servicos)) {
+      event.agendaServicos = safeClone(state.agendaContext.servicos);
+    }
+    if (typeof state.agendaContext.valor === 'number') {
+      event.agendaValor = state.agendaContext.valor;
+    }
+  }
+  return event;
+}
+
+function applyExameAgendaSnapshot(event = {}) {
+  const appointmentId = normalizeId(event.appointmentId || event.agendamentoId || event.appointment);
+  const currentAppointment = normalizeId(state.agendaContext?.appointmentId);
+  if (currentAppointment && appointmentId && currentAppointment !== appointmentId) {
+    return;
+  }
+
+  if (!state.agendaContext || typeof state.agendaContext !== 'object') {
+    state.agendaContext = appointmentId ? { appointmentId } : {};
+  } else if (appointmentId && !state.agendaContext.appointmentId) {
+    state.agendaContext.appointmentId = appointmentId;
+  }
+
+  if (Array.isArray(event.agendaServicos)) {
+    state.agendaContext.servicos = safeClone(event.agendaServicos) || [];
+    state.agendaContext.totalServicos = state.agendaContext.servicos.length;
+  }
+
+  if (event.agendaValor !== undefined) {
+    const valor = Number(event.agendaValor);
+    if (!Number.isNaN(valor)) {
+      state.agendaContext.valor = valor;
+    }
+  }
+
+  if (state.agendaContext) {
+    persistAgendaContext(state.agendaContext);
+  }
+}
+
 function normalizeAttachmentExtension(extension) {
   if (!extension) return '';
   const str = String(extension).trim().toLowerCase();
@@ -1682,12 +1747,15 @@ async function handleExameSubmit() {
       persistExamesForSelection();
       updateConsultaAgendaCard();
       const updatedRecordId = normalizeId(updatedRecord?.id || updatedRecord?._id || editingId);
-      emitFichaClinicaUpdate({
-        scope: 'exame',
-        action: 'update',
-        exameId: updatedRecordId || null,
-        servicoId: normalizeId(service?._id) || null,
-      }).catch(() => {});
+      emitFichaClinicaUpdate(
+        buildExameEventPayload({
+          scope: 'exame',
+          action: 'update',
+          exameId: updatedRecordId || null,
+          servicoId: normalizeId(service?._id) || null,
+          exame: safeClone(updatedRecord),
+        }),
+      ).catch(() => {});
       closeExameModal();
       notify('Exame atualizado com sucesso.', 'success');
       return;
@@ -1767,12 +1835,15 @@ async function handleExameSubmit() {
     persistExamesForSelection();
     updateConsultaAgendaCard();
     const createdRecordId = normalizeId(record.id || record._id);
-    emitFichaClinicaUpdate({
-      scope: 'exame',
-      action: 'create',
-      exameId: createdRecordId || null,
-      servicoId: normalizeId(service?._id) || null,
-    }).catch(() => {});
+    emitFichaClinicaUpdate(
+      buildExameEventPayload({
+        scope: 'exame',
+        action: 'create',
+        exameId: createdRecordId || null,
+        servicoId: normalizeId(service?._id) || null,
+        exame: safeClone(record),
+      }),
+    ).catch(() => {});
     closeExameModal();
     notify('Exame registrado com sucesso.', 'success');
   } catch (error) {
@@ -1913,12 +1984,14 @@ export async function deleteExame(exame, options = {}) {
       }
     }
 
-    emitFichaClinicaUpdate({
-      scope: 'exame',
-      action: 'delete',
-      exameId,
-      servicoId,
-    }).catch(() => {});
+    emitFichaClinicaUpdate(
+      buildExameEventPayload({
+        scope: 'exame',
+        action: 'delete',
+        exameId,
+        servicoId,
+      }),
+    ).catch(() => {});
     notify('Exame removido com sucesso.', 'success');
     return true;
   } catch (error) {
@@ -1932,6 +2005,91 @@ export async function deleteExame(exame, options = {}) {
 }
 
 state.deleteExame = deleteExame;
+
+export function handleExameRealTimeEvent(event = {}) {
+  if (!event || typeof event !== 'object') return false;
+  if (event.scope && event.scope !== 'exame') return false;
+
+  const action = String(event.action || '').toLowerCase();
+  const targetClienteId = normalizeId(event.clienteId || event.tutorId || event.cliente);
+  const targetPetId = normalizeId(event.petId || event.pet);
+  const targetAppointmentId = normalizeId(event.appointmentId || event.agendamentoId || event.appointment);
+
+  const currentClienteId = normalizeId(state.selectedCliente?._id);
+  const currentPetId = normalizeId(state.selectedPetId);
+  const currentAppointmentId = normalizeId(state.agendaContext?.appointmentId);
+
+  if (targetClienteId && currentClienteId && targetClienteId !== currentClienteId) return false;
+  if (targetPetId && currentPetId && targetPetId !== currentPetId) return false;
+  if (targetAppointmentId && currentAppointmentId && targetAppointmentId !== currentAppointmentId) return false;
+
+  let changed = false;
+
+  if (action === 'delete') {
+    const exameId = normalizeId(event.exameId || event.id || event.recordId);
+    if (!exameId) return false;
+    const previous = Array.isArray(state.exames) ? state.exames : [];
+    const next = previous.filter((item) => normalizeId(item?.id || item?._id) !== exameId);
+    if (next.length !== previous.length) {
+      state.exames = next;
+      const key = getConsultasKey(state.selectedCliente?._id, state.selectedPetId);
+      if (key) {
+        state.examesLoadKey = key;
+      }
+      persistExamesForSelection();
+      changed = true;
+    }
+    applyExameAgendaSnapshot(event);
+    if (changed) {
+      updateConsultaAgendaCard();
+    }
+    return changed;
+  }
+
+  const payload = event.exame || event.record || event.data;
+  if (!payload || typeof payload !== 'object') {
+    applyExameAgendaSnapshot(event);
+    return false;
+  }
+
+  const record = normalizeExameRecord({
+    ...payload,
+    id: payload.id || payload._id || event.exameId || event.id,
+  });
+  if (!record) {
+    applyExameAgendaSnapshot(event);
+    return false;
+  }
+
+  if (targetAppointmentId && !record.appointmentId) {
+    record.appointmentId = targetAppointmentId;
+  }
+
+  const list = Array.isArray(state.exames) ? [...state.exames] : [];
+  const recordId = normalizeId(record.id || record._id);
+  let updated = false;
+  for (let i = 0; i < list.length; i += 1) {
+    const entryId = normalizeId(list[i]?.id || list[i]?._id);
+    if (entryId && recordId && entryId === recordId) {
+      list[i] = { ...list[i], ...record, id: recordId, _id: recordId };
+      updated = true;
+      break;
+    }
+  }
+  if (!updated) {
+    list.unshift({ ...record, id: recordId, _id: recordId });
+  }
+
+  state.exames = list;
+  const key = getConsultasKey(state.selectedCliente?._id, state.selectedPetId);
+  if (key) {
+    state.examesLoadKey = key;
+  }
+  persistExamesForSelection();
+  applyExameAgendaSnapshot(event);
+  updateConsultaAgendaCard();
+  return true;
+}
 
 export function openExameModal(options = {}) {
   if (!ensureTutorAndPetSelected()) {

--- a/scripts/funcionarios/vet/ficha-clinica/init.js
+++ b/scripts/funcionarios/vet/ficha-clinica/init.js
@@ -30,6 +30,7 @@ import {
   activateHistoricoTab,
   activateConsultaTab,
   reopenCurrentAgendamento,
+  handleAtendimentoRealTimeEvent,
 } from './atendimento.js';
 import { loadHistoricoForSelection } from './historico.js';
 import {
@@ -79,7 +80,9 @@ function handleFichaRealTimeMessage(message) {
 
   if (event && typeof event === 'object') {
     const scope = event.scope;
-    if (scope === 'vacina') {
+    if (scope === 'atendimento') {
+      handled = handleAtendimentoRealTimeEvent(event) || handled;
+    } else if (scope === 'vacina') {
       handled = handleVacinaRealTimeEvent(event) || handled;
     } else if (scope === 'exame') {
       handled = handleExameRealTimeEvent(event) || handled;

--- a/scripts/funcionarios/vet/ficha-clinica/init.js
+++ b/scripts/funcionarios/vet/ficha-clinica/init.js
@@ -11,7 +11,11 @@ import { openDocumentoModal, loadDocumentosFromServer } from './documentos.js';
 import { openReceitaModal, loadReceitasFromServer } from './receitas.js';
 import { openExameModal, loadExamesForSelection, handleExameRealTimeEvent } from './exames.js';
 import { openPesoModal, loadPesosFromServer } from './pesos.js';
-import { openObservacaoModal, loadObservacoesForSelection } from './observacoes.js';
+import {
+  openObservacaoModal,
+  loadObservacoesForSelection,
+  handleObservacaoRealTimeEvent,
+} from './observacoes.js';
 import {
   searchClientes,
   hideSugestoes,
@@ -79,6 +83,8 @@ function handleFichaRealTimeMessage(message) {
       handled = handleVacinaRealTimeEvent(event) || handled;
     } else if (scope === 'exame') {
       handled = handleExameRealTimeEvent(event) || handled;
+    } else if (scope === 'observacao') {
+      handled = handleObservacaoRealTimeEvent(event) || handled;
     }
   }
 

--- a/scripts/funcionarios/vet/ficha-clinica/real-time.js
+++ b/scripts/funcionarios/vet/ficha-clinica/real-time.js
@@ -83,6 +83,27 @@ function getSelectionSnapshot() {
   };
 }
 
+function cloneEventPayload(event) {
+  if (!event || typeof event !== 'object') return {};
+  try {
+    return JSON.parse(JSON.stringify(event));
+  } catch {
+    if (Array.isArray(event)) {
+      return event.map((item) => (item && typeof item === 'object' ? cloneEventPayload(item) : item));
+    }
+    const result = {};
+    Object.keys(event).forEach((key) => {
+      const value = event[key];
+      if (value && typeof value === 'object') {
+        result[key] = cloneEventPayload(value);
+      } else {
+        result[key] = value;
+      }
+    });
+    return result;
+  }
+}
+
 function setupSocketListeners() {
   if (!socket) return;
 
@@ -244,7 +265,7 @@ export async function emitFichaClinicaUpdate(event = {}) {
       petId: selection.petId,
       appointmentId: selection.appointmentId || null,
     },
-    event: event && typeof event === 'object' ? { ...event } : {},
+    event: cloneEventPayload(event),
     userId: getCurrentUserId() || null,
     timestamp: Date.now(),
   });

--- a/scripts/funcionarios/vet/ficha-clinica/real-time.js
+++ b/scripts/funcionarios/vet/ficha-clinica/real-time.js
@@ -1,0 +1,252 @@
+// Real-time synchronization helpers for the Vet ficha clínica
+import { state, normalizeId, getCurrentUserId } from './core.js';
+
+let socket = null;
+let socketPromise = null;
+let scriptPromise = null;
+let targetRoomKey = null;
+let targetSelection = null;
+let currentRoomKey = null;
+const updateHandlers = new Set();
+
+function getServerBaseUrl() {
+  let base = '';
+  try {
+    if (typeof API_CONFIG !== 'undefined' && API_CONFIG && typeof API_CONFIG.SERVER_URL === 'string') {
+      base = API_CONFIG.SERVER_URL;
+    }
+  } catch (_) {
+    // ignore reference errors when API_CONFIG is not defined
+  }
+
+  if (!base && typeof window !== 'undefined') {
+    const cfg = window.API_CONFIG;
+    if (cfg && typeof cfg.SERVER_URL === 'string') {
+      base = cfg.SERVER_URL;
+    }
+  }
+
+  if (!base && typeof window !== 'undefined' && window.location) {
+    base = window.location.origin;
+  }
+
+  if (!base) return '';
+  return String(base).replace(/\/+$/, '');
+}
+
+function ensureSocketIoScript() {
+  if (typeof window === 'undefined') return Promise.resolve();
+  if (typeof window.io === 'function') return Promise.resolve();
+  if (scriptPromise) return scriptPromise;
+
+  const baseUrl = getServerBaseUrl() || '';
+  const src = baseUrl ? `${baseUrl}/socket.io/socket.io.js` : '/socket.io/socket.io.js';
+
+  scriptPromise = new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.crossOrigin = 'anonymous';
+    script.onload = () => resolve();
+    script.onerror = (event) => {
+      console.error('Não foi possível carregar o cliente Socket.IO.', event);
+      scriptPromise = null;
+      reject(new Error('socket.io-load-failed'));
+    };
+    document.head.appendChild(script);
+  });
+
+  return scriptPromise;
+}
+
+function computeRoomKey(clienteId, petId, appointmentId) {
+  const tutor = normalizeId(clienteId);
+  const pet = normalizeId(petId);
+  if (!(tutor && pet)) return '';
+  const appointment = normalizeId(appointmentId);
+  if (appointment) {
+    return `vet:ficha:${tutor}:${pet}:appt:${appointment}`;
+  }
+  return `vet:ficha:${tutor}:${pet}`;
+}
+
+function getSelectionSnapshot() {
+  const clienteId = normalizeId(state.selectedCliente?._id);
+  const petId = normalizeId(state.selectedPetId);
+  if (!(clienteId && petId)) return null;
+  const appointmentId = normalizeId(state.agendaContext?.appointmentId);
+  return {
+    clienteId,
+    petId,
+    appointmentId,
+    roomKey: computeRoomKey(clienteId, petId, appointmentId),
+  };
+}
+
+function setupSocketListeners() {
+  if (!socket) return;
+
+  socket.on('connect', () => {
+    currentRoomKey = null;
+    syncRoomWithServer();
+  });
+
+  socket.on('reconnect', () => {
+    currentRoomKey = null;
+    syncRoomWithServer();
+  });
+
+  socket.on('vet:ficha:update', (message) => {
+    if (!message || typeof message !== 'object') return;
+
+    const localSelection = getSelectionSnapshot();
+    if (!localSelection) return;
+
+    const remoteSelection = (() => {
+      const rawSelection = message.selection || {};
+      const clienteId = normalizeId(
+        rawSelection.clienteId
+          || rawSelection.tutorId
+          || rawSelection.cliente
+          || rawSelection.tutor,
+      );
+      const petId = normalizeId(rawSelection.petId || rawSelection.pet);
+      if (!(clienteId && petId)) return null;
+      const appointmentId = normalizeId(
+        rawSelection.appointmentId
+          || rawSelection.appointment
+          || rawSelection.agendamentoId,
+      );
+      return { clienteId, petId, appointmentId };
+    })();
+
+    if (!remoteSelection) return;
+
+    if (remoteSelection.clienteId !== localSelection.clienteId) return;
+    if (remoteSelection.petId !== localSelection.petId) return;
+
+    const localAppointment = normalizeId(localSelection.appointmentId);
+    const remoteAppointment = normalizeId(remoteSelection.appointmentId);
+    if (localAppointment && remoteAppointment && localAppointment !== remoteAppointment) {
+      return;
+    }
+
+    updateHandlers.forEach((handler) => {
+      try {
+        handler(message);
+      } catch (error) {
+        console.error('Erro ao processar atualização em tempo real da ficha clínica.', error);
+      }
+    });
+  });
+}
+
+function syncRoomWithServer() {
+  if (!socket || !socket.connected) return;
+
+  if (currentRoomKey && currentRoomKey !== targetRoomKey) {
+    socket.emit('vet:ficha:leave', { room: currentRoomKey });
+    currentRoomKey = null;
+  }
+
+  if (targetRoomKey && currentRoomKey !== targetRoomKey) {
+    socket.emit('vet:ficha:join', {
+      room: targetRoomKey,
+      selection: targetSelection,
+      userId: getCurrentUserId() || null,
+      timestamp: Date.now(),
+    });
+    currentRoomKey = targetRoomKey;
+  }
+
+  if (!targetRoomKey && currentRoomKey) {
+    socket.emit('vet:ficha:leave', { room: currentRoomKey });
+    currentRoomKey = null;
+  }
+}
+
+async function ensureSocket() {
+  if (socket) return socket;
+
+  if (!socketPromise) {
+    socketPromise = ensureSocketIoScript()
+      .then(() => {
+        if (typeof window === 'undefined' || typeof window.io !== 'function') {
+          throw new Error('Socket.IO client indisponível.');
+        }
+        const baseUrl = getServerBaseUrl();
+        socket = window.io(baseUrl || undefined, {
+          transports: ['websocket', 'polling'],
+          autoConnect: true,
+          reconnection: true,
+        });
+        setupSocketListeners();
+        return socket;
+      })
+      .catch((error) => {
+        console.error('Falha ao inicializar a conexão em tempo real da ficha clínica.', error);
+        socketPromise = null;
+        socket = null;
+        return null;
+      });
+  }
+
+  return socketPromise;
+}
+
+export async function initFichaRealTime() {
+  await ensureSocket();
+  if (socket && socket.connected) {
+    syncRoomWithServer();
+  }
+}
+
+export function registerFichaUpdateHandler(handler) {
+  if (typeof handler === 'function') {
+    updateHandlers.add(handler);
+  }
+}
+
+export function unregisterFichaUpdateHandler(handler) {
+  if (typeof handler === 'function') {
+    updateHandlers.delete(handler);
+  }
+}
+
+export async function updateFichaRealTimeSelection() {
+  const selection = getSelectionSnapshot();
+  if (!selection || !selection.roomKey) {
+    targetRoomKey = null;
+    targetSelection = null;
+  } else {
+    targetRoomKey = selection.roomKey;
+    targetSelection = {
+      clienteId: selection.clienteId,
+      petId: selection.petId,
+      appointmentId: selection.appointmentId || null,
+    };
+  }
+
+  await ensureSocket();
+  syncRoomWithServer();
+}
+
+export async function emitFichaClinicaUpdate(event = {}) {
+  await ensureSocket();
+  if (!socket || !targetRoomKey) return;
+  const selection = getSelectionSnapshot();
+  if (!selection || selection.roomKey !== targetRoomKey) return;
+
+  socket.emit('vet:ficha:update', {
+    room: targetRoomKey,
+    selection: targetSelection || {
+      clienteId: selection.clienteId,
+      petId: selection.petId,
+      appointmentId: selection.appointmentId || null,
+    },
+    event: event && typeof event === 'object' ? { ...event } : {},
+    userId: getCurrentUserId() || null,
+    timestamp: Date.now(),
+  });
+}
+

--- a/scripts/funcionarios/vet/ficha-clinica/tutor.js
+++ b/scripts/funcionarios/vet/ficha-clinica/tutor.js
@@ -22,6 +22,7 @@ import { loadDocumentosFromServer } from './documentos.js';
 import { loadReceitasFromServer } from './receitas.js';
 import { updateCardDisplay, updatePageVisibility, setCardMode } from './ui.js';
 import { loadHistoricoForSelection, setActiveMainTab } from './historico.js';
+import { updateFichaRealTimeSelection } from './real-time.js';
 
 function hideSugestoes() {
   if (els.cliSug) {
@@ -241,6 +242,8 @@ export async function onSelectCliente(cli, opts = {}) {
     persistPetId(null);
   }
 
+  updateFichaRealTimeSelection().catch(() => {});
+
   updatePageVisibility();
   updateConsultaAgendaCard();
 
@@ -318,6 +321,7 @@ export async function onSelectPet(petId, opts = {}) {
   if (!skipPersistPet) {
     persistPetId(state.selectedPetId);
   }
+  updateFichaRealTimeSelection().catch(() => {});
   const defaultToHistorico = isFinalizadoSelection(state.selectedCliente?._id, state.selectedPetId);
   setActiveMainTab(defaultToHistorico ? 'historico' : 'consulta');
   state.consultas = [];
@@ -401,6 +405,7 @@ export function clearCliente() {
   persistCliente(null);
   updatePageVisibility();
   updateConsultaAgendaCard();
+  updateFichaRealTimeSelection().catch(() => {});
 }
 
 export function clearPet() {
@@ -432,6 +437,7 @@ export function clearPet() {
   loadHistoricoForSelection();
   updateCardDisplay();
   updatePageVisibility();
+  updateFichaRealTimeSelection().catch(() => {});
 }
 
 export function restorePersistedSelection() {
@@ -461,4 +467,5 @@ export function restorePersistedSelection() {
   } else if (petId) {
     persistPetId(null);
   }
+  updateFichaRealTimeSelection().catch(() => {});
 }

--- a/scripts/funcionarios/vet/ficha-clinica/vacinas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/vacinas.js
@@ -17,6 +17,7 @@ import {
   isFinalizadoSelection,
 } from './core.js';
 import { getConsultasKey, ensureTutorAndPetSelected, updateConsultaAgendaCard } from './consultas.js';
+import { emitFichaClinicaUpdate } from './real-time.js';
 
 function getVacinaStorageKey(clienteId, petId) {
   const base = getConsultasKey(clienteId, petId);
@@ -958,6 +959,13 @@ async function handleVacinaSubmit() {
 
     persistVacinasForSelection();
     updateConsultaAgendaCard();
+    const recordId = normalizeId(nextRecord.id || nextRecord._id);
+    emitFichaClinicaUpdate({
+      scope: 'vacina',
+      action: isEditing ? 'update' : 'create',
+      vacinaId: recordId || null,
+      servicoId: normalizedServiceId || null,
+    }).catch(() => {});
     closeVacinaModal();
     notify(isEditing ? 'Vacina atualizada com sucesso.' : 'Vacina registrada com sucesso.', 'success');
   } catch (error) {
@@ -1103,6 +1111,12 @@ export async function deleteVacina(vacina, options = {}) {
     persistVacinasForSelection();
     updateConsultaAgendaCard();
     notify('Vacina removida com sucesso.', 'success');
+    emitFichaClinicaUpdate({
+      scope: 'vacina',
+      action: 'delete',
+      vacinaId: recordId || null,
+      servicoId,
+    }).catch(() => {});
     return true;
   } catch (error) {
     console.error('deleteVacina', error);

--- a/scripts/funcionarios/vet/ficha-clinica/vacinas.js
+++ b/scripts/funcionarios/vet/ficha-clinica/vacinas.js
@@ -49,6 +49,71 @@ function normalizeDateInputValue(value) {
   }
 }
 
+function safeClone(value) {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    if (Array.isArray(value)) {
+      return value.map((item) => (item && typeof item === 'object' ? { ...item } : item));
+    }
+    if (value && typeof value === 'object') {
+      return { ...value };
+    }
+    return value;
+  }
+}
+
+function buildVacinaEventPayload(extra = {}) {
+  const event = { ...extra };
+  const clienteId = normalizeId(state.selectedCliente?._id);
+  const petId = normalizeId(state.selectedPetId);
+  const appointmentId = normalizeId(state.agendaContext?.appointmentId);
+  if (clienteId) event.clienteId = clienteId;
+  if (petId) event.petId = petId;
+  if (appointmentId) event.appointmentId = appointmentId;
+  if (state.agendaContext && typeof state.agendaContext === 'object') {
+    if (Array.isArray(state.agendaContext.servicos)) {
+      event.agendaServicos = safeClone(state.agendaContext.servicos);
+    }
+    if (typeof state.agendaContext.valor === 'number') {
+      event.agendaValor = state.agendaContext.valor;
+    }
+  }
+  return event;
+}
+
+function applyAgendaSnapshotFromEvent(event = {}) {
+  const appointmentId = normalizeId(event.appointmentId || event.agendamentoId || event.appointment);
+  const currentAppointment = normalizeId(state.agendaContext?.appointmentId);
+  if (currentAppointment && appointmentId && currentAppointment !== appointmentId) {
+    return;
+  }
+
+  if (!state.agendaContext || typeof state.agendaContext !== 'object') {
+    state.agendaContext = appointmentId ? { appointmentId } : {};
+  } else if (appointmentId && !state.agendaContext.appointmentId) {
+    state.agendaContext.appointmentId = appointmentId;
+  }
+
+  if (Array.isArray(event.agendaServicos)) {
+    state.agendaContext.servicos = safeClone(event.agendaServicos) || [];
+    state.agendaContext.totalServicos = state.agendaContext.servicos.length;
+  }
+
+  if (event.agendaValor !== undefined) {
+    const valor = Number(event.agendaValor);
+    if (!Number.isNaN(valor)) {
+      state.agendaContext.valor = valor;
+    }
+  }
+
+  if (state.agendaContext) {
+    persistAgendaContext(state.agendaContext);
+  }
+}
+
 function normalizeVacinaRecord(raw) {
   if (!raw || typeof raw !== 'object') return null;
   const servicoId = normalizeId(raw.servicoId || raw.servico || raw.serviceId);
@@ -960,12 +1025,15 @@ async function handleVacinaSubmit() {
     persistVacinasForSelection();
     updateConsultaAgendaCard();
     const recordId = normalizeId(nextRecord.id || nextRecord._id);
-    emitFichaClinicaUpdate({
-      scope: 'vacina',
-      action: isEditing ? 'update' : 'create',
-      vacinaId: recordId || null,
-      servicoId: normalizedServiceId || null,
-    }).catch(() => {});
+    emitFichaClinicaUpdate(
+      buildVacinaEventPayload({
+        scope: 'vacina',
+        action: isEditing ? 'update' : 'create',
+        vacinaId: recordId || null,
+        servicoId: normalizedServiceId || null,
+        vacina: safeClone(nextRecord),
+      }),
+    ).catch(() => {});
     closeVacinaModal();
     notify(isEditing ? 'Vacina atualizada com sucesso.' : 'Vacina registrada com sucesso.', 'success');
   } catch (error) {
@@ -1111,12 +1179,14 @@ export async function deleteVacina(vacina, options = {}) {
     persistVacinasForSelection();
     updateConsultaAgendaCard();
     notify('Vacina removida com sucesso.', 'success');
-    emitFichaClinicaUpdate({
-      scope: 'vacina',
-      action: 'delete',
-      vacinaId: recordId || null,
-      servicoId,
-    }).catch(() => {});
+    emitFichaClinicaUpdate(
+      buildVacinaEventPayload({
+        scope: 'vacina',
+        action: 'delete',
+        vacinaId: recordId || null,
+        servicoId,
+      }),
+    ).catch(() => {});
     return true;
   } catch (error) {
     console.error('deleteVacina', error);
@@ -1126,3 +1196,90 @@ export async function deleteVacina(vacina, options = {}) {
 }
 
 state.deleteVacina = deleteVacina;
+
+export function handleVacinaRealTimeEvent(event = {}) {
+  if (!event || typeof event !== 'object') return false;
+  if (event.scope && event.scope !== 'vacina') return false;
+
+  const action = String(event.action || '').toLowerCase();
+  const targetClienteId = normalizeId(event.clienteId || event.tutorId || event.cliente);
+  const targetPetId = normalizeId(event.petId || event.pet);
+  const targetAppointmentId = normalizeId(
+    event.appointmentId || event.agendamentoId || event.appointment,
+  );
+
+  const currentClienteId = normalizeId(state.selectedCliente?._id);
+  const currentPetId = normalizeId(state.selectedPetId);
+  const currentAppointmentId = normalizeId(state.agendaContext?.appointmentId);
+
+  if (targetClienteId && currentClienteId && targetClienteId !== currentClienteId) return false;
+  if (targetPetId && currentPetId && targetPetId !== currentPetId) return false;
+  if (targetAppointmentId && currentAppointmentId && targetAppointmentId !== currentAppointmentId) return false;
+
+  let changed = false;
+
+  if (action === 'delete') {
+    const vacinaId = normalizeId(event.vacinaId || event.id || event.recordId);
+    if (!vacinaId) return false;
+    const previous = Array.isArray(state.vacinas) ? state.vacinas : [];
+    const next = previous.filter((item) => normalizeId(item?.id || item?._id) !== vacinaId);
+    if (next.length !== previous.length) {
+      state.vacinas = next;
+      const storageKey = getConsultasKey(state.selectedCliente?._id, state.selectedPetId);
+      if (storageKey) {
+        state.vacinasLoadKey = storageKey;
+      }
+      persistVacinasForSelection();
+      changed = true;
+    }
+    applyAgendaSnapshotFromEvent(event);
+    if (changed) {
+      updateConsultaAgendaCard();
+    }
+    return changed;
+  }
+
+  const payload = event.vacina || event.record || event.data;
+  if (!payload || typeof payload !== 'object') {
+    applyAgendaSnapshotFromEvent(event);
+    return false;
+  }
+
+  const record = normalizeVacinaRecord({
+    ...payload,
+    id: payload.id || payload._id || event.vacinaId || event.id,
+  });
+  if (!record) {
+    applyAgendaSnapshotFromEvent(event);
+    return false;
+  }
+
+  if (targetAppointmentId && !record.appointmentId) {
+    record.appointmentId = targetAppointmentId;
+  }
+
+  const list = Array.isArray(state.vacinas) ? [...state.vacinas] : [];
+  const recordId = normalizeId(record.id || record._id);
+  let updated = false;
+  for (let i = 0; i < list.length; i += 1) {
+    const entryId = normalizeId(list[i]?.id || list[i]?._id);
+    if (entryId && recordId && entryId === recordId) {
+      list[i] = { ...list[i], ...record, id: recordId, _id: recordId };
+      updated = true;
+      break;
+    }
+  }
+  if (!updated) {
+    list.unshift({ ...record, id: recordId, _id: recordId });
+  }
+
+  state.vacinas = list;
+  const storageKey = getConsultasKey(state.selectedCliente?._id, state.selectedPetId);
+  if (storageKey) {
+    state.vacinasLoadKey = storageKey;
+  }
+  persistVacinasForSelection();
+  applyAgendaSnapshotFromEvent(event);
+  updateConsultaAgendaCard();
+  return true;
+}


### PR DESCRIPTION
## Summary
- add a ficha clínica real-time helper module that connects to Socket.IO, manages room subscriptions, and exposes emit/update APIs
- bootstrap the real-time connection during ficha init, refreshing the current selection whenever remote updates arrive
- emit synchronization events after every ficha clínica mutation (consultas, anexos, vacinas, documentos, receitas, exames, pesos, atendimento) and extend the server to broadcast them to room members

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf1e2ac66883238ea88cf137fdedb2