### PR TITLE
feat: compact PDV workspace with customer modal

### DIFF
--- a/pages/admin/admin-pdv.html
+++ b/pages/admin/admin-pdv.html
@@ -73,11 +73,11 @@
                             <button type="button" class="pdv-tab-trigger px-3 py-2 text-sm font-semibold border-b-2 border-primary text-primary rounded-t" data-tab-target="caixa-tab">Caixa</button>
                         </nav>
 
-                        <div class="space-y-6">
-                            <div data-tab-panel="pdv-tab" class="hidden space-y-6">
-                                <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
-                                    <div class="xl:col-span-2 space-y-6">
-                                        <div class="rounded-xl border border-gray-200 p-6 space-y-4">
+                        <div class="space-y-5">
+                            <div data-tab-panel="pdv-tab" class="hidden space-y-5">
+                                <div class="grid grid-cols-1 xl:grid-cols-3 gap-4 xl:gap-5">
+                                    <div class="xl:col-span-2 space-y-5">
+                                        <div class="rounded-xl border border-gray-200 p-5 space-y-5">
                                             <div>
                                                 <label for="pdv-product-search" class="block text-sm font-semibold text-gray-700 mb-1">Pesquisar produtos</label>
                                                 <div class="relative">
@@ -100,10 +100,11 @@
                                                         <span id="pdv-selected-original-price" class="hidden text-xs text-gray-500 line-through">R$ 0,00</span>
                                                         <span id="pdv-selected-promo" class="hidden rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">Promoção ativa</span>
                                                     </div>
+                                                    <p id="pdv-selected-general-warning" class="hidden text-[11px] font-medium text-amber-600">Vincule um cliente para aplicar a promoção geral deste item.</p>
                                                 </div>
                                             </div>
 
-                                            <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                                            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
                                                 <div>
                                                     <span class="block text-sm font-medium text-gray-700">Valor do item</span>
                                                     <p id="pdv-item-value" class="text-lg font-semibold text-gray-800">R$ 0,00</p>
@@ -138,11 +139,33 @@
                                         </div>
                                     </div>
 
-                                    <aside class="space-y-4">
-                                            <div class="rounded-xl border border-gray-200 bg-gray-50 p-6 space-y-4">
-                                                <div class="flex items-center justify-between">
+                                    <aside class="space-y-5">
+                                            <div class="rounded-xl border border-gray-200 bg-gray-50 p-5 space-y-5">
+                                                <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                                                     <h3 class="text-base font-semibold text-gray-800">Itens da venda</h3>
-                                                    <span id="pdv-items-count" class="text-xs font-semibold text-gray-500">0 itens</span>
+                                                    <div class="flex items-center gap-3">
+                                                        <span id="pdv-items-count" class="text-xs font-semibold text-gray-500">0 itens</span>
+                                                        <button id="pdv-open-customer" type="button" class="inline-flex items-center gap-2 rounded-lg border border-primary px-3 py-1.5 text-xs font-semibold text-primary transition hover:bg-primary/5">
+                                                            <i class="fas fa-user-plus text-[11px]"></i>
+                                                            <span id="pdv-open-customer-label">Adicionar cliente</span>
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                                <div class="space-y-3">
+                                                    <div id="pdv-customer-summary-empty" class="rounded-lg border border-dashed border-gray-300 bg-white px-4 py-3 text-xs text-gray-500">
+                                                        Vincule um cliente para aplicar promoções gerais e registrar o responsável pela compra.
+                                                    </div>
+                                                    <div id="pdv-customer-summary-info" class="hidden rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-700">
+                                                        <div class="flex items-start justify-between gap-3">
+                                                            <div class="space-y-1">
+                                                                <p id="pdv-customer-name" class="text-sm font-semibold text-gray-800">—</p>
+                                                                <p id="pdv-customer-doc" class="text-xs text-gray-500">Documento: —</p>
+                                                                <p id="pdv-customer-contact" class="text-xs text-gray-500">Contato: —</p>
+                                                                <p id="pdv-customer-pet" class="hidden text-xs text-gray-500">Pet: —</p>
+                                                            </div>
+                                                            <button type="button" id="pdv-customer-remove" class="text-xs font-semibold text-red-500 transition hover:text-red-600">Remover</button>
+                                                        </div>
+                                                    </div>
                                                 </div>
                                                 <div id="pdv-items-empty" class="rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-center text-sm text-gray-500">Nenhum item adicionado até o momento.</div>
                                                 <ul id="pdv-items-list" class="hidden divide-y divide-gray-200"></ul>
@@ -160,10 +183,10 @@
                                     </div>
                                 </div>
 
-                            <div data-tab-panel="caixa-tab" class="space-y-6">
-                                <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
-                                    <div class="space-y-6">
-                                        <div class="rounded-xl border border-gray-200 p-6 space-y-4">
+                            <div data-tab-panel="caixa-tab" class="space-y-5">
+                                <div class="grid grid-cols-1 xl:grid-cols-2 gap-4 xl:gap-5">
+                                    <div class="space-y-5">
+                                        <div class="rounded-xl border border-gray-200 p-5 space-y-4">
                                             <div class="flex items-center justify-between">
                                                 <h3 class="text-base font-semibold text-gray-800">Situação do caixa</h3>
                                                 <span id="pdv-caixa-state-label" class="text-xs font-semibold text-gray-500">Caixa fechado</span>
@@ -197,7 +220,7 @@
                                             </div>
                                         </div>
 
-                                        <div class="rounded-xl border border-gray-200 p-6 space-y-4">
+                                        <div class="rounded-xl border border-gray-200 p-5 space-y-4">
                                             <div class="flex items-center justify-between">
                                                 <h3 class="text-base font-semibold text-gray-800">Meios de pagamento</h3>
                                                 <button id="pdv-reset-payments" type="button" class="text-xs font-semibold text-primary hover:underline">Zerar valores</button>
@@ -241,6 +264,54 @@
     <div id="admin-footer-placeholder"></div>
     <div id="modal-placeholder"></div>
     <div id="confirm-modal-placeholder"></div>
+
+    <div id="pdv-customer-modal" class="fixed inset-0 z-[55] hidden">
+        <div class="absolute inset-0 bg-slate-900/60" data-pdv-customer-dismiss="backdrop"></div>
+        <div class="relative mx-auto mt-16 w-full max-w-3xl overflow-hidden rounded-2xl bg-white shadow-2xl">
+            <div class="flex items-center justify-between border-b border-gray-200 px-6 py-4">
+                <div>
+                    <h2 class="text-lg font-semibold text-gray-800">Selecionar cliente</h2>
+                    <p class="text-sm text-gray-500">Localize o cliente e, se desejar, associe um pet à venda.</p>
+                </div>
+                <button type="button" id="pdv-customer-close" class="rounded-full p-2 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600" aria-label="Fechar modal de clientes">
+                    <i class="fas fa-times"></i>
+                </button>
+            </div>
+            <div class="px-6 pt-4">
+                <div class="flex flex-wrap gap-2 border-b border-gray-200 pb-3" role="tablist">
+                    <button type="button" class="rounded-lg border border-primary px-3 py-1.5 text-sm font-semibold text-primary" data-pdv-customer-tab="cliente" aria-selected="true">Cliente</button>
+                    <button type="button" class="rounded-lg border border-transparent px-3 py-1.5 text-sm font-semibold text-gray-500" data-pdv-customer-tab="pet" aria-selected="false">Pet</button>
+                </div>
+            </div>
+            <div class="space-y-6 px-6 py-5">
+                <div data-pdv-customer-panel="cliente" class="space-y-5">
+                    <div class="space-y-2">
+                        <label for="pdv-customer-search" class="block text-sm font-semibold text-gray-700">Buscar cliente</label>
+                        <input id="pdv-customer-search" type="search" placeholder="CPF, CNPJ, e-mail, celular ou telefone" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" autocomplete="off">
+                        <p class="text-xs text-gray-500">Digite o nome ou documento do cliente para realizar a busca.</p>
+                    </div>
+                    <div class="space-y-2">
+                        <div id="pdv-customer-results-loading" class="hidden rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-500">Buscando clientes...</div>
+                        <div id="pdv-customer-results-empty" class="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-500">Digite para buscar clientes.</div>
+                        <div id="pdv-customer-results" class="space-y-2"></div>
+                    </div>
+                </div>
+                <div data-pdv-customer-panel="pet" class="hidden space-y-4">
+                    <p class="text-sm text-gray-600">Selecione um cliente para visualizar os pets vinculados.</p>
+                    <div id="pdv-customer-pets-loading" class="hidden rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-500">Carregando pets do cliente...</div>
+                    <div id="pdv-customer-pets-empty" class="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-500">Nenhum pet disponível.</div>
+                    <div id="pdv-customer-pets" class="space-y-2"></div>
+                </div>
+            </div>
+            <div class="flex flex-col gap-3 border-t border-gray-200 bg-gray-50 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+                <button type="button" id="pdv-customer-clear" class="rounded-lg border border-gray-200 px-4 py-2 text-sm font-semibold text-gray-600 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60">Limpar seleção</button>
+                <div class="flex items-center gap-2">
+                    <button type="button" id="pdv-customer-cancel" class="rounded-lg border border-gray-200 px-4 py-2 text-sm font-semibold text-gray-600 transition hover:bg-gray-100">Cancelar</button>
+                    <button type="button" id="pdv-customer-confirm" class="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-60">Vincular cliente</button>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <div id="pdv-finalize-modal" class="fixed inset-0 z-50 hidden">
         <div class="absolute inset-0 bg-slate-900/60" data-pdv-finalize-dismiss="backdrop"></div>

