### PR TITLE
Ajusta largura dinâmica da agenda de serviços

### DIFF
--- a/src/input.css
+++ b/src/input.css
@@ -695,6 +695,14 @@
     display: flex;
     flex-direction: column;
     gap: 1rem;
+    align-items: flex-start;
+    width: max-content;
+    min-width: 100%;
+  }
+
+  #agenda-list > * {
+    width: max-content;
+    min-width: 100%;
   }
 
   #agenda-wrapper .agenda-grid-header {

--- a/src/output.css
+++ b/src/output.css
@@ -4348,6 +4348,13 @@
     display: flex;
     flex-direction: column;
     gap: 1rem;
+    align-items: flex-start;
+    width: max-content;
+    min-width: 100%;
+  }
+  #agenda-list > * {
+    width: max-content;
+    min-width: 100%;
   }
   #agenda-wrapper .agenda-grid-header {
     border-radius: 20px;


### PR DESCRIPTION
## Summary
- permite que o contêiner da agenda expanda de acordo com o conteúdo ao alinhar os itens e definir largura baseada no conteúdo
- garante que cabeçalho e corpo da grade mantenham largura mínima de 100% e cresçam juntos quando houver muitos profissionais

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d19e279b848323bed9d35bdf11990e