### PR TITLE
Add PDV sale action tags and placeholder tabs

### DIFF
--- a/pages/admin/admin-pdv.html
+++ b/pages/admin/admin-pdv.html
@@ -163,25 +163,27 @@
                                     </div>
 
                                     <aside class="space-y-5">
-                                            <div class="rounded-xl border border-gray-200 bg-gray-50 p-5 space-y-5">
-                                                <div class="flex flex-wrap items-center gap-2">
-                                                    <span class="text-[10px] font-semibold uppercase tracking-wide text-gray-400">Ações da venda</span>
-                                                    <button type="button" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1 text-[11px] font-semibold text-gray-600 transition hover:border-primary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary/20" data-sale-action="delivery">
-                                                        <i class="fas fa-truck text-[10px]"></i>
-                                                        <span class="text-xs font-semibold text-gray-700">Delivery</span>
-                                                    </button>
-                                                    <button type="button" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1 text-[11px] font-semibold text-gray-600 transition hover:border-primary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary/20" data-sale-action="orcamento">
-                                                        <i class="fas fa-file-lines text-[10px]"></i>
-                                                        <span class="text-xs font-semibold text-gray-700">Orçamento</span>
-                                                    </button>
-                                                    <button type="button" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1 text-[11px] font-semibold text-gray-600 transition hover:border-primary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary/20" data-sale-action="importar-atendimento">
-                                                        <i class="fas fa-headset text-[10px]"></i>
-                                                        <span class="text-xs font-semibold text-gray-700">Importar atendimento</span>
-                                                    </button>
-                                                    <button id="pdv-open-customer" type="button" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1 text-[11px] font-semibold text-gray-600 transition hover:border-primary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary/20" data-sale-action="customer">
-                                                        <i class="fas fa-user-plus text-[10px]"></i>
-                                                        <span id="pdv-open-customer-label" class="text-xs font-semibold text-gray-700">Adicionar cliente</span>
-                                                    </button>
+                                            <div class="rounded-xl border border-gray-200 bg-gray-50 p-5 space-y-4">
+                                                <div class="space-y-2">
+                                                    <span class="block text-[10px] font-semibold uppercase tracking-wide text-gray-400">Ações da venda</span>
+                                                    <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                                                        <button type="button" class="inline-flex items-center justify-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1 text-[11px] font-semibold text-gray-600 transition hover:border-primary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary/20" data-sale-action="delivery">
+                                                            <i class="fas fa-truck text-[10px]"></i>
+                                                            <span class="text-xs font-semibold text-gray-700">Delivery</span>
+                                                        </button>
+                                                        <button type="button" class="inline-flex items-center justify-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1 text-[11px] font-semibold text-gray-600 transition hover:border-primary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary/20" data-sale-action="orcamento">
+                                                            <i class="fas fa-file-lines text-[10px]"></i>
+                                                            <span class="text-xs font-semibold text-gray-700">Orçamento</span>
+                                                        </button>
+                                                        <button type="button" class="inline-flex items-center justify-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1 text-[11px] font-semibold text-gray-600 transition hover:border-primary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary/20" data-sale-action="importar-atendimento">
+                                                            <i class="fas fa-paw text-[10px]"></i>
+                                                            <span class="text-xs font-semibold text-gray-700">Importar atendimento</span>
+                                                        </button>
+                                                        <button id="pdv-open-customer" type="button" class="inline-flex items-center justify-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1 text-[11px] font-semibold text-gray-600 transition hover:border-primary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary/20" data-sale-action="customer">
+                                                            <i class="fas fa-user-plus text-[10px]"></i>
+                                                            <span id="pdv-open-customer-label" class="text-xs font-semibold text-gray-700">Adicionar cliente</span>
+                                                        </button>
+                                                    </div>
                                                 </div>
                                                 <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                                                     <h3 class="text-base font-semibold text-gray-800">Itens da venda</h3>

--- a/pages/admin/admin-pdv.html
+++ b/pages/admin/admin-pdv.html
@@ -293,11 +293,21 @@
                                 </div>
                             </div>
                             <div data-tab-panel="delivery-tab" class="hidden space-y-5">