--- a/pages/admin/admin-pdv.html
+++ b/pages/admin/admin-pdv.html
@@ -87,11 +87,6 @@
                                                     </div>
                                                     <p class="text-xs text-gray-500 mt-1">Os resultados são atualizados conforme a digitação, seguindo o mesmo critério de busca do site.</p>
                                                 </div>
-                                                <div>
-                                                    <label for="pdv-barcode-input" class="block text-sm font-semibold text-gray-700 mb-1">Adicionar por código de barras</label>
-                                                    <input id="pdv-barcode-input" type="text" inputmode="numeric" placeholder="Escaneie ou digite o código e pressione Enter" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" autocomplete="off">
-                                                    <p class="text-xs text-gray-500 mt-1">Pressione Enter para incluir o item automaticamente na venda.</p>
-                                                </div>
                                             </div>
 
                                             <div id="pdv-selected-preview" class="rounded-lg border border-gray-200 bg-gray-50 p-4 flex gap-4">

--- a/pages/admin/admin-pdv.html
+++ b/pages/admin/admin-pdv.html
@@ -78,13 +78,20 @@
                                 <div class="grid grid-cols-1 xl:grid-cols-3 gap-4 xl:gap-5">
                                     <div class="xl:col-span-2 space-y-5">
                                         <div class="rounded-xl border border-gray-200 p-5 space-y-5">
-                                            <div>
-                                                <label for="pdv-product-search" class="block text-sm font-semibold text-gray-700 mb-1">Pesquisar produtos</label>
-                                                <div class="relative">
-                                                    <input id="pdv-product-search" type="search" placeholder="Busque por código interno, código de barras ou nome" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" autocomplete="off">
-                                                    <div id="pdv-product-results" class="absolute left-0 right-0 top-full z-20 mt-2 hidden overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg"></div>
+                                            <div class="space-y-4">
+                                                <div>
+                                                    <label for="pdv-product-search" class="block text-sm font-semibold text-gray-700 mb-1">Pesquisar produtos</label>
+                                                    <div class="relative">
+                                                        <input id="pdv-product-search" type="search" placeholder="Busque por código interno, código de barras ou nome" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" autocomplete="off">
+                                                        <div id="pdv-product-results" class="absolute left-0 right-0 top-full z-20 mt-2 hidden overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg"></div>
+                                                    </div>
+                                                    <p class="text-xs text-gray-500 mt-1">Os resultados são atualizados conforme a digitação, seguindo o mesmo critério de busca do site.</p>
                                                 </div>
-                                                <p class="text-xs text-gray-500 mt-1">Os resultados são atualizados conforme a digitação, seguindo o mesmo critério de busca do site.</p>
+                                                <div>
+                                                    <label for="pdv-barcode-input" class="block text-sm font-semibold text-gray-700 mb-1">Adicionar por código de barras</label>
+                                                    <input id="pdv-barcode-input" type="text" inputmode="numeric" placeholder="Escaneie ou digite o código e pressione Enter" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" autocomplete="off">
+                                                    <p class="text-xs text-gray-500 mt-1">Pressione Enter para incluir o item automaticamente na venda.</p>
+                                                </div>
                                             </div>
 
                                             <div id="pdv-selected-preview" class="rounded-lg border border-gray-200 bg-gray-50 p-4 flex gap-4">

--- a/scripts/admin/admin-pdv.js
+++ b/scripts/admin/admin-pdv.js
@@ -81,6 +81,8 @@
     selectedProduct: null,
     quantidade: 1,
     itens: [],
+    vendaCliente: null,
+    vendaPet: null,
     paymentMethods: [],
     paymentMethodsLoading: false,
     pendingPagamentosData: null,
@@ -88,6 +90,14 @@
     vendaPagamentos: [],
     vendaDesconto: 0,
     vendaAcrescimo: 0,
+    customerSearchResults: [],
+    customerSearchLoading: false,
+    customerSearchQuery: '',
+    customerPets: [],
+    customerPetsLoading: false,
+    modalSelectedCliente: null,
+    modalSelectedPet: null,
+    modalActiveTab: 'cliente',
     summary: { abertura: 0, recebido: 0, saldo: 0 },
     caixaInfo: {
       aberturaData: null,
@@ -103,7 +113,11 @@
   };
 
   const elements = {};
+  const customerPetsCache = new Map();
   let searchTimeout = null;
