### PR TITLE
Add admin finance payment methods interface

### DIFF
--- a/components/admin/sidebar.html
+++ b/components/admin/sidebar.html
@@ -60,10 +60,31 @@
         </div>
       </div>
 
-      <a href="#" class="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 transition">
-        <i class="fas fa-wallet text-primary"></i>
-        Financeiro
-      </a>
+      <div>
+        <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-semibold text-gray-700 rounded-lg hover:bg-gray-50 transition" data-accordion-button>
+          <span class="inline-flex items-center gap-2">
+            <i class="fas fa-wallet text-primary"></i>
+            Financeiro
+          </span>
+          <i class="fas fa-chevron-down text-xs text-gray-500 transition-transform" data-chevron></i>
+        </button>
+        <div class="mt-2 space-y-3 pl-4 hidden" data-accordion-content>
+          <div>
+            <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-medium text-gray-700 rounded-lg hover:bg-gray-50 transition" data-accordion-button>
+              <span class="inline-flex items-center gap-2">
+                <i class="fas fa-receipt text-primary"></i>
+                Pagamentos
+              </span>
+              <i class="fas fa-chevron-down text-xs text-gray-500 transition-transform" data-chevron></i>
+            </button>
+            <div class="mt-2 space-y-2 pl-4 hidden" data-accordion-content>
+              <a href="/pages/admin/admin-financeiro-meios-pagamento.html" class="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
+                <span class="inline-flex items-center gap-2"><i class="fas fa-credit-card text-gray-400"></i>Meios de Pagamento</span>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
 
       <div>
         <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-semibold text-gray-700 rounded-lg hover:bg-gray-50 transition" data-accordion-button data-default-open="true">