-                                <div class="rounded-xl border border-dashed border-gray-300 bg-white p-6">
-                                    <div class="flex flex-col items-center justify-center gap-3 text-center text-gray-500">
-                                        <i class="fas fa-truck text-2xl text-gray-400"></i>
-                                        <p class="text-sm font-medium text-gray-600">Funcionalidade de delivery em desenvolvimento.</p>
+                                <div class="rounded-xl border border-gray-200 bg-white p-6 space-y-4">
+                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                        <div>
+                                            <h3 class="text-base font-semibold text-gray-800">Entregas registradas</h3>
+                                            <p class="text-xs text-gray-500">Acompanhe o andamento das vendas realizadas via delivery.</p>
+                                        </div>
+                                        <div class="flex items-center gap-2 text-xs text-gray-500">
+                                            <span class="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-gray-50 px-3 py-1 font-semibold uppercase tracking-wide">Status</span>
+                                            <span>Registrado • Em separação • Em rota • Finalizado</span>
+                                        </div>
                                     </div>
+                                    <div id="pdv-delivery-empty" class="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-center text-sm text-gray-500">
+                                        Nenhum delivery registrado até o momento.
+                                    </div>
+                                    <ul id="pdv-delivery-list" class="hidden space-y-4"></ul>
                                 </div>
                             </div>
                             <div data-tab-panel="cliente-tab" class="hidden space-y-5">
@@ -427,6 +437,85 @@
                         </div>
                     </div>
                 </section>