+  let customerSearchTimeout = null;
+  let customerSearchController = null;
+  let customerPetsController = null;
   let paymentModalState = null;
 
   const createUid = () => `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
@@ -144,6 +158,40 @@
   const safeNumber = (value) => {
     const number = Number(value);
     return Number.isFinite(number) ? number : 0;
+  };
+
+  const canApplyGeneralPromotion = () => Boolean(state.vendaCliente);
+
+  const hasGeneralPromotion = (product) =>
+    Boolean(product?.promocao?.ativa && safeNumber(product.promocao.porcentagem) > 0);
+
+  const buildProductSnapshot = (product) => {
+    if (!product || typeof product !== 'object') return {};
+    return {
+      _id: product._id || product.id || '',
+      nome: product.nome || product.descricao || '',
+      codigoInterno: product.codigoInterno || product.codInterno || '',
+      codigo:
+        product.codigo ||
+        product.codigoReferencia ||
+        product.sku ||
+        product.codigoInterno ||
+        product.codInterno ||
+        '',
+      codigoBarras:
+        product.codigoBarras ||
+        product.codigoDeBarras ||
+        product.barras ||
+        product.ean ||
+        '',
+      promocao: product.promocao ? { ...product.promocao } : null,
+      precoClube: product.precoClube || null,
+      venda: product.venda,
+      precoVenda: product.precoVenda,
+      preco: product.preco,
+      valor: product.valor,
+      price: product.price,
+    };
   };
 
   const parseDateValue = (value) => {
@@ -456,7 +504,10 @@
   const getFinalPrice = (product) => {
     const base = getBasePrice(product);
     if (!product) return base;
-    if (product?.promocao?.ativa && safeNumber(product.promocao.porcentagem) > 0) {
+    if (hasGeneralPromotion(product)) {
+      if (!canApplyGeneralPromotion()) {
+        return base;
+      }
       const desconto = base * (safeNumber(product.promocao.porcentagem) / 100);
       return Math.max(base - desconto, 0);
     }
@@ -491,6 +542,7 @@
     elements.selectedPrice = document.getElementById('pdv-selected-price');
     elements.selectedOriginalPrice = document.getElementById('pdv-selected-original-price');
     elements.selectedPromoBadge = document.getElementById('pdv-selected-promo');
+    elements.selectedGeneralWarning = document.getElementById('pdv-selected-general-warning');
 
     elements.itemValue = document.getElementById('pdv-item-value');
     elements.itemQuantity = document.getElementById('pdv-item-quantity');
@@ -503,6 +555,35 @@
     elements.itemsCount = document.getElementById('pdv-items-count');
     elements.itemsTotal = document.getElementById('pdv-items-total');
     elements.finalizeButton = document.getElementById('pdv-finalize-sale');
+
+    elements.customerOpenButton = document.getElementById('pdv-open-customer');
+    elements.customerOpenButtonLabel = document.getElementById('pdv-open-customer-label');
+    elements.customerSummaryEmpty = document.getElementById('pdv-customer-summary-empty');
+    elements.customerSummaryInfo = document.getElementById('pdv-customer-summary-info');
+    elements.customerName = document.getElementById('pdv-customer-name');
+    elements.customerDoc = document.getElementById('pdv-customer-doc');
+    elements.customerContact = document.getElementById('pdv-customer-contact');
+    elements.customerPet = document.getElementById('pdv-customer-pet');
+    elements.customerRemove = document.getElementById('pdv-customer-remove');
+
+    elements.customerModal = document.getElementById('pdv-customer-modal');
+    elements.customerModalClose = document.getElementById('pdv-customer-close');
+    elements.customerModalBackdrop =
+      elements.customerModal?.querySelector('[data-pdv-customer-dismiss]') || null;
+    elements.customerTabButtons =
+      elements.customerModal?.querySelectorAll('[data-pdv-customer-tab]') || [];
+    elements.customerModalPanels =
+      elements.customerModal?.querySelectorAll('[data-pdv-customer-panel]') || [];
+    elements.customerSearchInput = document.getElementById('pdv-customer-search');
+    elements.customerResultsList = document.getElementById('pdv-customer-results');
+    elements.customerResultsEmpty = document.getElementById('pdv-customer-results-empty');
+    elements.customerResultsLoading = document.getElementById('pdv-customer-results-loading');
+    elements.customerPetsList = document.getElementById('pdv-customer-pets');
+    elements.customerPetsEmpty = document.getElementById('pdv-customer-pets-empty');
+    elements.customerPetsLoading = document.getElementById('pdv-customer-pets-loading');
+    elements.customerConfirm = document.getElementById('pdv-customer-confirm');
+    elements.customerClear = document.getElementById('pdv-customer-clear');
+    elements.customerCancel = document.getElementById('pdv-customer-cancel');
 
     elements.caixaActions = document.getElementById('pdv-caixa-actions');
     elements.caixaStateLabel = document.getElementById('pdv-caixa-state-label');
@@ -657,6 +738,9 @@
     if (elements.selectedPromoBadge) {
       elements.selectedPromoBadge.classList.add('hidden');
     }
+    if (elements.selectedGeneralWarning) {
+      elements.selectedGeneralWarning.classList.add('hidden');
+    }
     if (elements.itemQuantity) {
       elements.itemQuantity.value = 1;
     }
@@ -683,6 +767,8 @@
     const barcode = getProductBarcode(product);
     const basePrice = getBasePrice(product);
     const finalPrice = getFinalPrice(product);
+    const generalPromo = hasGeneralPromotion(product);
+    const showGeneralWarning = generalPromo && !canApplyGeneralPromotion();
     if (elements.selectedName) {
       elements.selectedName.textContent = name;
     }
@@ -704,7 +790,15 @@
       }
     }
     if (elements.selectedPromoBadge) {
+      if (generalPromo) {
+        elements.selectedPromoBadge.textContent = 'Promoção geral';
+      } else {
+        elements.selectedPromoBadge.textContent = 'Promoção ativa';
+      }
       elements.selectedPromoBadge.classList.toggle('hidden', !(finalPrice < basePrice));
+    }
+    if (elements.selectedGeneralWarning) {
+      elements.selectedGeneralWarning.classList.toggle('hidden', !showGeneralWarning);
     }
     if (elements.itemQuantity) {
       elements.itemQuantity.value = state.quantidade;
@@ -725,6 +819,501 @@
     }
   };
 
+  const updateSaleCustomerSummary = () => {
+    if (elements.customerOpenButtonLabel) {
+      elements.customerOpenButtonLabel.textContent = state.vendaCliente
+        ? 'Trocar cliente'
+        : 'Adicionar cliente';
+    }
+    const hasCustomer = Boolean(state.vendaCliente);
+    if (elements.customerSummaryEmpty) {
+      elements.customerSummaryEmpty.classList.toggle('hidden', hasCustomer);
+    }
+    if (elements.customerSummaryInfo) {
+      elements.customerSummaryInfo.classList.toggle('hidden', !hasCustomer);
+    }
+    if (!hasCustomer) {
+      if (elements.customerPet) {
+        elements.customerPet.classList.add('hidden');
+      }
+      return;
+    }
+    const cliente = state.vendaCliente;
+    if (elements.customerName) {
+      elements.customerName.textContent = cliente.nome || 'Cliente sem nome';
+    }
+    if (elements.customerDoc) {
+      const doc = cliente.doc || cliente.cpf || cliente.cnpj || cliente.inscricaoEstadual || '';
+      elements.customerDoc.textContent = doc ? `Documento: ${doc}` : 'Documento não informado';
+    }
+    if (elements.customerContact) {
+      const contacts = [cliente.email, cliente.celular].filter(Boolean);
+      elements.customerContact.textContent = contacts.length
+        ? `Contato: ${contacts.join(' • ')}`
+        : 'Contato não informado';
+    }
+    if (elements.customerPet) {
+      if (state.vendaPet) {
+        const details = [state.vendaPet.tipo, state.vendaPet.raca].filter(Boolean).join(' • ');
+        const detailText = details ? ` (${details})` : '';
+        elements.customerPet.textContent = `Pet: ${state.vendaPet.nome || 'Pet sem nome'}${detailText}`;
+        elements.customerPet.classList.remove('hidden');
+      } else {
+        elements.customerPet.classList.add('hidden');
+      }
+    }
+  };
+
+  const recalculateItemsForCustomerChange = () => {
+    if (!state.itens.length) {
+      updateFinalizeButton();
+      updateSaleSummary();
+      return;
+    }
+    state.itens = state.itens.map((item) => {
+      if (!item.productSnapshot) {
+        return {
+          ...item,
+          generalPromo: Boolean(item.generalPromo && state.vendaCliente),
+        };
+      }
+      const snapshot = item.productSnapshot;
+      const valor = getFinalPrice(snapshot);
+      return {
+        ...item,
+        valor,
+        subtotal: valor * item.quantidade,
+        generalPromo: hasGeneralPromotion(snapshot),
+        codigoInterno:
+          item.codigoInterno ||
+          snapshot.codigoInterno ||
+          snapshot.codigo ||
+          item.codigo ||
+          '',
+        codigoBarras: item.codigoBarras || snapshot.codigoBarras || '',
+        productSnapshot: snapshot,
+      };
+    });
+    renderItemsList();
+  };
+
+  const setSaleCustomer = (cliente, pet = null) => {
+    state.vendaCliente = cliente ? { ...cliente } : null;
+    state.vendaPet = cliente && pet ? { ...pet } : null;
+    if (!cliente) {
+      state.vendaPet = null;
+    }
+    updateSaleCustomerSummary();
+    recalculateItemsForCustomerChange();
+    if (state.selectedProduct) {
+      updateSelectedProductView();
+    }
+    if (
+      elements.searchResults &&
+      !elements.searchResults.classList.contains('hidden') &&
+      state.searchResults.length &&
+      elements.searchInput &&
+      elements.searchInput.value.trim()
+    ) {
+      renderSearchResults(state.searchResults, elements.searchInput.value.trim());
+    }
+  };
+
+  const updateCustomerModalTabs = () => {
+    const buttons = Array.from(elements.customerTabButtons || []);
+    const panels = Array.from(elements.customerModalPanels || []);
+    buttons.forEach((button) => {
+      const tab = button.getAttribute('data-pdv-customer-tab');
+      const isActive = tab === state.modalActiveTab;
+      const isPetTab = tab === 'pet';
+      const disabled = isPetTab && !state.modalSelectedCliente;
+      button.classList.toggle('text-primary', isActive);
+      button.classList.toggle('border-primary', isActive);
+      button.classList.toggle('text-gray-500', !isActive);
+      button.classList.toggle('border-transparent', !isActive);
+      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      button.disabled = disabled;
+      button.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+      button.classList.toggle('opacity-60', disabled);
+      button.classList.toggle('cursor-not-allowed', disabled);
+    });
+    panels.forEach((panel) => {
+      const tab = panel.getAttribute('data-pdv-customer-panel');
+      panel.classList.toggle('hidden', tab !== state.modalActiveTab);
+    });
+  };
+
+  const updateCustomerModalActions = () => {
+    const hasSelection = Boolean(state.modalSelectedCliente);
+    if (elements.customerConfirm) {
+      elements.customerConfirm.disabled = !hasSelection;
+      elements.customerConfirm.classList.toggle('opacity-60', !hasSelection);
+      elements.customerConfirm.textContent = state.vendaCliente
+        ? 'Atualizar vínculo'
+        : 'Vincular cliente';
+    }
+    if (elements.customerClear) {
+      elements.customerClear.disabled = !hasSelection;
+      elements.customerClear.classList.toggle('opacity-60', !hasSelection);
+    }
+  };
+
+  const renderCustomerSearchResults = () => {
+    if (!elements.customerResultsList || !elements.customerResultsEmpty || !elements.customerResultsLoading) {
+      return;
+    }
+    elements.customerResultsList.innerHTML = '';
+    if (state.customerSearchLoading) {
+      elements.customerResultsLoading.classList.remove('hidden');
+      elements.customerResultsEmpty.classList.add('hidden');
+      return;
+    }
+    elements.customerResultsLoading.classList.add('hidden');
+    const query = state.customerSearchQuery.trim();
+    if (!query) {
+      elements.customerResultsEmpty.textContent = 'Digite para buscar clientes.';
+      elements.customerResultsEmpty.classList.remove('hidden');
+      return;
+    }
+    if (!state.customerSearchResults.length) {
+      elements.customerResultsEmpty.textContent = 'Nenhum cliente encontrado para a busca informada.';
+      elements.customerResultsEmpty.classList.remove('hidden');
+      return;
+    }
+    elements.customerResultsEmpty.classList.add('hidden');
+    const fragment = document.createDocumentFragment();
+    state.customerSearchResults.forEach((cliente) => {
+      const isSelected = Boolean(state.modalSelectedCliente && state.modalSelectedCliente._id === cliente._id);
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.setAttribute('data-customer-id', cliente._id);
+      button.className = [
+        'w-full text-left rounded-lg border px-4 py-3 transition flex flex-col gap-1',
+        isSelected
+          ? 'border-primary bg-primary/5 text-primary'
+          : 'border-gray-200 text-gray-700 hover:border-primary hover:bg-primary/5',
+      ].join(' ');
+      const documento = cliente.doc || cliente.cpf || cliente.cnpj || '';
+      const contato = [cliente.email, cliente.celular].filter(Boolean).join(' • ');
+      button.innerHTML = `
+        <span class="text-sm font-semibold">${cliente.nome || 'Cliente sem nome'}</span>
+        <span class="text-xs text-gray-500">${documento ? `Documento: ${documento}` : 'Documento não informado'}</span>
+        <span class="text-xs text-gray-500">${contato || 'Contato não informado'}</span>
+      `;
+      fragment.appendChild(button);
+    });
+    elements.customerResultsList.appendChild(fragment);
+  };
+
+  const renderCustomerPets = () => {
+    if (!elements.customerPetsList || !elements.customerPetsEmpty || !elements.customerPetsLoading) {
+      return;
+    }
+    elements.customerPetsList.innerHTML = '';
+    if (!state.modalSelectedCliente) {
+      elements.customerPetsLoading.classList.add('hidden');
+      elements.customerPetsEmpty.textContent = 'Selecione um cliente para visualizar os pets vinculados.';
+      elements.customerPetsEmpty.classList.remove('hidden');
+      return;
+    }
+    if (state.customerPetsLoading) {
+      elements.customerPetsLoading.classList.remove('hidden');
+      elements.customerPetsEmpty.classList.add('hidden');
+      return;
+    }
+    elements.customerPetsLoading.classList.add('hidden');
+    if (!state.customerPets.length) {
+      elements.customerPetsEmpty.textContent = 'Nenhum pet cadastrado para este cliente.';
+      elements.customerPetsEmpty.classList.remove('hidden');
+      return;
+    }
+    elements.customerPetsEmpty.classList.add('hidden');
+    const fragment = document.createDocumentFragment();
+    state.customerPets.forEach((pet) => {
+      const isSelected = Boolean(state.modalSelectedPet && state.modalSelectedPet._id === pet._id);
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.setAttribute('data-pet-id', pet._id);
+      button.className = [
+        'w-full text-left rounded-lg border px-4 py-3 transition flex flex-col gap-1',
+        isSelected
+          ? 'border-primary bg-primary/5 text-primary'
+          : 'border-gray-200 text-gray-700 hover:border-primary hover:bg-primary/5',
+      ].join(' ');
+      const details = [pet.tipo, pet.raca].filter(Boolean).join(' • ');
+      button.innerHTML = `
+        <span class="text-sm font-semibold">${pet.nome || 'Pet sem nome'}</span>
+        <span class="text-xs text-gray-500">${details || 'Detalhes não informados'}</span>
+      `;
+      fragment.appendChild(button);
+    });
+    elements.customerPetsList.appendChild(fragment);
+  };
+
+  const performCustomerSearch = async (term) => {
+    const query = term.trim();
+    state.customerSearchQuery = term;
+    if (customerSearchController) {
+      customerSearchController.abort();
+      customerSearchController = null;
+    }
+    if (!query) {
+      state.customerSearchResults = [];
+      state.customerSearchLoading = false;
+      renderCustomerSearchResults();
+      return;
+    }
+    const token = getToken();
+    const headers = token ? { Authorization: `Bearer ${token}` } : {};
+    state.customerSearchLoading = true;
+    renderCustomerSearchResults();
+    customerSearchController = new AbortController();
+    try {
+      const response = await fetch(
+        `${API_BASE}/func/clientes/buscar?q=${encodeURIComponent(query)}&limit=8`,
+        { headers, signal: customerSearchController.signal }
+      );
+      if (!response.ok) {
+        throw new Error('Não foi possível buscar clientes.');
+      }
+      const payload = await response.json();
+      state.customerSearchResults = Array.isArray(payload) ? payload : [];
+    } catch (error) {
+      if (error.name === 'AbortError') return;
+      console.error('Erro ao buscar clientes:', error);
+      notify(error.message || 'Não foi possível buscar clientes.', 'error');
+      state.customerSearchResults = [];
+    } finally {
+      state.customerSearchLoading = false;
+      customerSearchController = null;
+      renderCustomerSearchResults();
+    }
+  };
+
+  const fetchCustomerPets = async (clienteId) => {
+    if (!clienteId) return;
+    const cached = customerPetsCache.get(clienteId);
+    if (cached) {
+      state.customerPets = cached;
+      state.customerPetsLoading = false;
+      renderCustomerPets();
+      updateCustomerModalActions();
+      return;
+    }
+    const token = getToken();
+    const headers = token ? { Authorization: `Bearer ${token}` } : {};
+    state.customerPetsLoading = true;
+    renderCustomerPets();
+    if (customerPetsController) {
+      customerPetsController.abort();
+    }
+    customerPetsController = new AbortController();
+    try {
+      const response = await fetch(`${API_BASE}/func/clientes/${clienteId}/pets`, {
+        headers,
+        signal: customerPetsController.signal,
+      });
+      if (!response.ok) {
+        throw new Error('Não foi possível carregar os pets do cliente.');
+      }
+      const payload = await response.json();
+      const pets = Array.isArray(payload) ? payload : [];
+      customerPetsCache.set(clienteId, pets);
+      if (state.modalSelectedCliente && state.modalSelectedCliente._id === clienteId) {
+        state.customerPets = pets;
+      }
+    } catch (error) {
+      if (error.name === 'AbortError') return;
+      console.error('Erro ao carregar pets do cliente:', error);
+      notify(error.message || 'Não foi possível carregar os pets do cliente selecionado.', 'error');
+      if (state.modalSelectedCliente && state.modalSelectedCliente._id === clienteId) {
+        state.customerPets = [];
+      }
+    } finally {
+      if (state.modalSelectedCliente && state.modalSelectedCliente._id === clienteId) {
+        state.customerPetsLoading = false;
+        renderCustomerPets();
+        updateCustomerModalActions();
+      }
+      customerPetsController = null;
+    }
+  };
+
+  const setModalSelectedCliente = (cliente) => {
+    state.modalSelectedCliente = cliente ? { ...cliente } : null;
+    state.modalSelectedPet = null;
+    if (state.modalSelectedCliente && state.modalSelectedCliente._id) {
+      const cached = customerPetsCache.get(state.modalSelectedCliente._id);
+      if (cached) {
+        state.customerPets = cached;
+        state.customerPetsLoading = false;
+      } else {
+        state.customerPets = [];
+        state.customerPetsLoading = true;
+        fetchCustomerPets(state.modalSelectedCliente._id);
+      }
+    } else {
+      state.customerPets = [];
+      state.customerPetsLoading = false;
+    }
+    renderCustomerSearchResults();
+    renderCustomerPets();
+    updateCustomerModalTabs();
+    updateCustomerModalActions();
+  };
+
+  const openCustomerModal = () => {
+    if (!elements.customerModal) return;
+    state.modalActiveTab = 'cliente';
+    state.customerSearchQuery = '';
+    state.customerSearchResults = [];
+    state.customerSearchLoading = false;
+    state.customerPetsLoading = false;
+    if (elements.customerSearchInput) {
+      elements.customerSearchInput.value = '';
+    }
+    setModalSelectedCliente(state.vendaCliente ? { ...state.vendaCliente } : null);
+    if (
+      state.vendaPet &&
+      state.modalSelectedCliente &&
+      state.modalSelectedCliente._id &&
+      state.vendaCliente &&
+      state.vendaCliente._id === state.modalSelectedCliente._id
+    ) {
+      state.modalSelectedPet = { ...state.vendaPet };
+      renderCustomerPets();
+      updateCustomerModalActions();
+    }
+    elements.customerModal.classList.remove('hidden');
+    document.body.classList.add('overflow-hidden');
+    updateCustomerModalTabs();
+    renderCustomerSearchResults();
+    renderCustomerPets();
+    updateCustomerModalActions();
+    setTimeout(() => {
+      elements.customerSearchInput?.focus();
+    }, 150);
+  };
+
+  const closeCustomerModal = () => {
+    if (!elements.customerModal) return;
+    elements.customerModal.classList.add('hidden');
+    if (
+      (!elements.finalizeModal || elements.finalizeModal.classList.contains('hidden')) &&
+      (!elements.paymentValueModal || elements.paymentValueModal.classList.contains('hidden'))
+    ) {
+      document.body.classList.remove('overflow-hidden');
+    }
+    if (customerSearchTimeout) {
+      clearTimeout(customerSearchTimeout);
+      customerSearchTimeout = null;
+    }
+    if (customerSearchController) {
+      customerSearchController.abort();
+      customerSearchController = null;
+    }
+    if (customerPetsController) {
+      customerPetsController.abort();
+      customerPetsController = null;
+    }
+    state.customerSearchLoading = false;
+    state.customerPetsLoading = false;
+  };
+
+  const handleCustomerSearchInput = (event) => {
+    const value = event.target.value || '';
+    state.customerSearchQuery = value;
+    if (customerSearchTimeout) {
+      clearTimeout(customerSearchTimeout);
+    }
+    customerSearchTimeout = setTimeout(() => performCustomerSearch(value), 300);
+    if (!value.trim()) {
+      state.customerSearchResults = [];
+      state.customerSearchLoading = false;
+      renderCustomerSearchResults();
+    }
+  };
+
+  const handleCustomerResultsClick = (event) => {
+    const button = event.target.closest('[data-customer-id]');
+    if (!button) return;
+    const id = button.getAttribute('data-customer-id');
+    const cliente = state.customerSearchResults.find((item) => item._id === id);
+    if (!cliente) return;
+    setModalSelectedCliente(cliente);
+  };
+
+  const handleCustomerPetsClick = (event) => {
+    const button = event.target.closest('[data-pet-id]');
+    if (!button) return;
+    const id = button.getAttribute('data-pet-id');
+    const pet = state.customerPets.find((item) => item._id === id);
+    if (!pet) return;
+    if (state.modalSelectedPet && state.modalSelectedPet._id === id) {
+      state.modalSelectedPet = null;
+    } else {
+      state.modalSelectedPet = { ...pet };
+    }
+    renderCustomerPets();
+    updateCustomerModalActions();
+  };
+
+  const handleCustomerTabClick = (event) => {
+    const tab = event.currentTarget.getAttribute('data-pdv-customer-tab');
+    if (!tab) return;
+    if (tab === 'pet' && !state.modalSelectedCliente) {
+      event.preventDefault();
+      notify('Selecione um cliente para visualizar os pets.', 'info');
+      return;
+    }
+    state.modalActiveTab = tab;
+    updateCustomerModalTabs();
+    if (tab === 'pet' && state.modalSelectedCliente && state.modalSelectedCliente._id) {
+      if (!customerPetsCache.has(state.modalSelectedCliente._id) && !state.customerPetsLoading) {
+        fetchCustomerPets(state.modalSelectedCliente._id);
+      }
+    }
+  };
+
+  const handleCustomerConfirm = () => {
+    if (!state.modalSelectedCliente) {
+      notify('Selecione um cliente para vincular à venda.', 'warning');
+      return;
+    }
+    setSaleCustomer(state.modalSelectedCliente, state.modalSelectedPet);
+    closeCustomerModal();
+  };
+
+  const handleCustomerClearSelection = () => {
+    state.modalSelectedCliente = null;
+    state.modalSelectedPet = null;
+    state.customerPets = [];
+    state.customerPetsLoading = false;
+    state.customerSearchQuery = '';
+    state.customerSearchResults = [];
+    state.customerSearchLoading = false;
+    state.modalActiveTab = 'cliente';
+    if (elements.customerSearchInput) {
+      elements.customerSearchInput.value = '';
+    }
+    renderCustomerSearchResults();
+    renderCustomerPets();
+    updateCustomerModalTabs();
+    updateCustomerModalActions();
+  };
+
+  const handleCustomerRemove = () => {
+    if (!state.vendaCliente) return;
+    setSaleCustomer(null, null);
+  };
+
+  const handleCustomerModalKeydown = (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeCustomerModal();
+    }
+  };
+
   const renderItemsList = () => {
     if (!elements.itemsList || !elements.itemsEmpty || !elements.itemsCount || !elements.itemsTotal)
       return;
@@ -742,16 +1331,28 @@
     state.itens.forEach((item, index) => {
       const li = document.createElement('li');
       li.dataset.index = String(index);
-      li.className = 'flex items-center gap-3 py-3';
+      li.className = 'flex items-start gap-3 py-3';
+      const codigoInterno = item.codigoInterno || item.codigo || '—';
+      const codigoBarras = item.codigoBarras || '—';
+      const generalNotice = !state.vendaCliente && item.generalPromo
+        ? '<p class="text-[11px] text-amber-600">Vincule um cliente para aplicar a promoção geral.</p>'
+        : '';
       li.innerHTML = `
