### PR TITLE
Refina layout dos cartões da agenda

### DIFF
--- a/scripts/funcionarios/banho-e-tosa.js
+++ b/scripts/funcionarios/banho-e-tosa.js
@@ -726,42 +726,43 @@
         const card = document.createElement('div');
         card.setAttribute('data-appointment-id', a._id || '');
         card.style.setProperty('--stripe', meta.stripe);
-        card.style.setProperty('--card-max-w', '260px');
+        card.style.setProperty('--card-max-w', '320px');
         card.className = `agenda-card border ${meta.borderClass} cursor-move select-none`;
+        card.dataset.status = meta.key;
         card.setAttribute('draggable', 'true');
 
         const headerEl = document.createElement('div');
-        // reserva espaço à direita para os botões flutuantes (evita o chip “ficar por baixo”)
-        headerEl.className = 'flex items-center justify-between gap-2 pr-14 md:pr-16 mb-1';
+        headerEl.className = 'agenda-card__head flex justify-between';
 
         // usa o nome do cliente que já vem da API (clienteNome); fallback mantém o comportamento antigo
         const tutorShort = shortTutorName(a.clienteNome || '');
         const headLabel  = tutorShort ? `${tutorShort} | ${a.pet || ''}` : (a.pet || '');
 
         headerEl.innerHTML = `
-          <div class="font-semibold text-sm text-gray-900 truncate" title="${headLabel}">${headLabel}</div>
+          <div class="agenda-card__title font-semibold text-gray-900 truncate" title="${headLabel}">${headLabel}</div>
           ${renderStatusBadge(a.status)}
         `;
 
         const bodyEl = document.createElement('div');
+        bodyEl.classList.add('agenda-card__body');
         if (a.observacoes && String(a.observacoes).trim()) {
           const svc = document.createElement('div');
-          svc.className = 'text-[13px] text-gray-600 clamp-2';
+          svc.className = 'agenda-card__service text-gray-600 clamp-2';
           svc.textContent = a.servico || '';
           const obs = document.createElement('div');
-          obs.className = 'mt-1 text-[12px] text-gray-700 italic clamp-2';
+          obs.className = 'agenda-card__note mt-1 text-gray-700 italic clamp-2';
           obs.textContent = String(a.observacoes).trim();
           bodyEl.appendChild(svc);
           bodyEl.appendChild(obs);
         } else {
-          bodyEl.className = 'text-[13px] text-gray-600 clamp-2';
+          bodyEl.classList.add('text-gray-600', 'clamp-2');
           bodyEl.textContent = a.servico || '';
         }
 
         const footerEl = document.createElement('div');
-        footerEl.className = 'flex items-center justify-end gap-2 pt-1';
+        footerEl.className = 'agenda-card__footer flex items-center justify-end';
         const price = document.createElement('div');
-        price.className = 'text-[13px] text-gray-800 font-medium';
+        price.className = 'agenda-card__price text-gray-800 font-medium';
         price.textContent = money(a.valor);
 
         footerEl.appendChild(price);
@@ -857,7 +858,8 @@
       card.setAttribute('data-appointment-id', a._id || '');
       card.style.setProperty('--stripe', meta.stripe);
       card.style.setProperty('--card-max-w', '100%');                       // ocupa a coluna