+            </div>
+        </div>
+    </div>
+
+    <div id="pdv-delivery-address-modal" class="fixed inset-0 z-[55] hidden">
+        <div class="absolute inset-0 bg-slate-900/60" data-delivery-address-dismiss="backdrop"></div>
+        <div class="relative mx-auto mt-16 w-full max-w-3xl overflow-hidden rounded-2xl bg-white shadow-2xl">
+            <div class="flex items-center justify-between border-b border-gray-200 px-6 py-4">
+                <div>
+                    <h2 class="text-lg font-semibold text-gray-800">Selecionar endereço de entrega</h2>
+                    <p class="text-sm text-gray-500">Confirme o endereço do cliente ou cadastre um novo para continuar.</p>
+                </div>
+                <button type="button" class="rounded-full p-2 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600" data-delivery-address-dismiss="close" aria-label="Fechar modal de endereços">
+                    <i class="fas fa-times"></i>
+                </button>
+            </div>
+            <div class="space-y-5 px-6 py-5">
+                <div id="pdv-delivery-address-loading" class="hidden rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-500">
+                    Carregando endereços do cliente...
+                </div>
+                <div id="pdv-delivery-address-empty" class="hidden rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-500">
+                    Este cliente ainda não possui endereços cadastrados. Adicione um novo abaixo.
+                </div>
+                <div id="pdv-delivery-address-list" class="space-y-2"></div>
+                <button id="pdv-delivery-address-add" type="button" class="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-3 py-2 text-sm font-semibold text-gray-600 transition hover:border-primary hover:text-primary">
+                    <i class="fas fa-plus"></i>
+                    <span>Cadastrar novo endereço</span>
+                </button>
+                <form id="pdv-delivery-address-form" class="hidden grid grid-cols-1 gap-4 rounded-xl border border-gray-200 bg-gray-50 px-4 py-4 md:grid-cols-2">
+                    <div class="md:col-span-2">
+                        <label for="pdv-delivery-address-apelido" class="block text-xs font-semibold uppercase tracking-wide text-gray-500">Apelido</label>
+                        <input id="pdv-delivery-address-apelido" name="apelido" type="text" class="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="Principal, Casa, Trabalho" autocomplete="off">
+                    </div>
+                    <div>
+                        <label for="pdv-delivery-address-cep" class="block text-xs font-semibold uppercase tracking-wide text-gray-500">CEP *</label>
+                        <input id="pdv-delivery-address-cep" name="cep" type="text" class="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="00000-000" autocomplete="postal-code" required>
+                    </div>
+                    <div>
+                        <label for="pdv-delivery-address-numero" class="block text-xs font-semibold uppercase tracking-wide text-gray-500">Número *</label>
+                        <input id="pdv-delivery-address-numero" name="numero" type="text" class="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="S/N" autocomplete="off" required>
+                    </div>
+                    <div class="md:col-span-2">
+                        <label for="pdv-delivery-address-logradouro" class="block text-xs font-semibold uppercase tracking-wide text-gray-500">Endereço *</label>
+                        <input id="pdv-delivery-address-logradouro" name="logradouro" type="text" class="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="Rua, avenida..." autocomplete="address-line1" required>
+                    </div>
+                    <div>
+                        <label for="pdv-delivery-address-bairro" class="block text-xs font-semibold uppercase tracking-wide text-gray-500">Bairro</label>
+                        <input id="pdv-delivery-address-bairro" name="bairro" type="text" class="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" autocomplete="address-line2">
+                    </div>
+                    <div>
+                        <label for="pdv-delivery-address-cidade" class="block text-xs font-semibold uppercase tracking-wide text-gray-500">Cidade</label>
+                        <input id="pdv-delivery-address-cidade" name="cidade" type="text" class="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" autocomplete="address-level2">
+                    </div>
+                    <div>
+                        <label for="pdv-delivery-address-uf" class="block text-xs font-semibold uppercase tracking-wide text-gray-500">UF</label>
+                        <input id="pdv-delivery-address-uf" name="uf" type="text" maxlength="2" class="mt-1 w-full uppercase rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" autocomplete="address-level1">
+                    </div>
+                    <div>
+                        <label for="pdv-delivery-address-complemento" class="block text-xs font-semibold uppercase tracking-wide text-gray-500">Complemento</label>
+                        <input id="pdv-delivery-address-complemento" name="complemento" type="text" class="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="Apartamento, bloco..." autocomplete="address-line2">
+                    </div>
+                    <div class="md:col-span-2">
+                        <label class="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                            <input id="pdv-delivery-address-default" name="isDefault" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary">
+                            Definir como endereço principal
+                        </label>
+                    </div>
+                    <div class="md:col-span-2 flex items-center justify-end gap-2">
+                        <button type="button" id="pdv-delivery-address-cancel-form" class="rounded-lg border border-gray-200 px-4 py-2 text-sm font-semibold text-gray-600 transition hover:bg-gray-100">Cancelar</button>
+                        <button type="submit" class="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-secondary">Salvar endereço</button>
+                    </div>
+                </form>
+            </div>
+            <div class="flex items-center justify-between gap-3 border-t border-gray-200 bg-gray-50 px-6 py-4">
+                <p class="text-xs text-gray-500">Selecione o endereço que receberá a entrega para avançar.</p>
+                <div class="flex items-center gap-2">
+                    <button type="button" id="pdv-delivery-address-cancel" class="rounded-lg border border-gray-200 px-4 py-2 text-sm font-semibold text-gray-600 transition hover:bg-gray-100">Cancelar</button>
+                    <button type="button" id="pdv-delivery-address-confirm" class="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-60">Continuar</button>
+                </div>
             </div>
         </div>
     </div>

--- a/pages/admin/admin-pdv.html
+++ b/pages/admin/admin-pdv.html
@@ -90,6 +90,8 @@
                         <nav class="flex flex-wrap gap-2 border-b border-gray-200 pb-1" aria-label="Seções do PDV">
                             <button type="button" class="pdv-tab-trigger px-3 py-2 text-sm font-semibold border-b-2 border-transparent text-gray-500 hover:text-primary rounded-t" data-tab-target="pdv-tab" aria-disabled="true">PDV</button>
                             <button type="button" class="pdv-tab-trigger px-3 py-2 text-sm font-semibold border-b-2 border-primary text-primary rounded-t" data-tab-target="caixa-tab">Caixa</button>
+                            <button type="button" class="pdv-tab-trigger px-3 py-2 text-sm font-semibold border-b-2 border-transparent text-gray-500 hover:text-primary rounded-t" data-tab-target="delivery-tab">Delivery</button>
+                            <button type="button" class="pdv-tab-trigger px-3 py-2 text-sm font-semibold border-b-2 border-transparent text-gray-500 hover:text-primary rounded-t" data-tab-target="cliente-tab">Cliente</button>
                         </nav>
 
                         <div class="space-y-5">