-        <div class="flex-1 min-w-0">
-          <p class="text-sm font-semibold text-gray-800 truncate">${item.nome}</p>
-          <p class="text-xs text-gray-500">Cód: ${item.codigo || '—'} • Qtde: ${item.quantidade}</p>
+        <div class="flex-1 min-w-0 space-y-1">
+          <p class="text-sm font-semibold text-gray-800 leading-snug">${item.nome}</p>
+          <p class="text-xs text-gray-500 flex flex-wrap gap-x-3 gap-y-1">
+            <span>Cód. Interno: ${codigoInterno}</span>
+            <span>Barras: ${codigoBarras}</span>
+          </p>
+          <p class="text-xs text-gray-500">Qtde: ${item.quantidade} • Valor: ${formatCurrency(item.valor)}</p>
+          ${generalNotice}
         </div>
-        <div class="text-sm font-semibold text-gray-700">${formatCurrency(item.subtotal)}</div>
-        <button type="button" class="text-xs text-red-500 hover:text-red-600" data-remove-index="${index}" aria-label="Remover item">
-          <i class="fas fa-times"></i>
-        </button>
+        <div class="flex flex-col items-end gap-2 text-right">
+          <span class="text-sm font-semibold text-gray-700">${formatCurrency(item.subtotal)}</span>
+          <button type="button" class="text-xs text-red-500 transition hover:text-red-600" data-remove-index="${index}" aria-label="Remover item">
+            <i class="fas fa-times"></i>
+          </button>
+        </div>
       `;
       fragment.appendChild(li);
     });
@@ -1489,6 +2090,8 @@
     state.selectedProduct = null;
     state.quantidade = 1;
     state.itens = [];
+    state.vendaCliente = null;
+    state.vendaPet = null;
     state.summary = { abertura: 0, recebido: 0, saldo: 0 };
     state.caixaInfo = {
       aberturaData: null,
@@ -1505,6 +2108,48 @@
     state.vendaPagamentos = [];
     state.vendaDesconto = 0;
     state.vendaAcrescimo = 0;
+    state.customerSearchResults = [];
+    state.customerSearchLoading = false;
+    state.customerSearchQuery = '';
+    state.customerPets = [];
+    state.customerPetsLoading = false;
+    state.modalSelectedCliente = null;
+    state.modalSelectedPet = null;
+    state.modalActiveTab = 'cliente';
+    if (customerSearchTimeout) {
+      clearTimeout(customerSearchTimeout);
+      customerSearchTimeout = null;
+    }
+    if (customerSearchController) {
+      customerSearchController.abort();
+      customerSearchController = null;
+    }
+    if (customerPetsController) {
+      customerPetsController.abort();
+      customerPetsController = null;
+    }
+    if (elements.customerSearchInput) {
+      elements.customerSearchInput.value = '';
+    }
+    if (elements.customerResultsList) {
+      elements.customerResultsList.innerHTML = '';
+    }
+    if (elements.customerResultsLoading) {
+      elements.customerResultsLoading.classList.add('hidden');
+    }
+    if (elements.customerResultsEmpty) {
+      elements.customerResultsEmpty.textContent = 'Digite para buscar clientes.';
+      elements.customerResultsEmpty.classList.remove('hidden');
+    }
+    if (elements.customerPetsList) {
+      elements.customerPetsList.innerHTML = '';
+    }
+    if (elements.customerPetsLoading) {
+      elements.customerPetsLoading.classList.add('hidden');
+    }
+    if (elements.customerPetsEmpty) {
+      elements.customerPetsEmpty.textContent = 'Nenhum pet disponível.';
+    }
     if (elements.searchInput) {
       elements.searchInput.value = '';
     }
@@ -1513,6 +2158,7 @@
       elements.searchResults.innerHTML = '';
     }
     clearSelectedProduct();
+    updateSaleCustomerSummary();
     renderItemsList();
     renderPayments();
     renderSalePaymentMethods();
@@ -1526,6 +2172,10 @@
     updateStatusBadge();
     updateTabAvailability();
     updateFinalizeButton();
+    updateCustomerModalTabs();
+    updateCustomerModalActions();
+    renderCustomerSearchResults();
+    renderCustomerPets();
     setActiveTab('caixa-tab');
   };
 
@@ -1726,11 +2376,22 @@
       .map((product, index) => {
         const finalPrice = getFinalPrice(product);
         const basePrice = getBasePrice(product);
-        const badge = finalPrice < basePrice ? '<span class="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-semibold text-primary">Promo</span>' : '';
+        const generalPromo = hasGeneralPromotion(product);
+        const showGeneralWarning = generalPromo && !canApplyGeneralPromotion();
+        const badge = finalPrice < basePrice
+          ? '<span class="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-semibold text-primary">Promo</span>'
+          : '';
+        const generalBadge = showGeneralWarning
+          ? '<span class="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-semibold text-amber-700">Cliente necessário</span>'
+          : '';
+        const badges = [badge, generalBadge].filter(Boolean).join('');
         const priceLine = finalPrice < basePrice
           ? `<span class="text-sm font-semibold text-primary">R$ ${toReais(finalPrice)}</span><span class="text-xs text-gray-400 line-through">R$ ${toReais(basePrice)}</span>`
           : `<span class="text-sm font-semibold text-gray-800">R$ ${toReais(finalPrice)}</span>`;
         const image = getImageUrl(product);
+        const extraNotice = showGeneralWarning
+          ? '<span class="block text-[11px] text-amber-600 mt-1">Vincule um cliente para aplicar a promoção geral.</span>'
+          : '';
         return `
           <button type="button" class="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-primary/5" data-result-index="${index}">
             <span class="h-14 w-14 flex items-center justify-center rounded border border-gray-200 bg-white overflow-hidden">