-      card.className = `agenda-card border ${meta.borderClass} cursor-pointer select-none px-2 py-1`; // padding menor
+      card.className = `agenda-card agenda-card--compact border ${meta.borderClass} cursor-pointer select-none px-2 py-1`; // padding menor
+      card.dataset.status = meta.key;
       card.setAttribute('draggable', 'true');
       card.title = [
         a.pet || '',
@@ -867,35 +869,36 @@
 
       // Header: Tutor abreviado | Pet (sem hora)
       const headerEl = document.createElement('div');
-      headerEl.className = 'flex items-center justify-between gap-2 mb-1';
+      headerEl.className = 'agenda-card__head flex justify-between';
       const tutorShort = shortTutorName(a.clienteNome || a.tutor || '');
       const headLabel  = tutorShort ? `${tutorShort} | ${a.pet || ''}` : (a.pet || '');
       headerEl.innerHTML = `
-        <div class="font-medium text-[12px] text-gray-900 truncate" title="${headLabel}">${headLabel}</div>
+        <div class="agenda-card__title font-medium text-gray-900 truncate" title="${headLabel}">${headLabel}</div>
         <!-- nada do lado direito no header -->
       `;
 
       // Corpo: serviço 1 linha + observação 1 linha (opcional)
       const bodyEl = document.createElement('div');
+      bodyEl.classList.add('agenda-card__body');
       const svc = document.createElement('div');
-      svc.className = 'text-[12px] text-gray-600 truncate';
+      svc.className = 'agenda-card__service text-gray-600 truncate';
       svc.textContent = a.servico || '';
       bodyEl.appendChild(svc);
       if (a.observacoes && String(a.observacoes).trim()) {
         const obs = document.createElement('div');
-        obs.className = 'text-[11px] text-gray-700 italic truncate';
+        obs.className = 'agenda-card__note text-gray-700 italic truncate';
         obs.textContent = String(a.observacoes).trim();
         bodyEl.appendChild(obs);
       }
 
       // Rodapé: status + valor à direita
       const footerEl = document.createElement('div');
-      footerEl.className = 'flex items-center justify-end gap-2 pt-0.5';
+      footerEl.className = 'agenda-card__footer flex items-center justify-end';
       const statusEl = document.createElement('div');
       // badge menor para caber bem
       statusEl.innerHTML = renderStatusBadge(a.status).replace('text-xs','text-[10px]');
       const price = document.createElement('div');
-      price.className = 'text-[12px] text-gray-800 font-semibold';
+      price.className = 'agenda-card__price text-gray-800 font-semibold';
       price.textContent = money(a.valor);
       footerEl.appendChild(statusEl);
       footerEl.appendChild(price);
@@ -983,7 +986,8 @@
       card.setAttribute('data-appointment-id', a._id || '');
       card.style.setProperty('--stripe', meta.stripe);
       card.style.setProperty('--card-max-w', '100%');
-      card.className = `agenda-card border ${meta.borderClass} cursor-pointer select-none px-2 py-1`; // padding menor
+      card.className = `agenda-card agenda-card--compact border ${meta.borderClass} cursor-pointer select-none px-2 py-1`; // padding menor
+      card.dataset.status = meta.key;
       card.setAttribute('draggable', 'true');
       card.title = [
         a.pet || '',
@@ -993,7 +997,7 @@
 
       // Header: hora + STATUS centralizado (reserva espaço p/ botões à direita)
       const headerEl = document.createElement('div');
-      headerEl.className = 'flex items-center gap-2 pr-14 md:pr-16 mb-1';
+      headerEl.className = 'agenda-card__head flex items-center gap-2';
       headerEl.innerHTML = `
         <span class="inline-flex items-center px-1.5 py-[1px] rounded bg-slate-100 text-[10px] font-medium">${hhmm}</span>
         <div class="flex-1 flex items-center justify-center">
@@ -1016,15 +1020,15 @@
       const headLabel  = [tutorShort, (a.pet || '')].filter(Boolean).join(' | ');
 
       const nameEl = document.createElement('div');
-      nameEl.className = 'text-[12px] font-medium text-gray-900 text-center truncate';
+      nameEl.className = 'agenda-card__title font-medium text-gray-900 text-center truncate';
       nameEl.title = headLabel;
       nameEl.textContent = headLabel;
 
       // Rodapé: manter apenas o valor (R$) à direita
       const footerEl = document.createElement('div');
-      footerEl.className = 'flex items-center justify-end pt-0.5';
+      footerEl.className = 'agenda-card__footer flex items-center justify-end';
       const price = document.createElement('div');
-      price.className = 'text-[12px] text-gray-800 font-semibold';
+      price.className = 'agenda-card__price text-gray-800 font-semibold';
       price.textContent = money(a.valor);
       footerEl.appendChild(price);
 
@@ -1070,7 +1074,7 @@
         short: 'Agend.',
         stripe: '#64748B',     // slate-500
         text: '#0F172A',       // slate-900
-        badgeClass: 'bg-slate-100 text-slate-700 border border-slate-200',
+        badgeClass: 'agenda-status-badge agenda-status-badge--agendado',
         borderClass: 'border-slate-300'
       },
       em_espera: {
@@ -1078,7 +1082,7 @@
         short: 'Espera',
         stripe: '#B45309',     // amber-700
         text: '#1F2937',       // gray-800
-        badgeClass: 'bg-amber-50 text-amber-800 border border-amber-200',
+        badgeClass: 'agenda-status-badge agenda-status-badge--espera',
         borderClass: 'border-amber-400'
       },
       em_atendimento: {
@@ -1086,7 +1090,7 @@
         short: 'Atend.',
         stripe: '#1D4ED8',     // blue-700
         text: '#0B1235',
-        badgeClass: 'bg-blue-50 text-blue-800 border border-blue-200',
+        badgeClass: 'agenda-status-badge agenda-status-badge--atendimento',
         borderClass: 'border-blue-500'
       },
       finalizado: {
@@ -1094,18 +1098,18 @@
         short: 'Fim.',
         stripe: '#16A34A',     // green-600
         text: '#052E16',
-        badgeClass: 'bg-green-50 text-green-800 border border-green-200',
+        badgeClass: 'agenda-status-badge agenda-status-badge--finalizado',
         borderClass: 'border-green-500'
       }
     };
 
-    return map[k];
+    return { key: k, ...map[k] };
   }
 
   function renderStatusBadge(s) {
     const { label, badgeClass } = statusMeta(s);
     // `whitespace-nowrap` garante que o chip não quebre em duas linhas
-    return `<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${badgeClass}">${label}</span>`;
+    return `<span class="inline-flex items-center px-2 py-0.5 rounded-full font-medium whitespace-nowrap ${badgeClass}">${label}</span>`;
   }
 
   // Modal — modo adicionar
@@ -1760,17 +1764,17 @@
         actions.innerHTML = `
           <div class="agenda-card__actions-row">
             <button type="button" class="agenda-action edit" data-id="${id}" title="Editar" aria-label="Editar agendamento">
-              <i class="fa-solid fa-pen text-[16px] leading-none"></i>
+              <i class="fa-solid fa-pen text-[15px] leading-none"></i>
             </button>
             <button type="button" class="agenda-action status" data-id="${id}" title="Mudar status" aria-label="Mudar status do agendamento">
-              <i class="fa-regular fa-clock text-[16px] leading-none"></i>
+              <i class="fa-regular fa-clock text-[15px] leading-none"></i>
             </button>
           </div>
           <button type="button" class="agenda-action cobrar ${isPaid ? 'text-green-600' : 'text-slate-500'}" data-id="${id}" title="${isPaid ? 'Pago' : 'Registrar pagamento'}" aria-label="${isPaid ? 'Pagamento já registrado' : 'Registrar pagamento'}">
             ${
               isPaid
-                ? `<i class="fa-solid fa-dollar-sign text-[16px] leading-none"></i>`
-                : `<span class="fa-stack text-[12px] leading-none" style="width: 1.25em;">
+                ? `<i class="fa-solid fa-dollar-sign text-[15px] leading-none"></i>`
+                : `<span class="fa-stack text-[11px] leading-none" style="width: 1.15em;">
                     <i class="fa-solid fa-dollar-sign fa-stack-1x"></i>
                     <i class="fa-solid fa-slash fa-stack-1x"></i>
                   </span>`

--- a/scripts/funcionarios/banho-e-tosa.js
+++ b/scripts/funcionarios/banho-e-tosa.js
@@ -1755,19 +1755,18 @@
         const isPaid = !!item.pago || !!item.codigoVenda;
 
         const actions = document.createElement('div');
-        // flex em coluna para ter a “segunda linha” abaixo do '+'
-        actions.className = 'agenda-card__actions absolute top-1 right-1 hidden md:flex flex-col items-end gap-1';
+        actions.className = 'agenda-card__actions';
 
         actions.innerHTML = `
-          <div class="flex items-center gap-1">
-            <button type="button" class="agenda-action edit" data-id="${id}" title="Editar">
+          <div class="agenda-card__actions-row">
+            <button type="button" class="agenda-action edit" data-id="${id}" title="Editar" aria-label="Editar agendamento">
               <i class="fa-solid fa-pen text-[16px] leading-none"></i>
             </button>
-            <button type="button" class="agenda-action status" data-id="${id}" title="Mudar status">
+            <button type="button" class="agenda-action status" data-id="${id}" title="Mudar status" aria-label="Mudar status do agendamento">
               <i class="fa-regular fa-clock text-[16px] leading-none"></i>
             </button>
           </div>
-          <button type="button" class="agenda-action cobrar ${isPaid ? 'text-green-600' : 'text-slate-500'}" data-id="${id}" title="${isPaid ? 'Pago' : 'Registrar pagamento'}">
+          <button type="button" class="agenda-action cobrar ${isPaid ? 'text-green-600' : 'text-slate-500'}" data-id="${id}" title="${isPaid ? 'Pago' : 'Registrar pagamento'}" aria-label="${isPaid ? 'Pagamento já registrado' : 'Registrar pagamento'}">
             ${
               isPaid
                 ? `<i class="fa-solid fa-dollar-sign text-[16px] leading-none"></i>`
@@ -1779,6 +1778,7 @@
           </button>
         `;
         card.appendChild(actions);
+        card.classList.add('agenda-card--with-actions');
 
         // Se faturado e sem permissão -> não permitir arrastar/editar visualmente
         if ((!!item.pago || !!item.codigoVenda) && !isPrivilegedRole()) {

--- a/scripts/funcionarios/banhoetosa/core.js
+++ b/scripts/funcionarios/banhoetosa/core.js
@@ -293,5 +293,5 @@ export function statusMeta(s) {
 }
 export function renderStatusBadge(s) {
   const { label, badgeClass } = statusMeta(s);
-  return `<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${badgeClass}">${label}</span>`;
+  return `<span class="inline-flex items-center px-2 py-0.5 rounded-full font-medium whitespace-nowrap ${badgeClass}">${label}</span>`;
 }

--- a/scripts/funcionarios/banhoetosa/grid.js
+++ b/scripts/funcionarios/banhoetosa/grid.js
@@ -519,17 +519,17 @@ export function renderGrid() {
     const card = document.createElement('div');
     card.setAttribute('data-appointment-id', a._id || '');
     card.style.setProperty('--stripe', meta.stripe);
-    card.style.setProperty('--card-max-w', '260px');
+    card.style.setProperty('--card-max-w', '320px');
     card.className = 'agenda-card cursor-move select-none';
     card.dataset.status = meta.key;
     card.setAttribute('draggable', 'true');
 
     const headerEl = document.createElement('div');
-    headerEl.className = 'flex items-center justify-between gap-2 mb-1 agenda-card__head';
+    headerEl.className = 'agenda-card__head flex justify-between';
     const tutorShort = shortTutorName(a.clienteNome || '');
     const headLabel  = tutorShort ? `${tutorShort} | ${a.pet || ''}` : (a.pet || '');
     headerEl.innerHTML = `
-      <div class="agenda-card__title font-semibold text-sm text-gray-900 truncate" title="${headLabel}">${headLabel}</div>
+      <div class="agenda-card__title font-semibold text-gray-900 truncate" title="${headLabel}">${headLabel}</div>
       ${renderStatusBadge(a.status)}
     `;
 
@@ -537,22 +537,22 @@ export function renderGrid() {
     bodyEl.classList.add('agenda-card__body');
     if (a.observacoes && String(a.observacoes).trim()) {
       const svc = document.createElement('div');
-      svc.className = 'agenda-card__service text-[13px] text-gray-600 clamp-2';
+      svc.className = 'agenda-card__service text-gray-600 clamp-2';
       svc.textContent = a.servico || '';
       const obs = document.createElement('div');
-      obs.className = 'agenda-card__note mt-1 text-[12px] text-gray-700 italic clamp-2';
+      obs.className = 'agenda-card__note mt-1 text-gray-700 italic clamp-2';
       obs.textContent = String(a.observacoes).trim();
       bodyEl.appendChild(svc);
       bodyEl.appendChild(obs);
     } else {
-      bodyEl.classList.add('text-[13px]', 'text-gray-600', 'clamp-2');
+      bodyEl.classList.add('text-gray-600', 'clamp-2');
       bodyEl.textContent = a.servico || '';
     }
 
     const footerEl = document.createElement('div');
-    footerEl.className = 'flex items-center justify-end gap-2 pt-1 agenda-card__footer';
+    footerEl.className = 'agenda-card__footer flex items-center justify-end';
     const price = document.createElement('div');
-    price.className = 'agenda-card__price text-[13px] text-gray-800 font-medium';
+    price.className = 'agenda-card__price text-gray-800 font-medium';
     price.textContent = money(a.valor);
     footerEl.appendChild(createFichaClinicaChip(a));
     footerEl.appendChild(price);
@@ -638,32 +638,32 @@ export function renderWeekGrid() {
     card.title = [ a.pet || '', a.servico || '', (a.observacoes ? `Obs: ${String(a.observacoes).trim()}` : '') ].filter(Boolean).join(' • ');
 
     const headerEl = document.createElement('div');
-    headerEl.className = 'flex items-center justify-between gap-2 mb-1 agenda-card__head';
+    headerEl.className = 'agenda-card__head flex justify-between';
     const tutorShort = shortTutorName(a.clienteNome || a.tutor || '');
     const headLabel  = tutorShort ? `${tutorShort} | ${a.pet || ''}` : (a.pet || '');
     headerEl.innerHTML = `
-      <div class="agenda-card__title font-medium text-[12px] text-gray-900 truncate" title="${headLabel}">${headLabel}</div>
+      <div class="agenda-card__title font-medium text-gray-900 truncate" title="${headLabel}">${headLabel}</div>
     `;
 
     const bodyEl = document.createElement('div');
     bodyEl.classList.add('agenda-card__body');
     const svc = document.createElement('div');
-    svc.className = 'agenda-card__service text-[12px] text-gray-600 truncate';
+    svc.className = 'agenda-card__service text-gray-600 truncate';
     svc.textContent = a.servico || '';
     bodyEl.appendChild(svc);
     if (a.observacoes && String(a.observacoes).trim()) {
       const obs = document.createElement('div');
-      obs.className = 'agenda-card__note text-[11px] text-gray-700 italic truncate';
+      obs.className = 'agenda-card__note text-gray-700 italic truncate';
       obs.textContent = String(a.observacoes).trim();
       bodyEl.appendChild(obs);
     }
 
     const footerEl = document.createElement('div');
-    footerEl.className = 'flex items-center justify-end gap-2 pt-0.5 agenda-card__footer';
+    footerEl.className = 'agenda-card__footer flex items-center justify-end';
     const statusEl = document.createElement('div');
     statusEl.innerHTML = renderStatusBadge(a.status).replace('text-xs','text-[10px]');
     const price = document.createElement('div');
-    price.className = 'agenda-card__price text-[12px] text-gray-800 font-semibold';
+    price.className = 'agenda-card__price text-gray-800 font-semibold';
     price.textContent = money(a.valor);
     footerEl.appendChild(statusEl);
     footerEl.appendChild(createFichaClinicaChip(a));
@@ -741,7 +741,7 @@ export function renderMonthGrid() {
       card.setAttribute('draggable', 'true');
       card.title = [ a.pet || '', a.servico || '', (a.observacoes ? `Obs: ${String(a.observacoes).trim()}` : '') ].filter(Boolean).join(' • ');
       const headerEl = document.createElement('div');
-      headerEl.className = 'flex items-center gap-2 mb-1 agenda-card__head';
+      headerEl.className = 'agenda-card__head flex items-center gap-2';
       headerEl.innerHTML = `
         <span class="inline-flex items-center px-1.5 py-[1px] rounded bg-slate-100 text-[10px] font-medium">${hhmm}</span>
         <div class="flex-1 flex items-center justify-center">
@@ -755,12 +755,12 @@ export function renderMonthGrid() {
       const tutorShort = shortTutorName(rawTutorName);
       const headLabel  = [tutorShort, (a.pet || '')].filter(Boolean).join(' | ');
       const nameEl = document.createElement('div');
-      nameEl.className = 'agenda-card__title text-[12px] font-medium text-gray-900 text-center truncate';
+      nameEl.className = 'agenda-card__title font-medium text-gray-900 text-center truncate';
       nameEl.title = headLabel; nameEl.textContent = headLabel;
       const footerEl = document.createElement('div');
-      footerEl.className = 'flex items-center justify-end gap-2 pt-0.5 agenda-card__footer';
+      footerEl.className = 'agenda-card__footer flex items-center justify-end';
       const price = document.createElement('div');
-      price.className = 'agenda-card__price text-[12px] text-gray-800 font-semibold';
+      price.className = 'agenda-card__price text-gray-800 font-semibold';
       price.textContent = money(a.valor);
       footerEl.appendChild(createFichaClinicaChip(a));
       footerEl.appendChild(price);

--- a/scripts/funcionarios/banhoetosa/grid.js
+++ b/scripts/funcionarios/banhoetosa/grid.js
@@ -525,7 +525,7 @@ export function renderGrid() {
     card.setAttribute('draggable', 'true');
 
     const headerEl = document.createElement('div');
-    headerEl.className = 'flex items-center justify-between gap-2 pr-14 md:pr-16 mb-1 agenda-card__head';
+    headerEl.className = 'flex items-center justify-between gap-2 mb-1 agenda-card__head';
     const tutorShort = shortTutorName(a.clienteNome || '');
     const headLabel  = tutorShort ? `${tutorShort} | ${a.pet || ''}` : (a.pet || '');
     headerEl.innerHTML = `
@@ -741,7 +741,7 @@ export function renderMonthGrid() {
       card.setAttribute('draggable', 'true');
       card.title = [ a.pet || '', a.servico || '', (a.observacoes ? `Obs: ${String(a.observacoes).trim()}` : '') ].filter(Boolean).join(' • ');
       const headerEl = document.createElement('div');
-      headerEl.className = 'flex items-center gap-2 pr-14 md:pr-16 mb-1 agenda-card__head';
+      headerEl.className = 'flex items-center gap-2 mb-1 agenda-card__head';
       headerEl.innerHTML = `
         <span class="inline-flex items-center px-1.5 py-[1px] rounded bg-slate-100 text-[10px] font-medium">${hhmm}</span>
         <div class="flex-1 flex items-center justify-center">

--- a/scripts/funcionarios/banhoetosa/ui.js
+++ b/scripts/funcionarios/banhoetosa/ui.js
@@ -76,21 +76,22 @@ export function decorateCards() {
     const item = (state.agendamentos || []).find(x => String(x._id) === String(id)) || {};
     const isPaid = !!item.pago || !!item.codigoVenda;
     const actions = document.createElement('div');
-    actions.className = 'agenda-card__actions absolute top-1 right-1 hidden md:flex flex-col items-end gap-1';
+    actions.className = 'agenda-card__actions';
     actions.innerHTML = `
-      <div class="flex items-center gap-1">
-        <button type="button" class="agenda-action edit" data-id="${id}" title="Editar">
+      <div class="agenda-card__actions-row">
+        <button type="button" class="agenda-action edit" data-id="${id}" title="Editar" aria-label="Editar agendamento">
           <i class="fa-solid fa-pen text-[16px] leading-none"></i>
         </button>
-        <button type="button" class="agenda-action status" data-id="${id}" title="Mudar status">
+        <button type="button" class="agenda-action status" data-id="${id}" title="Mudar status" aria-label="Mudar status do agendamento">
           <i class="fa-regular fa-clock text-[16px] leading-none"></i>
         </button>
       </div>
-      <button type="button" class="agenda-action cobrar ${isPaid ? 'text-green-600' : 'text-slate-500'}" data-id="${id}" title="${isPaid ? 'Pago' : 'Registrar pagamento'}">
+      <button type="button" class="agenda-action cobrar ${isPaid ? 'text-green-600' : 'text-slate-500'}" data-id="${id}" title="${isPaid ? 'Pago' : 'Registrar pagamento'}" aria-label="${isPaid ? 'Pagamento já registrado' : 'Registrar pagamento'}">
         <i class="fa-solid fa-dollar-sign text-[16px] leading-none"></i>
       </button>
     `;
     card.appendChild(actions);
+    card.classList.add('agenda-card--with-actions');
     if ((!!item.pago || !!item.codigoVenda) && !isPrivilegedRole()) {
       card.setAttribute('draggable', 'false');
       card.classList.remove('cursor-move');

--- a/scripts/funcionarios/banhoetosa/ui.js
+++ b/scripts/funcionarios/banhoetosa/ui.js
@@ -80,14 +80,14 @@ export function decorateCards() {
     actions.innerHTML = `
       <div class="agenda-card__actions-row">
         <button type="button" class="agenda-action edit" data-id="${id}" title="Editar" aria-label="Editar agendamento">
-          <i class="fa-solid fa-pen text-[16px] leading-none"></i>
+          <i class="fa-solid fa-pen text-[15px] leading-none"></i>
         </button>
         <button type="button" class="agenda-action status" data-id="${id}" title="Mudar status" aria-label="Mudar status do agendamento">
-          <i class="fa-regular fa-clock text-[16px] leading-none"></i>
+          <i class="fa-regular fa-clock text-[15px] leading-none"></i>
         </button>
       </div>
       <button type="button" class="agenda-action cobrar ${isPaid ? 'text-green-600' : 'text-slate-500'}" data-id="${id}" title="${isPaid ? 'Pago' : 'Registrar pagamento'}" aria-label="${isPaid ? 'Pagamento já registrado' : 'Registrar pagamento'}">
-        <i class="fa-solid fa-dollar-sign text-[16px] leading-none"></i>
+        <i class="fa-solid fa-dollar-sign text-[15px] leading-none"></i>
       </button>
     `;
     card.appendChild(actions);

--- a/src/input.css
+++ b/src/input.css
@@ -434,6 +434,13 @@
     max-width: 100%;
     transition: box-shadow .22s ease, transform .22s ease, background .25s ease, border-color .25s ease;
     backdrop-filter: saturate(135%);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "head"
+      "body"
+      "footer";
+    row-gap: .45rem;
   }
   .agenda-card:hover {
     transform: translateY(-2px);
@@ -463,27 +470,41 @@
   .agenda-card:hover::after { opacity: 1; }
 
   .agenda-card__actions {
-    z-index: 6;
-    background: rgba(15, 23, 42, 0.18);
-    backdrop-filter: blur(12px);
-    padding: 6px;
+    grid-area: actions;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: .5rem;
+    margin-top: .25rem;
+    padding: .45rem .6rem;
     border-radius: 14px;
+    background: rgba(255,255,255,0.88);
+    border: 1px solid rgba(148, 163, 184, 0.28);
     box-shadow: 0 22px 40px -28px rgba(15, 23, 42, 0.55);
-    border: 1px solid rgba(148, 163, 184, 0.25);
-    transition: transform .2s ease, opacity .2s ease;
+    backdrop-filter: blur(12px);
+    flex-wrap: wrap;
   }
-  .agenda-card:hover .agenda-card__actions { display: flex !important; }
+  .agenda-card__actions-row {
+    display: flex;
+    align-items: center;
+    gap: .45rem;
+  }
   .agenda-card__actions .agenda-action {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 32px;
-    height: 32px;
-    border-radius: 10px;
-    background: rgba(255,255,255,0.82);
+    width: 34px;
+    height: 34px;
+    border-radius: 11px;
+    background: rgba(248,250,252,0.9);
     color: inherit;
     box-shadow: 0 8px 18px -14px rgba(15, 23, 42, 0.45);
     transition: transform .2s ease, box-shadow .2s ease, background .2s ease, color .2s ease;
+  }
+  .agenda-card__actions .agenda-action:focus-visible {
+    outline: 2px solid rgba(14,165,233,0.8);
+    outline-offset: 2px;
   }
   .agenda-card__actions .agenda-action:hover {
     background: linear-gradient(135deg, #0ea5e9, #38bdf8);
@@ -492,6 +513,52 @@
     box-shadow: 0 16px 26px -18px rgba(14, 165, 233, 0.65);
   }
   .agenda-card__actions .agenda-action:active { transform: translateY(0); box-shadow: 0 10px 20px -16px rgba(15, 23, 42, 0.5); }
+
+  .agenda-card--with-actions {
+    grid-template-areas:
+      "head"
+      "body"
+      "footer"
+      "actions";
+  }
+  .agenda-card--with-actions:not(.agenda-card--compact) .agenda-card__footer {
+    justify-content: space-between;
+  }
+  @media (min-width: 768px) {
+    .agenda-card--with-actions:not(.agenda-card--compact) {
+      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-areas:
+        "head actions"
+        "body actions"
+        "footer actions";
+      column-gap: 1rem;
+      align-items: start;
+    }
+    .agenda-card--with-actions:not(.agenda-card--compact) .agenda-card__actions {
+      flex-direction: column;
+      align-items: stretch;
+      justify-content: flex-start;
+      gap: .6rem;
+      margin-top: 0;
+      min-width: 56px;
+      padding: .6rem;
+    }
+    .agenda-card--with-actions:not(.agenda-card--compact) .agenda-card__actions-row {
+      justify-content: center;
+    }
+  }
+
+  .agenda-card--compact .agenda-card__actions {
+    justify-content: flex-end;
+    gap: .45rem;
+    margin-top: .35rem;
+  }
+  @media (min-width: 768px) {
+    .agenda-card--compact .agenda-card__actions {
+      flex-direction: row;
+      align-items: center;
+    }
+  }
 
   .agenda-card[data-status="agendado"] {
     --agenda-card-border: rgba(99,102,241,0.38);
@@ -518,17 +585,19 @@
     border-radius: 14px;
     padding: 10px 14px 10px 18px;
     min-height: auto;
+    row-gap: .35rem;
   }
-  .agenda-card--compact .agenda-card__head { margin-bottom: .35rem; }
+  .agenda-card--compact .agenda-card__head { margin-bottom: .25rem; }
   .agenda-card--compact .agenda-card__body { font-size: 12px; }
   .agenda-card--compact .agenda-card__price { font-size: 12px; padding: 0.1rem 0.55rem; }
 
   .agenda-card__head {
+    grid-area: head;
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 0.75rem;
-    margin-bottom: .55rem;
+    margin-bottom: 0;
     position: relative;
   }
   .agenda-card__title {
@@ -537,6 +606,7 @@
     letter-spacing: -0.01em;
   }
   .agenda-card__body {
+    grid-area: body;
     color: #475569;
     font-size: 13px;
     line-height: 1.35;
@@ -548,6 +618,7 @@
     font-style: italic;
   }
   .agenda-card__footer {
+    grid-area: footer;
     display: flex;
     align-items: center;
     justify-content: flex-end;

--- a/src/input.css
+++ b/src/input.css
@@ -428,8 +428,8 @@
     background: var(--agenda-card-bg);
     border: 1px solid var(--agenda-card-border);
     box-shadow: var(--agenda-card-shadow);
-    padding: 12px 16px 12px 22px;
-    min-height: 78px;
+    padding: 10px 14px 10px 18px;
+    min-height: 72px;
     width: 100%;
     max-width: 100%;
     transition: box-shadow .22s ease, transform .22s ease, background .25s ease, border-color .25s ease;
@@ -440,7 +440,7 @@
       "head"
       "body"
       "footer";
-    row-gap: .45rem;
+    row-gap: .35rem;
   }
   .agenda-card:hover {
     transform: translateY(-2px);
@@ -473,30 +473,31 @@
     grid-area: actions;
     z-index: 2;
     display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-content: flex-end;
-    gap: .5rem;
-    margin-top: .25rem;
-    padding: .45rem .6rem;
-    border-radius: 14px;
+    justify-content: flex-start;
+    gap: .35rem;
+    margin-top: 0;
+    padding: .35rem .45rem;
+    border-radius: 12px;
     background: rgba(255,255,255,0.88);
     border: 1px solid rgba(148, 163, 184, 0.28);
     box-shadow: 0 22px 40px -28px rgba(15, 23, 42, 0.55);
     backdrop-filter: blur(12px);
-    flex-wrap: wrap;
+    align-self: stretch;
+    justify-self: end;
+    min-width: 48px;
   }
   .agenda-card__actions-row {
-    display: flex;
-    align-items: center;
-    gap: .45rem;
+    display: contents;
   }
   .agenda-card__actions .agenda-action {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 34px;
-    height: 34px;
-    border-radius: 11px;
+    width: 32px;
+    height: 32px;
+    border-radius: 10px;
     background: rgba(248,250,252,0.9);
     color: inherit;
     box-shadow: 0 8px 18px -14px rgba(15, 23, 42, 0.45);
@@ -524,34 +525,30 @@
   .agenda-card--with-actions:not(.agenda-card--compact) .agenda-card__footer {
     justify-content: space-between;
   }
-  @media (min-width: 768px) {
+  @media (min-width: 560px) {
     .agenda-card--with-actions:not(.agenda-card--compact) {
-      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-columns: minmax(0, 1fr) minmax(48px, auto);
       grid-template-areas:
         "head actions"
         "body actions"
         "footer actions";
-      column-gap: 1rem;
+      column-gap: .65rem;
       align-items: start;
     }
     .agenda-card--with-actions:not(.agenda-card--compact) .agenda-card__actions {
-      flex-direction: column;
-      align-items: stretch;
-      justify-content: flex-start;
-      gap: .6rem;
-      margin-top: 0;
-      min-width: 56px;
-      padding: .6rem;
+      align-self: stretch;
+      justify-self: end;
+      height: 100%;
     }
-    .agenda-card--with-actions:not(.agenda-card--compact) .agenda-card__actions-row {
-      justify-content: center;
+    .agenda-card--with-actions:not(.agenda-card--compact) .agenda-card__footer {
+      justify-content: flex-start;
     }
   }
 
   .agenda-card--compact .agenda-card__actions {
     justify-content: flex-end;
-    gap: .45rem;
-    margin-top: .35rem;
+    gap: .35rem;
+    margin-top: .3rem;
   }
   @media (min-width: 768px) {
     .agenda-card--compact .agenda-card__actions {
@@ -588,15 +585,20 @@
     row-gap: .35rem;
   }
   .agenda-card--compact .agenda-card__head { margin-bottom: .25rem; }
+  .agenda-card--compact .agenda-card__title { font-size: 12px; }
   .agenda-card--compact .agenda-card__body { font-size: 12px; }
   .agenda-card--compact .agenda-card__price { font-size: 12px; padding: 0.1rem 0.55rem; }
+  .agenda-card--compact .agenda-status-badge {
+    font-size: .65rem;
+    padding: 0.15rem 0.5rem;
+  }
 
   .agenda-card__head {
     grid-area: head;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
-    gap: 0.75rem;
+    gap: 0.5rem;
     margin-bottom: 0;
     position: relative;
   }
@@ -604,34 +606,38 @@
     font-weight: 600;
     color: #0f172a;
     letter-spacing: -0.01em;
+    font-size: 13px;
   }
   .agenda-card__body {
     grid-area: body;
     color: #475569;
-    font-size: 13px;
-    line-height: 1.35;
+    font-size: 12px;
+    line-height: 1.32;
   }
   .agenda-card__service { font-weight: 500; }
   .agenda-card__note {
     color: #334155;
     opacity: .85;
     font-style: italic;
+    font-size: 11px;
+    line-height: 1.3;
   }
   .agenda-card__footer {
     grid-area: footer;
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    gap: .5rem;
-    padding-top: .4rem;
+    gap: .4rem;
+    padding-top: .3rem;
   }
   .agenda-card__price {
     display: inline-flex;
     align-items: center;
     font-weight: 600;
     color: #0f172a;
+    font-size: 12px;
     background: rgba(255,255,255,0.82);
-    padding: 0.15rem 0.6rem;
+    padding: 0.12rem 0.55rem;
     border-radius: 999px;
     box-shadow: inset 0 1px 0 rgba(255,255,255,0.6), 0 4px 12px -8px rgba(15,23,42,0.35);
   }
@@ -639,10 +645,10 @@
   .agenda-ficha-chip {
     display: inline-flex;
     align-items: center;
-    gap: .35rem;
-    padding: 0.22rem 0.65rem;
+    gap: .3rem;
+    padding: 0.18rem 0.55rem;
     border-radius: 999px;
-    font-size: 11px;
+    font-size: 10.5px;
     font-weight: 600;
     background: linear-gradient(135deg, rgba(14,165,233,0.12), rgba(59,130,246,0.12));
     color: #0f172a;
@@ -658,10 +664,10 @@
   .agenda-status-badge {
     display: inline-flex;
     align-items: center;
-    gap: .25rem;
-    padding: 0.22rem 0.6rem;
+    gap: .2rem;
+    padding: 0.18rem 0.55rem;
     border-radius: 999px;
-    font-size: .75rem;
+    font-size: .7rem;
     font-weight: 600;
     letter-spacing: 0.02em;
     text-transform: none;

--- a/src/output.css
+++ b/src/output.css
@@ -1967,6 +1967,9 @@
   .text-\[13px\] {
     font-size: 13px;
   }
+  .text-\[15px\] {
+    font-size: 15px;
+  }
   .text-\[16px\] {
     font-size: 16px;
   }
@@ -4072,8 +4075,8 @@
     background: var(--agenda-card-bg);
     border: 1px solid var(--agenda-card-border);
     box-shadow: var(--agenda-card-shadow);
-    padding: 12px 16px 12px 22px;
-    min-height: 78px;
+    padding: 10px 14px 10px 18px;
+    min-height: 72px;
     width: 100%;
     max-width: 100%;
     transition: box-shadow .22s ease, transform .22s ease, background .25s ease, border-color .25s ease;
@@ -4081,7 +4084,7 @@
     display: grid;
     grid-template-columns: minmax(0, 1fr);
     grid-template-areas: "head" "body" "footer";
-    row-gap: .45rem;
+    row-gap: .35rem;
   }
   .agenda-card:hover {
     transform: translateY(-2px);
@@ -4115,30 +4118,31 @@
     grid-area: actions;
     z-index: 2;
     display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-content: flex-end;
-    gap: .5rem;
-    margin-top: .25rem;
-    padding: .45rem .6rem;
-    border-radius: 14px;
+    justify-content: flex-start;
+    gap: .35rem;
+    margin-top: 0;
+    padding: .35rem .45rem;
+    border-radius: 12px;
     background: rgba(255,255,255,0.88);
     border: 1px solid rgba(148, 163, 184, 0.28);
     box-shadow: 0 22px 40px -28px rgba(15, 23, 42, 0.55);
     backdrop-filter: blur(12px);
-    flex-wrap: wrap;
+    align-self: stretch;
+    justify-self: end;
+    min-width: 48px;
   }
   .agenda-card__actions-row {
-    display: flex;
-    align-items: center;
-    gap: .45rem;
+    display: contents;
   }
   .agenda-card__actions .agenda-action {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 34px;
-    height: 34px;
-    border-radius: 11px;
+    width: 32px;
+    height: 32px;
+    border-radius: 10px;
     background: rgba(248,250,252,0.9);
     color: inherit;
     box-shadow: 0 8px 18px -14px rgba(15, 23, 42, 0.45);
@@ -4164,30 +4168,26 @@
   .agenda-card--with-actions:not(.agenda-card--compact) .agenda-card__footer {
     justify-content: space-between;
   }
-  @media (min-width: 768px) {
+  @media (min-width: 560px) {
     .agenda-card--with-actions:not(.agenda-card--compact) {
-      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-columns: minmax(0, 1fr) minmax(48px, auto);
       grid-template-areas: "head actions" "body actions" "footer actions";
-      column-gap: 1rem;
+      column-gap: .65rem;
       align-items: start;
     }
     .agenda-card--with-actions:not(.agenda-card--compact) .agenda-card__actions {
-      flex-direction: column;
-      align-items: stretch;
-      justify-content: flex-start;
-      gap: .6rem;
-      margin-top: 0;
-      min-width: 56px;
-      padding: .6rem;
+      align-self: stretch;
+      justify-self: end;
+      height: 100%;
     }
-    .agenda-card--with-actions:not(.agenda-card--compact) .agenda-card__actions-row {
-      justify-content: center;
+    .agenda-card--with-actions:not(.agenda-card--compact) .agenda-card__footer {
+      justify-content: flex-start;
     }
   }
   .agenda-card--compact .agenda-card__actions {
     justify-content: flex-end;
-    gap: .45rem;
-    margin-top: .35rem;
+    gap: .35rem;
+    margin-top: .3rem;
   }
   @media (min-width: 768px) {
     .agenda-card--compact .agenda-card__actions {
@@ -4224,6 +4224,9 @@
   .agenda-card--compact .agenda-card__head {
     margin-bottom: .25rem;
   }
+  .agenda-card--compact .agenda-card__title {
+    font-size: 12px;
+  }
   .agenda-card--compact .agenda-card__body {
     font-size: 12px;
   }
@@ -4231,12 +4234,16 @@
     font-size: 12px;
     padding: 0.1rem 0.55rem;
   }
+  .agenda-card--compact .agenda-status-badge {
+    font-size: .65rem;
+    padding: 0.15rem 0.5rem;
+  }
   .agenda-card__head {
     grid-area: head;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
-    gap: 0.75rem;
+    gap: 0.5rem;
     margin-bottom: 0;
     position: relative;
   }
@@ -4244,12 +4251,13 @@
     font-weight: 600;
     color: #0f172a;
     letter-spacing: -0.01em;
+    font-size: 13px;
   }
   .agenda-card__body {
     grid-area: body;
     color: #475569;
-    font-size: 13px;
-    line-height: 1.35;
+    font-size: 12px;
+    line-height: 1.32;
   }
   .agenda-card__service {
     font-weight: 500;
@@ -4258,32 +4266,35 @@
     color: #334155;
     opacity: .85;
     font-style: italic;
+    font-size: 11px;
+    line-height: 1.3;
   }
   .agenda-card__footer {
     grid-area: footer;
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    gap: .5rem;
-    padding-top: .4rem;
+    gap: .4rem;
+    padding-top: .3rem;
   }
   .agenda-card__price {
     display: inline-flex;
     align-items: center;
     font-weight: 600;
     color: #0f172a;
+    font-size: 12px;
     background: rgba(255,255,255,0.82);
-    padding: 0.15rem 0.6rem;
+    padding: 0.12rem 0.55rem;
     border-radius: 999px;
     box-shadow: inset 0 1px 0 rgba(255,255,255,0.6), 0 4px 12px -8px rgba(15,23,42,0.35);
   }
   .agenda-ficha-chip {
     display: inline-flex;
     align-items: center;
-    gap: .35rem;
-    padding: 0.22rem 0.65rem;
+    gap: .3rem;
+    padding: 0.18rem 0.55rem;
     border-radius: 999px;
-    font-size: 11px;
+    font-size: 10.5px;
     font-weight: 600;
     background: linear-gradient(135deg, rgba(14,165,233,0.12), rgba(59,130,246,0.12));
     color: #0f172a;
@@ -4298,10 +4309,10 @@
   .agenda-status-badge {
     display: inline-flex;
     align-items: center;
-    gap: .25rem;
-    padding: 0.22rem 0.6rem;
+    gap: .2rem;
+    padding: 0.18rem 0.55rem;
     border-radius: 999px;
-    font-size: .75rem;
+    font-size: .7rem;
     font-weight: 600;
     letter-spacing: 0.02em;
     text-transform: none;

--- a/src/output.css
+++ b/src/output.css
@@ -4078,6 +4078,10 @@
     max-width: 100%;
     transition: box-shadow .22s ease, transform .22s ease, background .25s ease, border-color .25s ease;
     backdrop-filter: saturate(135%);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas: "head" "body" "footer";
+    row-gap: .45rem;
   }
   .agenda-card:hover {
     transform: translateY(-2px);
@@ -4108,29 +4112,41 @@
     opacity: 1;
   }
   .agenda-card__actions {
-    z-index: 6;
-    background: rgba(15, 23, 42, 0.18);
-    backdrop-filter: blur(12px);
-    padding: 6px;
+    grid-area: actions;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: .5rem;
+    margin-top: .25rem;
+    padding: .45rem .6rem;
     border-radius: 14px;
+    background: rgba(255,255,255,0.88);
+    border: 1px solid rgba(148, 163, 184, 0.28);
     box-shadow: 0 22px 40px -28px rgba(15, 23, 42, 0.55);
-    border: 1px solid rgba(148, 163, 184, 0.25);
-    transition: transform .2s ease, opacity .2s ease;
+    backdrop-filter: blur(12px);
+    flex-wrap: wrap;
   }
-  .agenda-card:hover .agenda-card__actions {
-    display: flex !important;
+  .agenda-card__actions-row {
+    display: flex;
+    align-items: center;
+    gap: .45rem;
   }
   .agenda-card__actions .agenda-action {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 32px;
-    height: 32px;
-    border-radius: 10px;
-    background: rgba(255,255,255,0.82);
+    width: 34px;
+    height: 34px;
+    border-radius: 11px;
+    background: rgba(248,250,252,0.9);
     color: inherit;
     box-shadow: 0 8px 18px -14px rgba(15, 23, 42, 0.45);
     transition: transform .2s ease, box-shadow .2s ease, background .2s ease, color .2s ease;
+  }
+  .agenda-card__actions .agenda-action:focus-visible {
+    outline: 2px solid rgba(14,165,233,0.8);
+    outline-offset: 2px;
   }
   .agenda-card__actions .agenda-action:hover {
     background: linear-gradient(135deg, #0ea5e9, #38bdf8);
@@ -4141,6 +4157,43 @@
   .agenda-card__actions .agenda-action:active {
     transform: translateY(0);
     box-shadow: 0 10px 20px -16px rgba(15, 23, 42, 0.5);
+  }
+  .agenda-card--with-actions {
+    grid-template-areas: "head" "body" "footer" "actions";
+  }
+  .agenda-card--with-actions:not(.agenda-card--compact) .agenda-card__footer {
+    justify-content: space-between;
+  }
+  @media (min-width: 768px) {
+    .agenda-card--with-actions:not(.agenda-card--compact) {
+      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-areas: "head actions" "body actions" "footer actions";
+      column-gap: 1rem;
+      align-items: start;
+    }
+    .agenda-card--with-actions:not(.agenda-card--compact) .agenda-card__actions {
+      flex-direction: column;
+      align-items: stretch;
+      justify-content: flex-start;
+      gap: .6rem;
+      margin-top: 0;
+      min-width: 56px;
+      padding: .6rem;
+    }
+    .agenda-card--with-actions:not(.agenda-card--compact) .agenda-card__actions-row {
+      justify-content: center;
+    }
+  }
+  .agenda-card--compact .agenda-card__actions {
+    justify-content: flex-end;
+    gap: .45rem;
+    margin-top: .35rem;
+  }
+  @media (min-width: 768px) {
+    .agenda-card--compact .agenda-card__actions {
+      flex-direction: row;
+      align-items: center;
+    }
   }
   .agenda-card[data-status="agendado"] {
     --agenda-card-border: rgba(99,102,241,0.38);
@@ -4166,9 +4219,10 @@
     border-radius: 14px;
     padding: 10px 14px 10px 18px;
     min-height: auto;
+    row-gap: .35rem;
   }
   .agenda-card--compact .agenda-card__head {
-    margin-bottom: .35rem;
+    margin-bottom: .25rem;
   }
   .agenda-card--compact .agenda-card__body {
     font-size: 12px;
@@ -4178,11 +4232,12 @@
     padding: 0.1rem 0.55rem;
   }
   .agenda-card__head {
+    grid-area: head;
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 0.75rem;
-    margin-bottom: .55rem;
+    margin-bottom: 0;
     position: relative;
   }
   .agenda-card__title {
@@ -4191,6 +4246,7 @@
     letter-spacing: -0.01em;
   }
   .agenda-card__body {
+    grid-area: body;
     color: #475569;
     font-size: 13px;
     line-height: 1.35;
@@ -4204,6 +4260,7 @@
     font-style: italic;
   }
   .agenda-card__footer {
+    grid-area: footer;
     display: flex;
     align-items: center;
     justify-content: flex-end;


### PR DESCRIPTION
## Summary
- reorganize o layout dos cartões da agenda para usar grid, reservando espaço para as ações e melhorando o comportamento responsivo
- atualize a decoração dos cartões para inserir os botões com aria-labels e marcar cartões com a nova classe de layout
- remova paddings extras do cabeçalho do cartão para aproveitar melhor a largura disponível

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1a72b13d88323be4a6d161062070e