--- a/pages/admin/admin-financeiro-meios-pagamento.html
+++ b/pages/admin/admin-financeiro-meios-pagamento.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin: Meios de Pagamento - E o Bicho</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+  <link rel="stylesheet" href="../../src/output.css">
+</head>
+<body class="bg-gray-100">
+  <div id="admin-header-placeholder"></div>
+
+  <main class="container mx-auto px-4 py-8 min-h-screen">
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
+      <aside class="md:col-span-4">
+        <div id="admin-sidebar-placeholder"></div>
+      </aside>
+
+      <div class="md:col-span-4 space-y-6">
+        <header class="bg-white rounded-xl shadow-sm border border-gray-100 p-6 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 class="text-2xl font-bold text-gray-800">Meios de Pagamento</h1>
+            <p class="text-sm text-gray-600">Configure formas de recebimento e visualize o impacto financeiro de cada modalidade.</p>
+          </div>
+          <div class="flex items-center gap-3">
+            <span class="inline-flex items-center gap-2 rounded-full bg-blue-50 text-blue-700 text-xs font-semibold px-3 py-1">
+              <i class="fas fa-lock"></i>
+              Dados restritos ao financeiro
+            </span>
+          </div>
+        </header>
+
+        <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+          <section class="xl:col-span-2 space-y-6">
+            <form id="payment-method-form" class="bg-white rounded-xl shadow-sm border border-gray-100 p-6 space-y-8">
+              <input type="hidden" id="payment-method-id">
+
+              <div class="space-y-4">
+                <div class="flex items-center justify-between">
+                  <h2 class="text-lg font-semibold text-gray-800">Empresa e identificação</h2>
+                  <button type="button" id="payment-method-reset" class="text-sm text-primary hover:underline">Novo meio</button>
+                </div>
+                <p class="text-sm text-gray-600">Selecione a empresa que receberá os valores e personalize a identificação do meio de pagamento.</p>
+
+                <div class="space-y-4">
+                  <div>
+                    <label for="payment-company" class="block text-sm font-medium text-gray-700 mb-1">Empresa vinculada <span class="text-red-500">*</span></label>
+                    <select id="payment-company" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
+                      <option value="">Carregando empresas...</option>
+                    </select>
+                    <p class="text-xs text-gray-500 mt-1">Os parâmetros fiscais e contábeis herdam da empresa selecionada.</p>
+                  </div>
+
+                  <div class="grid grid-cols-1 md:grid-cols-12 gap-4">
+                    <div class="md:col-span-4">
+                      <label for="payment-code" class="block text-sm font-medium text-gray-700 mb-1">Código</label>
+                      <div class="relative">
+                        <input type="text" id="payment-code" class="w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm font-semibold text-gray-700" readonly>
+                        <span class="absolute inset-y-0 right-3 flex items-center text-gray-400 text-xs">Automático</span>
+                      </div>
+                    </div>
+                    <div class="md:col-span-8">
+                      <label for="payment-name" class="block text-sm font-medium text-gray-700 mb-1">Nome do meio de pagamento <span class="text-red-500">*</span></label>
+                      <input type="text" id="payment-name" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="Ex.: Cartão de Crédito" required>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="space-y-4">
+                <h2 class="text-lg font-semibold text-gray-800">Tipo de recebimento</h2>
+                <p class="text-sm text-gray-600">Defina como o pagamento será processado para ajustar repasses e prazos.</p>
+
+                <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                  <label class="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-700 has-[:checked]:border-primary has-[:checked]:text-primary">
+                    <span>À vista</span>
+                    <input type="radio" name="payment-type" value="avista" class="text-primary focus:ring-primary" checked>
+                  </label>
+                  <label class="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-700 has-[:checked]:border-primary has-[:checked]:text-primary">
+                    <span>Débito</span>
+                    <input type="radio" name="payment-type" value="debito" class="text-primary focus:ring-primary">
+                  </label>
+                  <label class="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-700 has-[:checked]:border-primary has-[:checked]:text-primary">
+                    <span>Crédito</span>
+                    <input type="radio" name="payment-type" value="credito" class="text-primary focus:ring-primary">
+                  </label>
+                </div>
+
+                <div id="avista-section" class="space-y-4">
+                  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                      <label for="avista-days" class="block text-sm font-medium text-gray-700 mb-1">Prazo de recebimento (dias)</label>
+                      <input type="number" id="avista-days" min="0" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" value="0">
+                    </div>
+                    <div>
+                      <label for="avista-discount" class="block text-sm font-medium text-gray-700 mb-1">Desconto aplicado (%)</label>
+                      <input type="number" id="avista-discount" min="0" step="0.01" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" value="0">
+                    </div>
+                  </div>
+                  <div class="rounded-lg border border-emerald-100 bg-emerald-50 px-4 py-3">
+                    <div class="flex items-center gap-3 text-emerald-700">
+                      <i class="fas fa-money-bill-wave text-lg"></i>
+                      <div>
+                        <p class="text-sm font-semibold">Pré-visualização do repasse à vista</p>
+                        <p id="avista-preview" class="text-sm text-emerald-800">Recebimento no mesmo dia (D+0) sem desconto.</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div id="debito-section" class="space-y-4 hidden">
+                  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                      <label for="debito-days" class="block text-sm font-medium text-gray-700 mb-1">Prazo de recebimento (dias)</label>
+                      <input type="number" id="debito-days" min="0" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" value="1">
+                    </div>
+                    <div>
+                      <label for="debito-discount" class="block text-sm font-medium text-gray-700 mb-1">Desconto aplicado (%)</label>
+                      <input type="number" id="debito-discount" min="0" step="0.01" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" value="0">
+                    </div>
+                  </div>
+                  <div class="rounded-lg border border-cyan-100 bg-cyan-50 px-4 py-3">
+                    <div class="flex items-center gap-3 text-cyan-700">
+                      <i class="fas fa-credit-card text-lg"></i>
+                      <div>
+                        <p class="text-sm font-semibold">Pré-visualização do repasse no débito</p>
+                        <p id="debito-preview" class="text-sm text-cyan-800">Recebimento em D+1 com 0% de desconto.</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div id="credito-section" class="space-y-4 hidden">
+                  <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div class="md:col-span-1">
+                      <label for="credito-installments" class="block text-sm font-medium text-gray-700 mb-1">Parcelas aceitas</label>
+                      <input type="number" id="credito-installments" min="1" max="12" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" value="3">
+                    </div>
+                    <div class="md:col-span-1">
+                      <label for="credito-days" class="block text-sm font-medium text-gray-700 mb-1">Prazo de recebimento (dias)</label>
+                      <input type="number" id="credito-days" min="0" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" value="30">
+                    </div>
+                    <div class="md:col-span-1">
+                      <label for="credito-discount" class="block text-sm font-medium text-gray-700 mb-1">Desconto aplicado (%)</label>
+                      <input type="number" id="credito-discount" min="0" step="0.01" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" value="2.49">
+                    </div>
+                  </div>
+                  <div class="rounded-lg border border-indigo-100 bg-indigo-50 px-4 py-3 space-y-3">
+                    <div class="flex items-center gap-3 text-indigo-700">
+                      <i class="fas fa-layer-group text-lg"></i>
+                      <div>
+                        <p class="text-sm font-semibold">Pré-visualização por parcela</p>
+                        <p class="text-sm text-indigo-800">Simule o recebimento em cada faixa de parcelamento aceito.</p>
+                      </div>
+                    </div>
+                    <div id="credito-preview-list" class="space-y-2"></div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between border-t border-gray-100 pt-4">
+                <p class="text-xs text-gray-500">Campos marcados com <span class="text-red-500">*</span> são obrigatórios.</p>
+                <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+                  <button type="button" id="payment-method-cancel" class="hidden rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:border-gray-300">Cancelar edição</button>
+                  <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-5 py-2 text-sm font-semibold text-white hover:bg-secondary transition">
+                    <i class="fas fa-save"></i>
+                    <span id="payment-submit-label">Salvar meio</span>
+                  </button>
+                </div>
+              </div>
+            </form>
+
+            <section class="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+              <div class="flex items-center justify-between">
+                <h2 class="text-lg font-semibold text-gray-800">Meios cadastrados</h2>
+                <span id="payment-method-count" class="text-xs font-semibold text-gray-500">0</span>
+              </div>
+              <p class="text-sm text-gray-600 mb-4">Visualize e organize os meios de pagamento já configurados.</p>
+              <div id="payment-methods-list" class="space-y-3"></div>
+              <div id="payment-methods-empty" class="text-sm text-gray-500 text-center py-6 border border-dashed border-gray-200 rounded-lg">
+                Nenhum meio de pagamento cadastrado até o momento.
+              </div>
+            </section>
+          </section>
+
+          <aside class="xl:col-span-1 space-y-6">
+            <section class="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+              <h2 class="text-lg font-semibold text-gray-800">Resumo da empresa</h2>
+              <p class="text-sm text-gray-600 mb-4">Confira os principais dados da empresa vinculada.</p>
+              <div id="payment-company-summary" class="space-y-3 text-sm text-gray-700">
+                <p class="text-gray-500">Selecione uma empresa para visualizar detalhes.</p>
+              </div>
+            </section>
+
+            <section class="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+              <h2 class="text-lg font-semibold text-gray-800">Pré-visualização consolidada</h2>
+              <p class="text-sm text-gray-600 mb-4">Entenda rapidamente prazos e descontos aplicados.</p>
+              <div id="payment-overview" class="space-y-3 text-sm text-gray-700">
+                <p class="text-gray-500">Escolha um tipo de recebimento para ver o resumo.</p>
+              </div>
+            </section>
+          </aside>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <div id="admin-footer-placeholder"></div>
+  <div id="modal-placeholder"></div>
+  <div id="confirm-modal-placeholder"></div>
+
+  <script>var basePath = '../../';</script>
+  <script src="../../scripts/core/config.js"></script>
+  <script src="../../scripts/core/ui.js"></script>
+  <script src="../../scripts/core/main.js"></script>
+  <script src="../../scripts/admin/admin.js"></script>
+  <script src="../../scripts/admin/admin-financeiro-meios-pagamento.js"></script>
+</body>
+</html>