@@ -1740,8 +2401,9 @@
               <span class="block text-sm font-semibold text-gray-800 truncate">${product.nome || 'Produto sem nome'}</span>
               <span class="mt-1 flex flex-wrap items-center gap-2 text-xs text-gray-500">
                 ${priceLine}
-                ${badge}
+                ${badges}
               </span>
+              ${extraNotice}
               <span class="block text-[11px] text-gray-400 mt-1">Cód: ${getProductCode(product) || '—'} • Barras: ${getProductBarcode(product) || '—'}</span>
             </span>
           </button>
@@ -1816,20 +2478,38 @@
     const unitPrice = getFinalPrice(product);
     const subtotal = unitPrice * quantidade;
     const codigo = getProductCode(product);
+    const codigoInterno = product?.codigoInterno || product?.codInterno || codigo;
+    const codigoBarras = getProductBarcode(product);
     const nome = product?.nome || 'Produto sem nome';
-    const existingIndex = state.itens.findIndex((item) => item.id === product._id || item.codigo === codigo);
+    const generalPromo = hasGeneralPromotion(product);
+    const snapshot = buildProductSnapshot(product);
+    const existingIndex = state.itens.findIndex(
+      (item) =>
+        item.id === product._id ||
+        item.codigo === codigo ||
+        (!!codigoInterno && item.codigoInterno === codigoInterno)
+    );
     if (existingIndex >= 0) {
       const current = state.itens[existingIndex];
       current.quantidade += quantidade;
+      current.valor = unitPrice;
       current.subtotal = current.quantidade * current.valor;
+      current.codigoInterno = codigoInterno || current.codigoInterno;
+      current.codigoBarras = codigoBarras || current.codigoBarras;
+      current.generalPromo = generalPromo;
+      current.productSnapshot = snapshot;
     } else {
       state.itens.push({
         id: product._id || product.id || codigo || String(Date.now()),
         codigo,
+        codigoInterno,
+        codigoBarras,
         nome,
         quantidade,
         valor: unitPrice,
         subtotal,
+        generalPromo,
+        productSnapshot: snapshot,
       });
     }
     renderItemsList();