@@ -162,15 +164,28 @@
 
                                     <aside class="space-y-5">
                                             <div class="rounded-xl border border-gray-200 bg-gray-50 p-5 space-y-5">
+                                                <div class="flex flex-wrap items-center gap-2">
+                                                    <span class="text-[10px] font-semibold uppercase tracking-wide text-gray-400">Ações da venda</span>
+                                                    <button type="button" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1 text-[11px] font-semibold text-gray-600 transition hover:border-primary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary/20" data-sale-action="delivery">
+                                                        <i class="fas fa-truck text-[10px]"></i>
+                                                        <span class="text-xs font-semibold text-gray-700">Delivery</span>
+                                                    </button>
+                                                    <button type="button" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1 text-[11px] font-semibold text-gray-600 transition hover:border-primary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary/20" data-sale-action="orcamento">
+                                                        <i class="fas fa-file-lines text-[10px]"></i>
+                                                        <span class="text-xs font-semibold text-gray-700">Orçamento</span>
+                                                    </button>
+                                                    <button type="button" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1 text-[11px] font-semibold text-gray-600 transition hover:border-primary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary/20" data-sale-action="importar-atendimento">
+                                                        <i class="fas fa-headset text-[10px]"></i>
+                                                        <span class="text-xs font-semibold text-gray-700">Importar atendimento</span>
+                                                    </button>
+                                                    <button id="pdv-open-customer" type="button" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1 text-[11px] font-semibold text-gray-600 transition hover:border-primary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary/20" data-sale-action="customer">
+                                                        <i class="fas fa-user-plus text-[10px]"></i>
+                                                        <span id="pdv-open-customer-label" class="text-xs font-semibold text-gray-700">Adicionar cliente</span>
+                                                    </button>
+                                                </div>
                                                 <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                                                     <h3 class="text-base font-semibold text-gray-800">Itens da venda</h3>
-                                                    <div class="flex items-center gap-3">
-                                                        <span id="pdv-items-count" class="text-xs font-semibold text-gray-500">0 itens</span>
-                                                        <button id="pdv-open-customer" type="button" class="inline-flex items-center gap-2 rounded-lg border border-primary px-3 py-1.5 text-xs font-semibold text-primary transition hover:bg-primary/5">
-                                                            <i class="fas fa-user-plus text-[11px]"></i>
-                                                            <span id="pdv-open-customer-label">Adicionar cliente</span>
-                                                        </button>
-                                                    </div>
+                                                    <span id="pdv-items-count" class="text-xs font-semibold text-gray-500">0 itens</span>
                                                 </div>
                                                 <div class="space-y-3">
                                                     <div id="pdv-customer-summary-empty" class="rounded-lg border border-dashed border-gray-300 bg-white px-4 py-3 text-xs text-gray-500">
@@ -272,6 +287,22 @@
                                                 <li id="pdv-history-empty" class="text-xs text-gray-400">Nenhuma movimentação registrada ainda.</li>
                                             </ul>
                                         </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div data-tab-panel="delivery-tab" class="hidden space-y-5">
+                                <div class="rounded-xl border border-dashed border-gray-300 bg-white p-6">
+                                    <div class="flex flex-col items-center justify-center gap-3 text-center text-gray-500">
+                                        <i class="fas fa-truck text-2xl text-gray-400"></i>
+                                        <p class="text-sm font-medium text-gray-600">Funcionalidade de delivery em desenvolvimento.</p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div data-tab-panel="cliente-tab" class="hidden space-y-5">
+                                <div class="rounded-xl border border-dashed border-gray-300 bg-white p-6">
+                                    <div class="flex flex-col items-center justify-center gap-3 text-center text-gray-500">
+                                        <i class="fas fa-user-friends text-2xl text-gray-400"></i>
+                                        <p class="text-sm font-medium text-gray-600">Área do cliente em desenvolvimento.</p>
                                     </div>
                                 </div>
                             </div>

--- a/scripts/admin/admin-pdv.js
+++ b/scripts/admin/admin-pdv.js
@@ -1729,6 +1729,48 @@
     elements.customerPetsList.appendChild(fragment);
   };
 
