### PR TITLE
Add PDV configuration screen and backend support

### DIFF
--- a/pages/admin/admin-empresa-configuracoes-pdv.html
+++ b/pages/admin/admin-empresa-configuracoes-pdv.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin: Configurações do PDV - E o Bicho</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+    <link rel="stylesheet" href="../../src/output.css">
+</head>
+<body class="bg-gray-100">
+    <div id="admin-header-placeholder"></div>
+
+    <main class="container mx-auto px-4 py-8 min-h-screen">
+        <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
+            <aside class="md:col-span-4">
+                <div id="admin-sidebar-placeholder"></div>
+            </aside>
+
+            <div class="md:col-span-4 space-y-6">
+                <header class="bg-white border border-gray-100 rounded-xl shadow-sm p-6 flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+                    <div>
+                        <h1 class="text-2xl font-bold text-gray-800">Configurações do PDV</h1>
+                        <p class="text-sm text-gray-600">Defina impressões, descontos, emissão fiscal e depósito padrão por ponto de venda.</p>
+                    </div>
+                    <div class="flex items-center gap-3 text-xs text-gray-500">
+                        <i class="fas fa-database text-primary"></i>
+                        <span>Alterações salvas diretamente no banco do PDV</span>
+                    </div>
+                </header>
+
+                <section class="bg-white border border-gray-100 rounded-xl shadow-sm p-6 space-y-4">
+                    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                        <div>
+                            <label for="company-select" class="block text-sm font-semibold text-gray-700 mb-1">Empresa</label>
+                            <select id="company-select" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
+                                <option value="">Selecione uma empresa</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label for="pdv-select" class="block text-sm font-semibold text-gray-700 mb-1">PDV</label>
+                            <select id="pdv-select" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" disabled>
+                                <option value="">Selecione um PDV</option>
+                            </select>
+                        </div>
+                    </div>
+                    <p id="pdv-selection-hint" class="text-xs text-gray-500">Escolha a empresa para carregar os PDVs disponíveis.</p>
+                </section>
+
+                <section class="bg-white border border-gray-100 rounded-xl shadow-sm p-6">
+                    <div id="config-empty-state" class="flex flex-col items-center justify-center text-center text-gray-500 py-12">
+                        <i class="fas fa-cash-register text-3xl mb-3 text-gray-400"></i>
+                        <p class="text-sm font-medium">Selecione uma empresa e um PDV para configurar.</p>
+                    </div>
+
+                    <div id="config-content" class="hidden space-y-6">
+                        <nav class="flex flex-wrap gap-2 border-b border-gray-200 pb-1" aria-label="Abas de configuração">
+                            <button type="button" class="tab-trigger px-3 py-2 text-sm font-semibold border-b-2 border-primary text-primary rounded-t" data-tab-target="impressao">Impressão</button>
+                            <button type="button" class="tab-trigger px-3 py-2 text-sm font-semibold border-b-2 border-transparent text-gray-500 hover:text-primary" data-tab-target="venda">Venda</button>
+                            <button type="button" class="tab-trigger px-3 py-2 text-sm font-semibold border-b-2 border-transparent text-gray-500 hover:text-primary" data-tab-target="administrativo">Administrativo</button>
+                            <button type="button" class="tab-trigger px-3 py-2 text-sm font-semibold border-b-2 border-transparent text-gray-500 hover:text-primary" data-tab-target="fiscal">Fiscal</button>
+                            <button type="button" class="tab-trigger px-3 py-2 text-sm font-semibold border-b-2 border-transparent text-gray-500 hover:text-primary" data-tab-target="estoque">Estoque</button>
+                        </nav>
+
+                        <div class="space-y-6">
+                            <div data-tab-panel="impressao">
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                                    <div class="space-y-3">
+                                        <span class="block text-sm font-semibold text-gray-700">Sempre imprimir comprovante</span>
+                                        <div class="flex flex-wrap gap-3" role="radiogroup">
+                                            <label class="inline-flex items-center gap-2 text-sm text-gray-700">
+                                                <input type="radio" name="sempre-imprimir" value="sim" class="text-primary focus:ring-primary" data-config-field>
+                                                <span>Sim</span>
+                                            </label>
+                                            <label class="inline-flex items-center gap-2 text-sm text-gray-700">
+                                                <input type="radio" name="sempre-imprimir" value="nao" class="text-primary focus:ring-primary" data-config-field>
+                                                <span>Não</span>
+                                            </label>
+                                            <label class="inline-flex items-center gap-2 text-sm text-gray-700">
+                                                <input type="radio" name="sempre-imprimir" value="perguntar" class="text-primary focus:ring-primary" data-config-field>
+                                                <span>Perguntar</span>
+                                            </label>
+                                        </div>
+                                        <p class="text-xs text-gray-500">Defina o comportamento padrão após finalizar uma venda.</p>
+                                    </div>
+                                    <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600">
+                                        <p class="font-medium text-gray-700">Dica rápida</p>
+                                        <p class="mt-2">Configure impressoras diferentes para cada documento. As vias podem ser ajustadas individualmente conforme a rotina do caixa.</p>
+                                    </div>
+                                </div>
+
+                                <div class="mt-6 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
+                                    <div class="p-4 border border-gray-200 rounded-lg space-y-3">
+                                        <h3 class="text-sm font-semibold text-gray-700">Impressora de Venda</h3>
+                                        <input type="text" id="impressora-venda-nome" class="config-input w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="Nome ou endereço" data-config-field>
+                                        <div>
+                                            <label for="impressora-venda-vias" class="block text-xs font-medium text-gray-600 mb-1">Vias</label>
+                                            <input type="number" id="impressora-venda-vias" min="1" max="10" class="config-input w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" data-config-field>
+                                        </div>
+                                    </div>
+                                    <div class="p-4 border border-gray-200 rounded-lg space-y-3">
+                                        <h3 class="text-sm font-semibold text-gray-700">Impressora de Orçamento</h3>
+                                        <input type="text" id="impressora-orcamento-nome" class="config-input w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="Nome ou endereço" data-config-field>
+                                        <div>
+                                            <label for="impressora-orcamento-vias" class="block text-xs font-medium text-gray-600 mb-1">Vias</label>
+                                            <input type="number" id="impressora-orcamento-vias" min="1" max="10" class="config-input w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" data-config-field>
+                                        </div>
+                                    </div>
+                                    <div class="p-4 border border-gray-200 rounded-lg space-y-3">
+                                        <h3 class="text-sm font-semibold text-gray-700">Contas a Receber</h3>
+                                        <input type="text" id="impressora-contas-nome" class="config-input w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="Nome ou endereço" data-config-field>
+                                        <div>
+                                            <label for="impressora-contas-vias" class="block text-xs font-medium text-gray-600 mb-1">Vias</label>
+                                            <input type="number" id="impressora-contas-vias" min="1" max="10" class="config-input w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" data-config-field>
+                                        </div>
+                                    </div>
+                                    <div class="p-4 border border-gray-200 rounded-lg space-y-3">
+                                        <h3 class="text-sm font-semibold text-gray-700">Impressora do Caixa</h3>
+                                        <input type="text" id="impressora-caixa-nome" class="config-input w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="Nome ou endereço" data-config-field>
+                                        <div>
+                                            <label for="impressora-caixa-vias" class="block text-xs font-medium text-gray-600 mb-1">Vias</label>
+                                            <input type="number" id="impressora-caixa-vias" min="1" max="10" class="config-input w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" data-config-field>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div data-tab-panel="venda" class="hidden">
+                                <div class="space-y-4">
+                                    <div>
+                                        <span class="block text-sm font-semibold text-gray-700 mb-2">Permitir desconto por perfil</span>
+                                        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                                            <label class="flex items-center gap-2 px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-700 hover:border-primary/50">
+                                                <input type="checkbox" value="funcionario" class="desconto-checkbox text-primary focus:ring-primary" data-config-field>
+                                                <span>Funcionário</span>
+                                            </label>
+                                            <label class="flex items-center gap-2 px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-700 hover:border-primary/50">
+                                                <input type="checkbox" value="gerente" class="desconto-checkbox text-primary focus:ring-primary" data-config-field>
+                                                <span>Gerente</span>
+                                            </label>
+                                            <label class="flex items-center gap-2 px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-700 hover:border-primary/50">
+                                                <input type="checkbox" value="admin" class="desconto-checkbox text-primary focus:ring-primary" data-config-field>
+                                                <span>Admin</span>
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <p class="text-xs text-gray-500">Os perfis marcados poderão aplicar descontos diretamente no PDV.</p>
+                                </div>
+                            </div>
+
+                            <div data-tab-panel="administrativo" class="hidden">
+                                <div class="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-6 text-sm text-gray-600">
+                                    <p class="font-semibold text-gray-700">Centralize orientações internas</p>
+                                    <p class="mt-2">Use esta aba para registrar procedimentos administrativos, senhas de fechamento ou recados para o time do caixa. Nenhuma configuração automática é aplicada aqui.</p>
+                                </div>
+                            </div>
+
+                            <div data-tab-panel="fiscal" class="hidden">
+                                <div class="space-y-4">
+                                    <div>
+                                        <span class="block text-sm font-semibold text-gray-700 mb-2">Tipo de emissão padrão</span>
+                                        <div class="flex flex-wrap gap-3" role="radiogroup">
+                                            <label class="flex items-center gap-2 px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-700 hover:border-primary/50">
+                                                <input type="radio" name="tipo-emissao" value="matricial" class="text-primary focus:ring-primary" data-config-field>
+                                                <span>Matricial</span>
+                                            </label>
+                                            <label class="flex items-center gap-2 px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-700 hover:border-primary/50">
+                                                <input type="radio" name="tipo-emissao" value="fiscal" class="text-primary focus:ring-primary" data-config-field>
+                                                <span>Fiscal</span>
+                                            </label>
+                                            <label class="flex items-center gap-2 px-3 py-2 border border-gray-200 rounded-lg text-sm text-gray-700 hover:border-primary/50">
+                                                <input type="radio" name="tipo-emissao" value="ambos" class="text-primary focus:ring-primary" data-config-field>
+                                                <span>Ambos</span>
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <p class="text-xs text-gray-500">A emissão padrão define qual layout o PDV utilizará ao iniciar uma venda fiscal.</p>
+                                </div>
+                            </div>
+
+                            <div data-tab-panel="estoque" class="hidden">
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <div>
+                                        <label for="deposito-padrao" class="block text-sm font-semibold text-gray-700 mb-1">Depósito padrão</label>
+                                        <select id="deposito-padrao" class="config-input w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" data-config-field>
+                                            <option value="">Selecione um depósito</option>
+                                        </select>
+                                        <p class="mt-2 text-xs text-gray-500">Os produtos reservados neste PDV serão vinculados ao depósito selecionado.</p>
+                                    </div>
+                                    <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600">
+                                        <p class="font-medium text-gray-700">Sem o depósito cadastrado?</p>
+                                        <p class="mt-1">Acesse a aba de <a href="./admin-depositos.html" class="text-primary font-semibold hover:underline">Depósitos</a> para criar novas unidades e volte para selecioná-las aqui.</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 pt-4 border-t border-gray-100">
+                            <p id="config-status" class="text-xs text-gray-500">As alterações só serão aplicadas após salvar.</p>
+                            <button id="save-config-button" class="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-primary text-white text-sm font-semibold hover:bg-secondary transition disabled:opacity-60 disabled:pointer-events-none">
+                                <i class="fas fa-save"></i>
+                                <span>Salvar configurações</span>
+                            </button>
+                        </div>
+                    </div>
+                </section>
+            </div>
+        </div>
+    </main>
+
+    <div id="admin-footer-placeholder"></div>
+    <div id="modal-placeholder"></div>
+    <div id="confirm-modal-placeholder"></div>
+
+    <script>var basePath = '../../';</script>
+    <script src="../../scripts/core/config.js"></script>
+    <script src="../../scripts/core/ui.js"></script>
+    <script src="../../scripts/core/main.js"></script>
+    <script src="../../scripts/admin/admin.js"></script>
+    <script src="../../scripts/admin/admin-configuracoes-pdv.js"></script>
+</body>
+</html>