@@ -2228,6 +2908,20 @@
         setActiveTab(target);
       });
     });
+    elements.customerOpenButton?.addEventListener('click', openCustomerModal);
+    elements.customerRemove?.addEventListener('click', handleCustomerRemove);
+    elements.customerModalClose?.addEventListener('click', closeCustomerModal);
+    elements.customerModalBackdrop?.addEventListener('click', closeCustomerModal);
+    elements.customerCancel?.addEventListener('click', closeCustomerModal);
+    elements.customerConfirm?.addEventListener('click', handleCustomerConfirm);
+    elements.customerClear?.addEventListener('click', handleCustomerClearSelection);
+    elements.customerSearchInput?.addEventListener('input', handleCustomerSearchInput);
+    elements.customerResultsList?.addEventListener('click', handleCustomerResultsClick);
+    elements.customerPetsList?.addEventListener('click', handleCustomerPetsClick);
+    Array.from(elements.customerTabButtons || []).forEach((button) => {
+      button.addEventListener('click', handleCustomerTabClick);
+    });
+    elements.customerModal?.addEventListener('keydown', handleCustomerModalKeydown);
   };
 
   const init = async () => {

--- a/src/output.css
+++ b/src/output.css
@@ -57,6 +57,10 @@
     --color-teal-50: oklch(98.4% 0.014 180.72);
     --color-teal-200: oklch(91% 0.096 180.426);
     --color-teal-700: oklch(51.1% 0.096 186.391);
+    --color-cyan-50: oklch(98.4% 0.019 200.873);
+    --color-cyan-100: oklch(95.6% 0.045 203.388);
+    --color-cyan-700: oklch(52% 0.105 223.128);
+    --color-cyan-800: oklch(45% 0.085 224.283);
     --color-sky-50: oklch(97.7% 0.013 236.62);
     --color-sky-100: oklch(95.1% 0.026 236.824);
     --color-sky-200: oklch(90.1% 0.058 230.902);
@@ -81,6 +85,7 @@
     --color-indigo-500: oklch(58.5% 0.233 277.117);
     --color-indigo-600: oklch(51.1% 0.262 276.966);
     --color-indigo-700: oklch(45.7% 0.24 277.023);
+    --color-indigo-800: oklch(39.8% 0.195 277.366);
     --color-rose-50: oklch(96.9% 0.015 12.422);
     --color-rose-100: oklch(94.1% 0.03 12.58);
     --color-rose-200: oklch(89.2% 0.058 10.001);
@@ -99,6 +104,7 @@
     --color-slate-600: oklch(44.6% 0.043 257.281);
     --color-slate-700: oklch(37.2% 0.044 257.287);
     --color-slate-800: oklch(27.9% 0.041 260.031);
+    --color-slate-900: oklch(20.8% 0.042 265.755);
     --color-gray-50: oklch(98.5% 0.002 247.839);
     --color-gray-100: oklch(96.7% 0.003 264.542);
     --color-gray-200: oklch(92.8% 0.006 264.531);
@@ -122,6 +128,7 @@
     --container-2xl: 42rem;
     --container-3xl: 48rem;
     --container-4xl: 56rem;
+    --container-5xl: 64rem;
     --text-xs: 0.75rem;
     --text-xs--line-height: calc(1 / 0.75);
     --text-sm: 0.875rem;
@@ -452,6 +459,9 @@
   .z-50 {
     z-index: 50;
   }
+  .z-\[55\] {
+    z-index: 55;
+  }
   .z-\[60\] {
     z-index: 60;
   }
@@ -550,6 +560,12 @@
   }
   .mt-12 {
     margin-top: calc(var(--spacing) * 12);
+  }
+  .mt-16 {
+    margin-top: calc(var(--spacing) * 16);
+  }
+  .mt-24 {
+    margin-top: calc(var(--spacing) * 24);
   }
   .mt-auto {
     margin-top: auto;
@@ -734,11 +750,17 @@
   .h-\[55px\] {
     height: 55px;
   }
+  .h-\[85vh\] {
+    height: 85vh;
+  }
   .h-\[420px\] {
     height: 420px;
   }
   .h-\[calc\(100\%-20px\)\] {
     height: calc(100% - 20px);
+  }
+  .h-\[calc\(100\%-64px\)\] {
+    height: calc(100% - 64px);
   }
   .h-auto {
     height: auto;
@@ -919,6 +941,9 @@
   }
   .max-w-4xl {
     max-width: var(--container-4xl);
+  }
+  .max-w-5xl {
+    max-width: var(--container-5xl);
   }
   .max-w-\[180px\] {
     max-width: 180px;
@@ -1223,6 +1248,9 @@
   .gap-x-2 {
     column-gap: calc(var(--spacing) * 2);
   }
+  .gap-x-3 {
+    column-gap: calc(var(--spacing) * 3);
+  }
   .gap-x-6 {
     column-gap: calc(var(--spacing) * 6);
   }
@@ -1330,6 +1358,10 @@
   .rounded-xl {
     border-radius: var(--radius-xl);
   }
+  .rounded-t {
+    border-top-left-radius: 0.25rem;
+    border-top-right-radius: 0.25rem;
+  }
   .rounded-t-lg {
     border-top-left-radius: var(--radius-lg);
     border-top-right-radius: var(--radius-lg);
@@ -1427,6 +1459,12 @@
   }
   .border-blue-500 {
     border-color: var(--color-blue-500);
+  }
+  .border-cyan-100 {
+    border-color: var(--color-cyan-100);
+  }
+  .border-emerald-100 {
+    border-color: var(--color-emerald-100);
   }
   .border-emerald-200 {
     border-color: var(--color-emerald-200);
@@ -1569,6 +1607,9 @@
   .bg-blue-500 {
     background-color: var(--color-blue-500);
   }
+  .bg-cyan-50 {
+    background-color: var(--color-cyan-50);
+  }
   .bg-dark {
     background-color: var(--color-dark);
   }
@@ -1710,6 +1751,9 @@
   .bg-rose-600 {
     background-color: var(--color-rose-600);
   }
+  .bg-secondary {
+    background-color: var(--color-secondary);
+  }
   .bg-sky-50 {
     background-color: var(--color-sky-50);
   }
@@ -1731,6 +1775,12 @@
   .bg-slate-700 {
     background-color: var(--color-slate-700);
   }
+  .bg-slate-900\/60 {
+    background-color: color-mix(in srgb, oklch(20.8% 0.042 265.755) 60%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-slate-900) 60%, transparent);
+    }
+  }
   .bg-teal-50 {
     background-color: var(--color-teal-50);
   }
@@ -1739,6 +1789,12 @@
   }
   .bg-white {
     background-color: var(--color-white);
+  }
+  .bg-white\/70 {
+    background-color: color-mix(in srgb, #fff 70%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 70%, transparent);
+    }
   }
   .bg-white\/80 {
     background-color: color-mix(in srgb, #fff 80%, transparent);
@@ -1857,6 +1913,9 @@
   .py-10 {
     padding-block: calc(var(--spacing) * 10);
   }
+  .py-12 {
+    padding-block: calc(var(--spacing) * 12);
+  }
   .py-24 {
     padding-block: calc(var(--spacing) * 24);
   }
@@ -1941,6 +2000,9 @@
   .pl-5 {
     padding-left: calc(var(--spacing) * 5);
   }
+  .pl-9 {
+    padding-left: calc(var(--spacing) * 9);
+  }
   .pl-10 {
     padding-left: calc(var(--spacing) * 10);
   }
@@ -2023,6 +2085,10 @@
   .leading-5 {
     --tw-leading: calc(var(--spacing) * 5);
     line-height: calc(var(--spacing) * 5);
+  }
+  .leading-6 {
+    --tw-leading: calc(var(--spacing) * 6);
+    line-height: calc(var(--spacing) * 6);
   }
   .leading-none {
     --tw-leading: 1;
@@ -2110,6 +2176,12 @@
   .text-blue-800 {
     color: var(--color-blue-800);
   }
+  .text-cyan-700 {
+    color: var(--color-cyan-700);
+  }
+  .text-cyan-800 {
+    color: var(--color-cyan-800);
+  }
   .text-emerald-500 {
     color: var(--color-emerald-500);
   }
@@ -2160,6 +2232,9 @@
   }
   .text-indigo-700 {
     color: var(--color-indigo-700);
+  }
+  .text-indigo-800 {
+    color: var(--color-indigo-800);
   }
   .text-orange-600 {
     color: var(--color-orange-600);
@@ -2366,6 +2441,12 @@
   }
   .ring-orange-100 {
     --tw-ring-color: var(--color-orange-100);
+  }
+  .ring-primary\/30 {
+    --tw-ring-color: color-mix(in srgb, #7A9A55 30%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-ring-color: color-mix(in oklab, var(--color-primary) 30%, transparent);
+    }
   }
   .ring-primary\/60 {
     --tw-ring-color: color-mix(in srgb, #7A9A55 60%, transparent);
@@ -2692,6 +2773,16 @@
       }
     }
   }
+  .hover\:border-primary\/60 {
+    &:hover {
+      @media (hover: hover) {
+        border-color: color-mix(in srgb, #7A9A55 60%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          border-color: color-mix(in oklab, var(--color-primary) 60%, transparent);
+        }
+      }
+    }
+  }
   .hover\:border-red-500 {
     &:hover {
       @media (hover: hover) {
@@ -2976,6 +3067,16 @@
       }
     }
   }
+  .hover\:bg-secondary\/90 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: color-mix(in srgb, #5F7A41 90%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          background-color: color-mix(in oklab, var(--color-secondary) 90%, transparent);
+        }
+      }
+    }
+  }
   .hover\:bg-sky-50 {
     &:hover {
       @media (hover: hover) {
@@ -3067,6 +3168,13 @@
       }
     }
   }