+  const clearProductSearchArea = () => {
+    if (searchTimeout) {
+      clearTimeout(searchTimeout);
+      searchTimeout = null;
+    }
+    if (state.searchController) {
+      state.searchController.abort();
+      state.searchController = null;
+    }
+    state.searchResults = [];
+    if (elements.searchInput) {
+      elements.searchInput.value = '';
+    }
+    if (elements.searchResults) {
+      elements.searchResults.classList.add('hidden');
+      elements.searchResults.innerHTML = '';
+    }
+  };
+
+  const clearCustomerSearchArea = () => {
+    if (customerSearchTimeout) {
+      clearTimeout(customerSearchTimeout);
+      customerSearchTimeout = null;
+    }
+    if (customerSearchController) {
+      customerSearchController.abort();
+      customerSearchController = null;
+    }
+    state.customerSearchQuery = '';
+    state.customerSearchResults = [];
+    state.customerSearchLoading = false;
+    if (elements.customerSearchInput) {
+      elements.customerSearchInput.value = '';
+    }
+    renderCustomerSearchResults();
+  };
+
+  const clearSaleSearchAreas = () => {
+    clearProductSearchArea();
+    clearCustomerSearchArea();
+  };
+
   const performCustomerSearch = async (term) => {
     const query = term.trim();
     state.customerSearchQuery = term;
@@ -3120,6 +3162,7 @@
     state.vendaDesconto = 0;
     state.vendaAcrescimo = 0;
     clearSelectedProduct();
+    clearSaleSearchAreas();
     renderItemsList();
     renderSalePaymentsPreview();
     updateFinalizeButton();
@@ -3173,6 +3216,7 @@
     state.vendaDesconto = 0;
     state.vendaAcrescimo = 0;
     clearSelectedProduct();
+    clearSaleSearchAreas();
     renderItemsList();
     renderSalePaymentsPreview();
     updateFinalizeButton();
@@ -3231,6 +3275,7 @@
     order.finalizedAt = nowIso;
     renderDeliveryOrders();
     notify('Delivery finalizado e registrado no caixa.', 'success');
+    clearSaleSearchAreas();
     closeFinalizeModal();
     promptDeliveryPrint(saleSnapshot);
   };
@@ -4785,6 +4830,7 @@
     }
     renderItemsList();
     notify('Item adicionado à pré-visualização.', 'success');
+    clearSaleSearchAreas();
     return true;
   };
 

--- a/scripts/admin/admin-pdv.js
+++ b/scripts/admin/admin-pdv.js
@@ -988,6 +988,7 @@
     elements.itemsCount = document.getElementById('pdv-items-count');
     elements.itemsTotal = document.getElementById('pdv-items-total');
     elements.finalizeButton = document.getElementById('pdv-finalize-sale');
+    elements.saleActionButtons = document.querySelectorAll('[data-sale-action]');
 
     elements.customerOpenButton = document.getElementById('pdv-open-customer');
     elements.customerOpenButtonLabel = document.getElementById('pdv-open-customer-label');
@@ -4262,7 +4263,17 @@
         setActiveTab(target);
       });
     });
-    elements.customerOpenButton?.addEventListener('click', openCustomerModal);
+    Array.from(elements.saleActionButtons || []).forEach((button) => {
+      const action = button.getAttribute('data-sale-action');
+      if (!action) return;
+      if (action === 'customer') {
+        button.addEventListener('click', openCustomerModal);
+        return;
+      }
+      button.addEventListener('click', () => {
+        notify('Funcionalidade em desenvolvimento.', 'info');
+      });
+    });
     elements.customerRemove?.addEventListener('click', handleCustomerRemove);
     elements.customerModalClose?.addEventListener('click', closeCustomerModal);
     elements.customerModalBackdrop?.addEventListener('click', closeCustomerModal);


### PR DESCRIPTION
## Summary
- add a row of PDV sale action tags for delivery, orçamento, importar atendimento, and adicionar cliente
- create placeholder Delivery and Cliente tabs that indicate the features are in development
- hook the new sale action buttons into the existing logic, reusing the customer modal and showing development toasts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8298402a48323b079cfa8cf4b1abf