--- a/scripts/admin/admin-configuracoes-pdv.js
+++ b/scripts/admin/admin-configuracoes-pdv.js
@@ -1,0 +1,534 @@
+(function () {
+  const API_BASE =
+    (typeof API_CONFIG !== 'undefined' && API_CONFIG && API_CONFIG.BASE_URL) || '/api';
+
+  const state = {
+    stores: [],
+    pdvs: [],
+    deposits: [],
+    selectedStore: '',
+    selectedPdv: '',
+    saving: false,
+  };
+
+  const elements = {};
+
+  const getToken = () => {
+    try {
+      const raw = localStorage.getItem('loggedInUser');
+      if (!raw) return '';
+      const parsed = JSON.parse(raw);
+      return parsed?.token || '';
+    } catch (error) {
+      console.warn('Não foi possível obter o token do usuário logado.', error);
+      return '';
+    }
+  };
+
+  const notify = (message, type = 'info') => {
+    if (typeof window?.showToast === 'function') {
+      window.showToast(message, type);
+      return;
+    }
+    if (typeof window?.showModal === 'function') {
+      window.showModal({
+        title: type === 'error' ? 'Erro' : 'Aviso',
+        message,
+        confirmText: 'OK',
+      });
+      return;
+    }
+    window.alert(message);
+  };
+
+  const queryElements = () => {
+    elements.companySelect = document.getElementById('company-select');
+    elements.pdvSelect = document.getElementById('pdv-select');
+    elements.configContent = document.getElementById('config-content');
+    elements.emptyState = document.getElementById('config-empty-state');
+    elements.saveButton = document.getElementById('save-config-button');
+    elements.statusLabel = document.getElementById('config-status');
+    elements.selectionHint = document.getElementById('pdv-selection-hint');
+    elements.depositoSelect = document.getElementById('deposito-padrao');
+
+    elements.printerInputs = {
+      venda: {
+        nome: document.getElementById('impressora-venda-nome'),
+        vias: document.getElementById('impressora-venda-vias'),
+      },
+      orcamento: {
+        nome: document.getElementById('impressora-orcamento-nome'),
+        vias: document.getElementById('impressora-orcamento-vias'),
+      },
+      contas: {
+        nome: document.getElementById('impressora-contas-nome'),
+        vias: document.getElementById('impressora-contas-vias'),
+      },
+      caixa: {
+        nome: document.getElementById('impressora-caixa-nome'),
+        vias: document.getElementById('impressora-caixa-vias'),
+      },
+    };
+  };
+
+  const setStatus = (message) => {
+    if (elements.statusLabel) {
+      elements.statusLabel.textContent = message;
+    }
+  };
+
+  const toggleSaving = (saving) => {
+    state.saving = saving;
+    if (elements.saveButton) {
+      elements.saveButton.disabled = saving;
+      elements.saveButton.classList.toggle('opacity-60', saving);
+      elements.saveButton.classList.toggle('pointer-events-none', saving);
+      const label = elements.saveButton.querySelector('span');
+      if (label) {
+        label.textContent = saving ? 'Salvando...' : 'Salvar configurações';
+      }
+    }
+  };
+
+  const toggleConfigVisibility = (visible) => {
+    if (elements.configContent) {
+      elements.configContent.classList.toggle('hidden', !visible);
+    }
+    if (elements.emptyState) {
+      elements.emptyState.classList.toggle('hidden', visible);
+    }
+  };
+
+  const disableConfigFields = (disabled) => {
+    document.querySelectorAll('[data-config-field]').forEach((input) => {
+      input.disabled = disabled;
+    });
+    if (elements.saveButton) {
+      elements.saveButton.disabled = disabled || state.saving;
+    }
+  };
+
+  const resetRadios = (selector, defaultValue) => {
+    const radios = document.querySelectorAll(selector);
+    let checked = false;
+    radios.forEach((radio) => {
+      if (radio.value === defaultValue) {
+        radio.checked = true;
+        checked = true;
+      } else {
+        radio.checked = false;
+      }
+    });
+    if (!checked && radios.length > 0) {
+      radios[0].checked = true;
+    }
+  };
+
+  const clearForm = () => {
+    resetRadios('input[name="sempre-imprimir"]', 'perguntar');
+    resetRadios('input[name="tipo-emissao"]', 'fiscal');
+
+    Object.values(elements.printerInputs).forEach(({ nome, vias }) => {
+      if (nome) nome.value = '';
+      if (vias) vias.value = '';
+    });
+
+    document.querySelectorAll('.desconto-checkbox').forEach((checkbox) => {
+      checkbox.checked = false;
+    });
+
+    if (elements.depositoSelect) {
+      elements.depositoSelect.value = '';
+    }
+
+    setStatus('As alterações só serão aplicadas após salvar.');
+  };
+
+  const populateCompanySelect = () => {
+    if (!elements.companySelect) return;
+    const previous = elements.companySelect.value;
+    const options = ['<option value="">Selecione uma empresa</option>'];
+    state.stores.forEach((store) => {
+      options.push(
+        `<option value="${store._id}">${store.nome || store.nomeFantasia || 'Empresa sem nome'}</option>`
+      );
+    });
+    elements.companySelect.innerHTML = options.join('');
+
+    if (previous && state.stores.some((store) => store._id === previous)) {
+      elements.companySelect.value = previous;
+    }
+  };
+
+  const populatePdvSelect = () => {
+    if (!elements.pdvSelect) return;
+    const options = ['<option value="">Selecione um PDV</option>'];
+    state.pdvs.forEach((pdv) => {
+      options.push(`<option value="${pdv._id}">${pdv.nome || pdv.codigo}</option>`);
+    });
+    elements.pdvSelect.innerHTML = options.join('');
+    elements.pdvSelect.disabled = state.pdvs.length === 0;
+
+    if (!state.pdvs.length) {
+      state.selectedPdv = '';
+      if (elements.selectionHint) {
+        elements.selectionHint.textContent = 'Nenhum PDV encontrado para a empresa selecionada.';
+      }
+      toggleConfigVisibility(false);
+      clearForm();
+    }
+  };
+
+  const populateDeposits = () => {
+    if (!elements.depositoSelect) return;
+    const options = ['<option value="">Selecione um depósito</option>'];
+    state.deposits.forEach((deposit) => {
+      options.push(`<option value="${deposit._id}">${deposit.nome}</option>`);
+    });
+    elements.depositoSelect.innerHTML = options.join('');
+  };
+
+  const formatDateTime = (date) => {
+    if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
+    return date.toLocaleString('pt-BR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const fetchStores = async () => {
+    const response = await fetch(`${API_BASE}/stores`);
+    if (!response.ok) {
+      throw new Error('Não foi possível carregar as empresas cadastradas.');
+    }
+    const payload = await response.json();
+    state.stores = Array.isArray(payload) ? payload : Array.isArray(payload?.stores) ? payload.stores : [];
+    populateCompanySelect();
+  };
+
+  const fetchPdvs = async (storeId) => {
+    const query = storeId ? `?empresa=${encodeURIComponent(storeId)}` : '';
+    const response = await fetch(`${API_BASE}/pdvs${query}`);
+    if (!response.ok) {
+      throw new Error('Não foi possível carregar os PDVs da empresa.');
+    }
+    const payload = await response.json();
+    state.pdvs = Array.isArray(payload?.pdvs)
+      ? payload.pdvs
+      : Array.isArray(payload)
+      ? payload
+      : [];
+    populatePdvSelect();
+  };
+
+  const fetchDeposits = async (storeId) => {
+    if (!storeId) {
+      state.deposits = [];
+      populateDeposits();
+      return;
+    }
+    const response = await fetch(`${API_BASE}/deposits?empresa=${encodeURIComponent(storeId)}`);
+    if (!response.ok) {
+      throw new Error('Não foi possível carregar os depósitos da empresa.');
+    }
+    const payload = await response.json();
+    state.deposits = Array.isArray(payload?.deposits) ? payload.deposits : [];
+    populateDeposits();
+  };
+
+  const fetchPdvDetails = async (pdvId) => {
+    const response = await fetch(`${API_BASE}/pdvs/${pdvId}`);
+    if (!response.ok) {
+      const message = await response.json().catch(() => null);
+      throw new Error(message?.message || 'Não foi possível carregar as configurações do PDV.');
+    }
+    return response.json();
+  };
+
+  const fillPrinterInputs = (printer, inputs) => {
+    if (!inputs) return;
+    const { nome, vias } = inputs;
+    if (nome) nome.value = printer?.nome || '';
+    if (vias) vias.value = printer?.vias || '';
+  };
+
+  const populateForm = (pdv) => {
+    const impressao = pdv?.configuracoesImpressao || {};
+    const venda = pdv?.configuracoesVenda || {};
+    const fiscal = pdv?.configuracoesFiscal || {};
+    const estoque = pdv?.configuracoesEstoque || {};
+
+    const sempreImprimir = impressao.sempreImprimir || 'perguntar';
+    resetRadios('input[name="sempre-imprimir"]', sempreImprimir);
+
+    fillPrinterInputs(impressao.impressoraVenda, elements.printerInputs.venda);
+    fillPrinterInputs(impressao.impressoraOrcamento, elements.printerInputs.orcamento);
+    fillPrinterInputs(impressao.impressoraContasReceber, elements.printerInputs.contas);
+    fillPrinterInputs(impressao.impressoraCaixa, elements.printerInputs.caixa);
+
+    const perfis = Array.isArray(venda.permitirDesconto) ? new Set(venda.permitirDesconto) : new Set();
+    document.querySelectorAll('.desconto-checkbox').forEach((checkbox) => {
+      checkbox.checked = perfis.has(checkbox.value);
+    });
+
+    const tipoEmissao = fiscal.tipoEmissaoPadrao || 'fiscal';
+    resetRadios('input[name="tipo-emissao"]', tipoEmissao);
+
+    if (elements.depositoSelect) {
+      const depositoValue = estoque.depositoPadrao?._id || estoque.depositoPadrao || '';
+      const optionExists = Array.from(elements.depositoSelect.options).some(
+        (option) => option.value === String(depositoValue)
+      );
+      if (
+        depositoValue &&
+        !state.deposits.some((deposit) => String(deposit._id) === String(depositoValue)) &&
+        !optionExists
+      ) {
+        const fallbackOption = document.createElement('option');
+        fallbackOption.value = depositoValue;
+        fallbackOption.textContent = 'Depósito não listado';
+        elements.depositoSelect.appendChild(fallbackOption);
+      }
+      elements.depositoSelect.value = depositoValue;
+    }
+
+    const now = formatDateTime(new Date());
+    setStatus(`Configurações carregadas. Última leitura: ${now}.`);
+  };
+
+  const handleTabNavigation = () => {
+    const triggers = document.querySelectorAll('.tab-trigger');
+    const panels = document.querySelectorAll('[data-tab-panel]');
+    triggers.forEach((trigger) => {
+      trigger.addEventListener('click', () => {
+        const target = trigger.getAttribute('data-tab-target');
+        triggers.forEach((button) => {
+          const isActive = button === trigger;
+          button.classList.toggle('text-primary', isActive);
+          button.classList.toggle('border-primary', isActive);
+          button.classList.toggle('border-transparent', !isActive);
+          button.classList.toggle('text-gray-500', !isActive);
+        });
+        panels.forEach((panel) => {
+          panel.classList.toggle('hidden', panel.getAttribute('data-tab-panel') !== target);
+        });
+      });
+    });
+  };
+
+  const readPrinterConfig = ({ nome, vias }, label) => {
+    const nomeValue = nome?.value.trim() || '';
+    const viasValue = vias?.value.trim() || '';
+
+    if (!nomeValue && !viasValue) {
+      return { ok: true, value: null };
+    }
+
+    if (!nomeValue) {
+      notify(`Informe o nome da ${label}.`, 'warning');
+      nome?.focus();
+      return { ok: false };
+    }
+
+    let viasNumber = 1;
+    if (viasValue) {
+      const parsed = Number(viasValue);
+      if (!Number.isFinite(parsed)) {
+        notify(`Informe um número válido de vias para a ${label}.`, 'warning');
+        vias?.focus();
+        return { ok: false };
+      }
+      const inteiro = Math.trunc(parsed);
+      if (inteiro < 1 || inteiro > 10) {
+        notify('O número de vias deve estar entre 1 e 10.', 'warning');
+        vias?.focus();
+        return { ok: false };
+      }
+      viasNumber = inteiro;
+    }
+
+    return { ok: true, value: { nome: nomeValue, vias: viasNumber } };
+  };
+
+  const collectFormData = () => {
+    const sempre = document.querySelector('input[name="sempre-imprimir"]:checked');
+    const sempreImprimir = sempre?.value || 'perguntar';
+
+    const printerVenda = readPrinterConfig(elements.printerInputs.venda, 'impressora de venda');
+    if (!printerVenda.ok) return null;
+    const printerOrcamento = readPrinterConfig(elements.printerInputs.orcamento, 'impressora de orçamento');
+    if (!printerOrcamento.ok) return null;
+    const printerContas = readPrinterConfig(elements.printerInputs.contas, 'impressora de contas a receber');
+    if (!printerContas.ok) return null;
+    const printerCaixa = readPrinterConfig(elements.printerInputs.caixa, 'impressora do caixa');
+    if (!printerCaixa.ok) return null;
+
+    const perfis = Array.from(document.querySelectorAll('.desconto-checkbox:checked')).map(
+      (checkbox) => checkbox.value
+    );
+
+    const tipoEmissao = document.querySelector('input[name="tipo-emissao"]:checked')?.value || 'fiscal';
+
+    const depositoPadrao = elements.depositoSelect?.value || null;
+
+    return {
+      impressao: {
+        sempreImprimir,
+        impressoraVenda: printerVenda.value,
+        impressoraOrcamento: printerOrcamento.value,
+        impressoraContasReceber: printerContas.value,
+        impressoraCaixa: printerCaixa.value,
+      },
+      venda: {
+        permitirDesconto: perfis,
+      },
+      fiscal: {
+        tipoEmissaoPadrao: tipoEmissao,
+      },
+      estoque: {
+        depositoPadrao,
+      },
+    };
+  };
+
+  const updateStateWithPdv = (pdv) => {
+    const index = state.pdvs.findIndex((item) => item._id === pdv._id);
+    if (index >= 0) {
+      state.pdvs[index] = { ...state.pdvs[index], ...pdv };
+    }
+  };
+
+  const handleSave = async () => {
+    if (!state.selectedPdv) {
+      notify('Selecione um PDV antes de salvar as configurações.', 'warning');
+      return;
+    }
+    const payload = collectFormData();
+    if (!payload) return;
+
+    try {
+      toggleSaving(true);
+      setStatus('Salvando configurações...');
+      const token = getToken();
+      if (!token) {
+        throw new Error('Sessão expirada. Faça login novamente para continuar.');
+      }
+      const response = await fetch(`${API_BASE}/pdvs/${state.selectedPdv}/configuracoes`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(data?.message || 'Não foi possível salvar as configurações.');
+      }
+      updateStateWithPdv(data);
+      populateForm(data);
+      notify('Configurações atualizadas com sucesso.', 'success');
+      setStatus(`Configurações atualizadas às ${formatDateTime(new Date())}.`);
+    } catch (error) {
+      console.error('Erro ao salvar configurações do PDV:', error);
+      notify(error.message || 'Erro ao salvar configurações do PDV.', 'error');
+      setStatus('Não foi possível salvar as configurações. Tente novamente.');
+    } finally {
+      toggleSaving(false);
+    }
+  };
+
+  const handleCompanyChange = async () => {
+    const value = elements.companySelect?.value || '';
+    state.selectedStore = value;
+    state.selectedPdv = '';
+    clearForm();
+    toggleConfigVisibility(false);
+    elements.pdvSelect.value = '';
+    elements.pdvSelect.disabled = true;
+    if (elements.selectionHint) {
+      elements.selectionHint.textContent = value
+        ? 'Carregando PDVs disponíveis...'
+        : 'Escolha a empresa para carregar os PDVs disponíveis.';
+    }
+
+    try {
+      if (!value) {
+        state.pdvs = [];
+        state.deposits = [];
+        populatePdvSelect();
+        populateDeposits();
+        disableConfigFields(true);
+        return;
+      }
+      disableConfigFields(true);
+      await Promise.all([fetchPdvs(value), fetchDeposits(value)]);
+      if (elements.selectionHint) {
+        elements.selectionHint.textContent =
+          state.pdvs.length > 0
+            ? 'Selecione o PDV desejado para visualizar as configurações.'
+            : 'Nenhum PDV encontrado para a empresa selecionada.';
+      }
+      disableConfigFields(false);
+    } catch (error) {
+      console.error('Erro ao carregar dados da empresa:', error);
+      notify(error.message || 'Erro ao carregar dados da empresa selecionada.', 'error');
+      state.pdvs = [];
+      state.deposits = [];
+      populatePdvSelect();
+      populateDeposits();
+      disableConfigFields(true);
+    }
+  };
+
+  const handlePdvChange = async () => {
+    const value = elements.pdvSelect?.value || '';
+    state.selectedPdv = value;
+    if (!value) {
+      clearForm();
+      toggleConfigVisibility(false);
+      return;
+    }
+    disableConfigFields(true);
+    setStatus('Carregando configurações do PDV...');
+    try {
+      const pdv = await fetchPdvDetails(value);
+      populateForm(pdv);
+      toggleConfigVisibility(true);
+      disableConfigFields(false);
+    } catch (error) {
+      console.error('Erro ao carregar o PDV selecionado:', error);
+      notify(error.message || 'Erro ao carregar o PDV selecionado.', 'error');
+      toggleConfigVisibility(false);
+      setStatus('Não foi possível carregar as configurações do PDV.');
+    }
+  };
+
+  const bindEvents = () => {
+    elements.companySelect?.addEventListener('change', handleCompanyChange);
+    elements.pdvSelect?.addEventListener('change', handlePdvChange);
+    elements.saveButton?.addEventListener('click', (event) => {
+      event.preventDefault();
+      if (state.saving) return;
+      handleSave();
+    });
+  };
+
+  const init = async () => {
+    queryElements();
+    handleTabNavigation();
+    disableConfigFields(true);
+    try {
+      await fetchStores();
+    } catch (error) {
+      console.error('Erro ao carregar empresas:', error);
+      notify(error.message || 'Erro ao carregar a lista de empresas.', 'error');
+    }
+    bindEvents();
+  };
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/servidor/models/Pdv.js
+++ b/servidor/models/Pdv.js
@@ -1,6 +1,57 @@
 const mongoose = require('mongoose');
 
 const ambientesPermitidos = ['homologacao', 'producao'];
+const opcoesImpressao = ['sim', 'nao', 'perguntar'];
+const perfisDesconto = ['funcionario', 'gerente', 'admin'];
+const tiposEmissao = ['matricial', 'fiscal', 'ambos'];
+
+const printerSchema = new mongoose.Schema(
+  {
+    nome: { type: String, trim: true, default: '' },
+    vias: {
+      type: Number,
+      min: [1, 'O número mínimo de vias é 1.'],
+      max: [10, 'O número máximo de vias é 10.'],
+      default: 1,
+    },
+  },
+  { _id: false }
+);
+
+const impressaoSchema = new mongoose.Schema(
+  {
+    sempreImprimir: { type: String, enum: opcoesImpressao, default: 'perguntar' },
+    impressoraVenda: { type: printerSchema, default: undefined },
+    impressoraOrcamento: { type: printerSchema, default: undefined },
+    impressoraContasReceber: { type: printerSchema, default: undefined },
+    impressoraCaixa: { type: printerSchema, default: undefined },
+  },
+  { _id: false }
+);
+
+const vendaSchema = new mongoose.Schema(
+  {
+    permitirDesconto: {
+      type: [{ type: String, enum: perfisDesconto }],
+      default: [],
+    },
+  },
+  { _id: false }
+);
+
+const fiscalSchema = new mongoose.Schema(
+  {
+    tipoEmissaoPadrao: { type: String, enum: tiposEmissao, default: 'fiscal' },
+  },
+  { _id: false }
+);
+
+const estoqueSchema = new mongoose.Schema(
+  {
+    depositoPadrao: { type: mongoose.Schema.Types.ObjectId, ref: 'Deposit', default: null },
+  },
+  { _id: false }
+);
 
 const pdvSchema = new mongoose.Schema(
   {
@@ -29,6 +80,10 @@ const pdvSchema = new mongoose.Schema(
     ultimaSincronizacao: { type: Date, default: null },
     criadoPor: { type: String, trim: true },
     atualizadoPor: { type: String, trim: true },
+    configuracoesImpressao: { type: impressaoSchema, default: () => ({}) },
+    configuracoesVenda: { type: vendaSchema, default: () => ({}) },
+    configuracoesFiscal: { type: fiscalSchema, default: () => ({}) },
+    configuracoesEstoque: { type: estoqueSchema, default: () => ({}) },
   },
   {
     timestamps: true,


### PR DESCRIPTION
## Summary
- add a dedicated admin page to configure PDV printing, sales, fiscal and estoque preferences by empresa/PDV
- implement client-side logic to load, edit and persist the PDV settings via the API
- extend the PDV schema and routes to store printer, discount, emission and depósito padrão data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6cb308d3083238a2006e38b30557b