### PR TITLE
Fix real-time attachment sync

### DIFF
--- a/scripts/funcionarios/vet/ficha-clinica/init.js
+++ b/scripts/funcionarios/vet/ficha-clinica/init.js
@@ -6,6 +6,7 @@ import {
   openAnexoModal,
   loadAnexosForSelection,
   loadAnexosFromServer,
+  handleAnexoRealTimeEvent,
 } from './anexos.js';
 import { openDocumentoModal, loadDocumentosFromServer } from './documentos.js';
 import { openReceitaModal, loadReceitasFromServer } from './receitas.js';
@@ -88,6 +89,8 @@ function handleFichaRealTimeMessage(message) {
       handled = handleExameRealTimeEvent(event) || handled;
     } else if (scope === 'observacao') {
       handled = handleObservacaoRealTimeEvent(event) || handled;
+    } else if (scope === 'anexo') {
+      handled = handleAnexoRealTimeEvent(event) || handled;
     }
   }
 


### PR DESCRIPTION
## Summary
- add a merge helper so locally cached attachments combine with data fetched from the server
- prevent the ficha clínica attachment loader from clearing remote updates when no local cache exists

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d16086b6308323b379c0e4d0870585