### PR TITLE
Fix unreachable code after caixa snapshot in admin PDV script

### DIFF
--- a/scripts/admin/admin-pdv.js
+++ b/scripts/admin/admin-pdv.js
@@ -492,6 +492,8 @@
       },
     };
 
+  };
+
   const getSaleReceiptSnapshot = (
     items = state.itens,
     payments = state.vendaPagamentos


### PR DESCRIPTION
## Summary
- close the getFechamentoSnapshot arrow function properly so subsequent helpers stay accessible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8145a4160832385cdd3c7656e9cbd