### PR TITLE
Add company selector to fiscal tab on product edit page

### DIFF
--- a/pages/admin/admin-produto-editar.html
+++ b/pages/admin/admin-produto-editar.html
@@ -209,6 +209,16 @@
                         </div>
 
                         <div id="tab-fiscal" class="space-y-8 hidden">
+                            <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+                                <div class="w-full md:max-w-xs">
+                                    <label for="fiscal-company-select" class="block text-sm font-medium text-gray-700">Empresa</label>
+                                    <select id="fiscal-company-select" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-primary focus:ring-primary text-sm">
+                                        <option value="__general__">Configuração geral</option>
+                                    </select>
+                                    <p class="mt-2 text-xs text-gray-500">Escolha uma empresa para visualizar ou ajustar regras fiscais específicas.</p>
+                                </div>
+                                <div id="fiscal-company-summary" class="flex flex-col items-start gap-2 text-sm text-gray-600 md:items-end"></div>
+                            </div>
                             <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
                                 <div class="md:col-span-1">
                                     <label for="ncm" class="block text-sm font-medium text-gray-700">NCM</label>


### PR DESCRIPTION
## Summary
- add a company selector and summary panel to the fiscal information tab on the product management screen
- load and persist fiscal rules per company, updating the form and payload using the selected organization

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6009c13e4832381ca6defa344e24f