--- a/scripts/admin/admin-financeiro-meios-pagamento.js
+++ b/scripts/admin/admin-financeiro-meios-pagamento.js
@@ -1,0 +1,465 @@
+(function () {
+  const API_BASE =
+    (typeof API_CONFIG !== 'undefined' && API_CONFIG && API_CONFIG.BASE_URL) || '/api';
+
+  const selectors = {
+    form: '#payment-method-form',
+    resetButton: '#payment-method-reset',
+    cancelButton: '#payment-method-cancel',
+    submitLabel: '#payment-submit-label',
+    companySelect: '#payment-company',
+    companySummary: '#payment-company-summary',
+    codeInput: '#payment-code',
+    nameInput: '#payment-name',
+    typeRadios: 'input[name="payment-type"]',
+    avistaSection: '#avista-section',
+    avistaDays: '#avista-days',
+    avistaDiscount: '#avista-discount',
+    avistaPreview: '#avista-preview',
+    debitoSection: '#debito-section',
+    debitoDays: '#debito-days',
+    debitoDiscount: '#debito-discount',
+    debitoPreview: '#debito-preview',
+    creditoSection: '#credito-section',
+    creditoInstallments: '#credito-installments',
+    creditoDays: '#credito-days',
+    creditoDiscount: '#credito-discount',
+    creditoPreviewList: '#credito-preview-list',
+    overview: '#payment-overview',
+    methodsList: '#payment-methods-list',
+    methodsEmptyState: '#payment-methods-empty',
+    methodsCount: '#payment-method-count',
+  };
+
+  const state = {
+    companies: [],
+    selectedCompanyId: '',
+    currentType: 'avista',
+    methods: [],
+  };
+
+  const elements = {};
+
+  const notify = (message, type = 'info') => {
+    if (typeof window.showToast === 'function') {
+      window.showToast({ message, type });
+    } else {
+      console[type === 'error' ? 'error' : 'log'](message);
+    }
+  };
+
+  const parseNumber = (value, fallback = 0) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  };
+
+  const formatDays = (value) => {
+    const days = Math.max(0, parseNumber(value, 0));
+    if (days === 0) return 'Recebimento no mesmo dia (D+0)';
+    if (days === 1) return 'Recebimento em 1 dia (D+1)';
+    return `Recebimento em ${days} dias (D+${days})`;
+  };
+
+  const formatDiscount = (value) => {
+    const discount = Math.max(0, parseNumber(value, 0));
+    if (discount === 0) return 'Sem desconto aplicado';
+    return `Desconto de ${discount.toFixed(2).replace('.', ',')}%`;
+  };
+
+  const getSelectedCompany = () =>
+    state.companies.find((company) => company && company._id === state.selectedCompanyId) || null;
+
+  const updateCodeField = () => {
+    if (!elements.codeInput) return;
+    elements.codeInput.value = 'Gerado automaticamente';
+  };
+
+  const updateCompanySummary = () => {
+    if (!elements.companySummary) return;
+    const company = getSelectedCompany();
+    if (!company) {
+      elements.companySummary.innerHTML =
+        '<p class="text-gray-500">Selecione uma empresa para visualizar detalhes.</p>';
+      return;
+    }
+
+    const nome = company.nome || company.nomeFantasia || company.razaoSocial || '—';
+    const razao = company.razaoSocial || company.nome || '—';
+    const documento = company.cnpj || company.cpf || '—';
+    const email = company.emailFiscal || company.email || '—';
+    const telefone = company.telefone || company.celular || company.whatsapp || '—';
+
+    elements.companySummary.innerHTML = `
+      <div class="space-y-4">
+        <div>
+          <p class="text-xs uppercase tracking-wide text-gray-500">Nome fantasia</p>
+          <p class="text-sm font-semibold text-gray-800">${nome}</p>
+        </div>
+        <div>
+          <p class="text-xs uppercase tracking-wide text-gray-500">Razão social</p>
+          <p class="text-sm text-gray-700">${razao}</p>
+        </div>
+        <div class="grid grid-cols-2 gap-3">
+          <div>
+            <p class="text-xs uppercase tracking-wide text-gray-500">Documento</p>
+            <p class="text-sm text-gray-700">${documento}</p>
+          </div>
+          <div>
+            <p class="text-xs uppercase tracking-wide text-gray-500">Telefone</p>
+            <p class="text-sm text-gray-700">${telefone}</p>
+          </div>
+        </div>
+        <div>
+          <p class="text-xs uppercase tracking-wide text-gray-500">Contato fiscal</p>
+          <p class="text-sm text-gray-700">${email}</p>
+        </div>
+      </div>
+    `;
+  };
+
+  const updateOverview = () => {
+    if (!elements.overview) return;
+
+    const company = getSelectedCompany();
+    const companyName = company ? company.nome || company.nomeFantasia || 'Empresa selecionada' : '—';
+
+    const buildRow = (label, value) => `
+      <div class="flex items-start justify-between gap-4">
+        <span class="text-xs uppercase tracking-wide text-gray-500">${label}</span>
+        <span class="text-sm font-medium text-gray-800 text-right">${value}</span>
+      </div>
+    `;
+
+    if (state.currentType === 'avista') {
+      const days = formatDays(elements.avistaDays?.value);
+      const discount = formatDiscount(elements.avistaDiscount?.value);
+      elements.overview.innerHTML = `
+        <div class="space-y-3">
+          ${buildRow('Empresa', companyName)}
+          ${buildRow('Modalidade', 'À vista')}
+          ${buildRow('Prazo', days)}
+          ${buildRow('Desconto', discount)}
+        </div>
+      `;
+      return;
+    }
+
+    if (state.currentType === 'debito') {
+      const days = formatDays(elements.debitoDays?.value);
+      const discount = formatDiscount(elements.debitoDiscount?.value);
+      elements.overview.innerHTML = `
+        <div class="space-y-3">
+          ${buildRow('Empresa', companyName)}
+          ${buildRow('Modalidade', 'Débito')}
+          ${buildRow('Prazo', days)}
+          ${buildRow('Desconto', discount)}
+        </div>
+      `;
+      return;
+    }
+
+    const installments = Math.max(1, parseNumber(elements.creditoInstallments?.value, 1));
+    const days = formatDays(elements.creditoDays?.value);
+    const discount = formatDiscount(elements.creditoDiscount?.value);
+    elements.overview.innerHTML = `
+      <div class="space-y-3">
+        ${buildRow('Empresa', companyName)}
+        ${buildRow('Modalidade', 'Crédito')}
+        ${buildRow('Parcelas', `${installments}x`)}
+        ${buildRow('Prazo', days)}
+        ${buildRow('Desconto', discount)}
+      </div>
+    `;
+  };
+
+  const updateAvistaPreview = () => {
+    if (!elements.avistaPreview) return;
+    const days = formatDays(elements.avistaDays?.value);
+    const discount = formatDiscount(elements.avistaDiscount?.value);
+    elements.avistaPreview.textContent = `${days} • ${discount}`;
+  };
+
+  const updateDebitoPreview = () => {
+    if (!elements.debitoPreview) return;
+    const days = formatDays(elements.debitoDays?.value);
+    const discount = formatDiscount(elements.debitoDiscount?.value);
+    elements.debitoPreview.textContent = `${days} • ${discount}`;
+  };
+
+  const updateCreditoPreview = () => {
+    if (!elements.creditoPreviewList) return;
+    const installments = Math.max(1, parseNumber(elements.creditoInstallments?.value, 1));
+    const days = formatDays(elements.creditoDays?.value);
+    const discount = formatDiscount(elements.creditoDiscount?.value);
+
+    const items = [];
+    for (let i = 1; i <= installments; i += 1) {
+      items.push(`
+        <div class="flex items-center justify-between rounded-lg border border-indigo-100 bg-white/70 px-3 py-2">
+          <span class="text-sm font-semibold text-indigo-700">Crédito ${i}x</span>
+          <span class="text-xs text-indigo-600">${days} • ${discount}</span>
+        </div>
+      `);
+    }
+
+    elements.creditoPreviewList.innerHTML = items.join('');
+  };
+
+  const toggleSections = () => {
+    const mapping = {
+      avista: elements.avistaSection,
+      debito: elements.debitoSection,
+      credito: elements.creditoSection,
+    };
+
+    Object.entries(mapping).forEach(([type, section]) => {
+      if (!section) return;
+      if (type === state.currentType) {
+        section.classList.remove('hidden');
+      } else {
+        section.classList.add('hidden');
+      }
+    });
+  };
+
+  const populateCompanySelect = () => {
+    if (!elements.companySelect) return;
+    const options = [];
+    if (!state.companies.length) {
+      options.push('<option value="">Nenhuma empresa cadastrada</option>');
+    } else {
+      options.push('<option value="">Selecione uma empresa</option>');
+      state.companies.forEach((company) => {
+        const label = company.nome || company.nomeFantasia || 'Empresa sem nome';
+        options.push(`<option value="${company._id}">${label}</option>`);
+      });
+    }
+    elements.companySelect.innerHTML = options.join('');
+    if (state.selectedCompanyId) {
+      elements.companySelect.value = state.selectedCompanyId;
+    }
+  };
+
+  const fetchCompanies = async () => {
+    try {
+      const response = await fetch(`${API_BASE}/stores`);
+      if (!response.ok) {
+        throw new Error('Não foi possível carregar as empresas cadastradas.');
+      }
+      const payload = await response.json();
+      state.companies = Array.isArray(payload) ? payload : [];
+      populateCompanySelect();
+      updateCompanySummary();
+      updateOverview();
+    } catch (error) {
+      console.error('Erro ao carregar empresas:', error);
+      notify(error.message || 'Falha ao carregar empresas cadastradas.', 'error');
+      state.companies = [];
+      populateCompanySelect();
+    }
+  };
+
+  const handleCompanyChange = (event) => {
+    state.selectedCompanyId = event.target.value || '';
+    updateCompanySummary();
+    updateOverview();
+  };
+
+  const handleTypeChange = (event) => {
+    state.currentType = event.target.value;
+    toggleSections();
+    updateAvistaPreview();
+    updateDebitoPreview();
+    updateCreditoPreview();
+    updateOverview();
+  };
+
+  const resetForm = () => {
+    state.selectedCompanyId = '';
+    state.currentType = 'avista';
+
+    if (elements.form) {
+      elements.form.reset();
+    }
+
+    if (elements.companySelect) {
+      elements.companySelect.value = '';
+    }
+
+    if (elements.avistaDays) elements.avistaDays.value = 0;
+    if (elements.avistaDiscount) elements.avistaDiscount.value = 0;
+    if (elements.debitoDays) elements.debitoDays.value = 1;
+    if (elements.debitoDiscount) elements.debitoDiscount.value = 0;
+    if (elements.creditoInstallments) elements.creditoInstallments.value = 3;
+    if (elements.creditoDays) elements.creditoDays.value = 30;
+    if (elements.creditoDiscount) elements.creditoDiscount.value = 2.49;
+
+    const radios = Array.from(document.querySelectorAll(selectors.typeRadios));
+    radios.forEach((radio) => {
+      radio.checked = radio.value === 'avista';
+    });
+
+    updateCodeField();
+    toggleSections();
+    updateAvistaPreview();
+    updateDebitoPreview();
+    updateCreditoPreview();
+    updateCompanySummary();
+    updateOverview();
+  };
+
+  const renderMethods = () => {
+    if (!elements.methodsList || !elements.methodsEmptyState || !elements.methodsCount) return;
+
+    if (!state.methods.length) {
+      elements.methodsList.innerHTML = '';
+      elements.methodsEmptyState.classList.remove('hidden');
+      elements.methodsCount.textContent = '0';
+      return;
+    }
+
+    elements.methodsEmptyState.classList.add('hidden');
+    elements.methodsCount.textContent = String(state.methods.length);
+
+    const cards = state.methods.map((method) => {
+      const typeLabel =
+        method.type === 'credito'
+          ? `Crédito • ${method.installments || 1}x`
+          : method.type === 'debito'
+          ? 'Débito'
+          : 'À vista';
+      return `
+        <article class="rounded-lg border border-gray-200 px-4 py-3">
+          <div class="flex items-center justify-between gap-4">
+            <div>
+              <h3 class="text-sm font-semibold text-gray-800">${method.name}</h3>
+              <p class="text-xs text-gray-500">${typeLabel}</p>
+            </div>
+            <span class="text-xs font-semibold text-gray-400">${method.code || '—'}</span>
+          </div>
+        </article>
+      `;
+    });
+
+    elements.methodsList.innerHTML = cards.join('');
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    const company = getSelectedCompany();
+    if (!company) {
+      notify('Selecione uma empresa antes de salvar o meio de pagamento.', 'error');
+      elements.companySelect?.focus();
+      return;
+    }
+
+    const name = (elements.nameInput?.value || '').trim();
+    if (!name) {
+      notify('Informe um nome para o meio de pagamento.', 'error');
+      elements.nameInput?.focus();
+      return;
+    }
+
+    const generatedId =
+      (typeof window !== 'undefined' && window.crypto && typeof window.crypto.randomUUID === 'function')
+        ? window.crypto.randomUUID()
+        : `temp-${Date.now()}`;
+
+    const baseCode = (elements.codeInput?.value || '').trim();
+
+    const basePayload = {
+      id: generatedId,
+      companyId: company._id,
+      companyName: company.nome || company.nomeFantasia || 'Empresa selecionada',
+      name,
+      code:
+        baseCode && baseCode !== 'Gerado automaticamente'
+          ? baseCode
+          : `MP-${String(state.methods.length + 1).padStart(3, '0')}`,
+      type: state.currentType,
+    };
+
+    if (state.currentType === 'avista') {
+      basePayload.days = Math.max(0, parseNumber(elements.avistaDays?.value, 0));
+      basePayload.discount = Math.max(0, parseNumber(elements.avistaDiscount?.value, 0));
+    } else if (state.currentType === 'debito') {
+      basePayload.days = Math.max(0, parseNumber(elements.debitoDays?.value, 1));
+      basePayload.discount = Math.max(0, parseNumber(elements.debitoDiscount?.value, 0));
+    } else {
+      basePayload.days = Math.max(0, parseNumber(elements.creditoDays?.value, 30));
+      basePayload.discount = Math.max(0, parseNumber(elements.creditoDiscount?.value, 0));
+      basePayload.installments = Math.max(1, parseNumber(elements.creditoInstallments?.value, 1));
+    }
+
+    state.methods.unshift(basePayload);
+    renderMethods();
+    notify('Pré-visualização salva localmente. Integração com o backend ainda pendente.', 'success');
+    resetForm();
+  };
+
+  const bindEvents = () => {
+    if (elements.companySelect) {
+      elements.companySelect.addEventListener('change', handleCompanyChange);
+    }
+
+    const radios = Array.from(document.querySelectorAll(selectors.typeRadios));
+    radios.forEach((radio) => radio.addEventListener('change', handleTypeChange));
+
+    elements.avistaDays?.addEventListener('input', () => {
+      updateAvistaPreview();
+      updateOverview();
+    });
+    elements.avistaDiscount?.addEventListener('input', () => {
+      updateAvistaPreview();
+      updateOverview();
+    });
+
+    elements.debitoDays?.addEventListener('input', () => {
+      updateDebitoPreview();
+      updateOverview();
+    });
+    elements.debitoDiscount?.addEventListener('input', () => {
+      updateDebitoPreview();
+      updateOverview();
+    });
+
+    elements.creditoInstallments?.addEventListener('input', () => {
+      updateCreditoPreview();
+      updateOverview();
+    });
+    elements.creditoDays?.addEventListener('input', () => {
+      updateCreditoPreview();
+      updateOverview();
+    });
+    elements.creditoDiscount?.addEventListener('input', () => {
+      updateCreditoPreview();
+      updateOverview();
+    });
+
+    elements.resetButton?.addEventListener('click', (event) => {
+      event.preventDefault();
+      resetForm();
+    });
+
+    elements.form?.addEventListener('submit', handleSubmit);
+  };
+
+  const initialize = () => {
+    Object.entries(selectors).forEach(([key, selector]) => {
+      if (key === 'typeRadios') return;
+      elements[key] = document.querySelector(selector);
+    });
+
+    updateCodeField();
+    toggleSections();
+    updateAvistaPreview();
+    updateDebitoPreview();
+    updateCreditoPreview();
+    updateOverview();
+    renderMethods();
+    bindEvents();
+    fetchCompanies();
+  };
+
+  document.addEventListener('DOMContentLoaded', initialize);
+})();


### PR DESCRIPTION
## Summary
- add nested Financeiro > Pagamentos menu entry pointing to the new payment methods screen
- create the admin payment methods page with company selection, type controls and preview sections
- implement the corresponding script to load companies, manage previews and keep a local list of created payment methods

## Testing
- Not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d6dce88b3083239dd2d37626371d09