+  .hover\:text-indigo-700 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-indigo-700);
+      }
+    }
+  }
   .hover\:text-primary {
     &:hover {
       @media (hover: hover) {
@@ -3091,6 +3199,13 @@
       }
     }
   }
+  .hover\:text-red-600 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-red-600);
+      }
+    }
+  }
   .hover\:text-red-700 {
     &:hover {
       @media (hover: hover) {
@@ -3102,6 +3217,13 @@
     &:hover {
       @media (hover: hover) {
         color: var(--color-red-800);
+      }
+    }
+  }
+  .hover\:text-rose-700 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-rose-700);
       }
     }
   }
@@ -3315,6 +3437,14 @@
       --tw-ring-color: var(--color-primary);
     }
   }
+  .focus\:ring-primary\/20 {
+    &:focus {
+      --tw-ring-color: color-mix(in srgb, #7A9A55 20%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        --tw-ring-color: color-mix(in oklab, var(--color-primary) 20%, transparent);
+      }
+    }
+  }
   .focus\:ring-primary\/30 {
     &:focus {
       --tw-ring-color: color-mix(in srgb, #7A9A55 30%, transparent);
@@ -3391,6 +3521,11 @@
       outline-style: none;
     }
   }
+  .disabled\:pointer-events-none {
+    &:disabled {
+      pointer-events: none;
+    }
+  }
   .disabled\:cursor-not-allowed {
     &:disabled {
       cursor: not-allowed;
@@ -3414,6 +3549,16 @@
   .disabled\:opacity-75 {
     &:disabled {
       opacity: 75%;
+    }
+  }
+  .has-\[\:checked\]\:border-primary {
+    &:has(*:is(:checked)) {
+      border-color: var(--color-primary);
+    }
+  }
+  .has-\[\:checked\]\:text-primary {
+    &:has(*:is(:checked)) {
+      color: var(--color-primary);
     }
   }
   .supports-\[backdrop-filter\]\:bg-white\/60 {
@@ -3492,6 +3637,11 @@
       align-items: center;
     }
   }
+  .sm\:items-start {
+    @media (width >= 40rem) {
+      align-items: flex-start;
+    }
+  }
   .sm\:justify-between {
     @media (width >= 40rem) {
       justify-content: space-between;
@@ -3563,6 +3713,11 @@
       grid-column: span 7 / span 7;
     }
   }
+  .md\:col-span-8 {
+    @media (width >= 48rem) {
+      grid-column: span 8 / span 8;
+    }
+  }
   .md\:col-span-9 {
     @media (width >= 48rem) {
       grid-column: span 9 / span 9;
@@ -3621,6 +3776,11 @@
   .md\:max-w-xl {
     @media (width >= 48rem) {
       max-width: var(--container-xl);
+    }
+  }
+  .md\:max-w-xs {
+    @media (width >= 48rem) {
+      max-width: var(--container-xs);
     }
   }
   .md\:grid-cols-1 {
@@ -3698,6 +3858,27 @@
         --tw-space-x-reverse: 0;
         margin-inline-start: calc(calc(var(--spacing) * 8) * var(--tw-space-x-reverse));
         margin-inline-end: calc(calc(var(--spacing) * 8) * calc(1 - var(--tw-space-x-reverse)));
+      }
+    }
+  }
+  .md\:divide-x {
+    @media (width >= 48rem) {
+      :where(& > :not(:last-child)) {
+        --tw-divide-x-reverse: 0;
+        border-inline-style: var(--tw-border-style);
+        border-inline-start-width: calc(1px * var(--tw-divide-x-reverse));
+        border-inline-end-width: calc(1px * calc(1 - var(--tw-divide-x-reverse)));
+      }
+    }
+  }
+  .md\:divide-y-0 {
+    @media (width >= 48rem) {
+      :where(& > :not(:last-child)) {
+        --tw-divide-y-reverse: 0;
+        border-bottom-style: var(--tw-border-style);
+        border-top-style: var(--tw-border-style);
+        border-top-width: calc(0px * var(--tw-divide-y-reverse));
+        border-bottom-width: calc(0px * calc(1 - var(--tw-divide-y-reverse)));
       }
     }
   }
@@ -3832,6 +4013,11 @@
       padding: calc(var(--spacing) * 6);
     }
   }
+  .xl\:col-span-1 {
+    @media (width >= 80rem) {
+      grid-column: span 1 / span 1;
+    }
+  }
   .xl\:col-span-2 {
     @media (width >= 80rem) {
       grid-column: span 2 / span 2;
@@ -3857,6 +4043,11 @@
       grid-column: span 8 / span 8;
     }
   }
+  .xl\:grid-cols-2 {
+    @media (width >= 80rem) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
   .xl\:grid-cols-3 {
     @media (width >= 80rem) {
       grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -3865,6 +4056,11 @@
   .xl\:grid-cols-4 {
     @media (width >= 80rem) {
       grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+  }
+  .xl\:gap-5 {
+    @media (width >= 80rem) {
+      gap: calc(var(--spacing) * 5);
     }
   }
 }
@@ -5284,6 +5480,11 @@
   syntax: "*";
   inherits: false;
 }
+@property --tw-divide-x-reverse {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
 @keyframes spin {
   to {
     transform: rotate(360deg);
@@ -5354,6 +5555,7 @@
       --tw-backdrop-sepia: initial;
       --tw-duration: initial;
       --tw-ease: initial;
+      --tw-divide-x-reverse: 0;
     }
   }
 }


### PR DESCRIPTION
## Summary
- compact the PDV workspace spacing and update the sale items list to show full product names, internal codes, and barcodes
- add customer linking controls with a dedicated modal that searches clients/pets and attaches them to the ongoing sale
- only apply general promotions when a client is linked, showing contextual warnings when unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d722101fa88323b96859771d7354ad