### PR TITLE
Configure SHA-1 digest algorithm for NFC-e signature

### DIFF
--- a/servidor/services/nfceEmitter.js
+++ b/servidor/services/nfceEmitter.js
@@ -1204,14 +1204,14 @@ const emitPdvSaleFiscal = async ({ sale, pdv, store, emissionDate, environment, 
     getKeyInfo: () => `<X509Data><X509Certificate>${certB64}</X509Certificate></X509Data>`,
   };
   const refXPath = "/*[local-name()='NFe']/*[local-name()='infNFe']";
-  signer.addReference(
-    refXPath,
-    [
+  signer.addReference({
+    xpath: refXPath,
+    transforms: [
       'http://www.w3.org/2000/09/xmldsig#enveloped-signature',
       'http://www.w3.org/TR/2001/REC-xml-c14n-20010315',
     ],
-    'http://www.w3.org/2000/09/xmldsig#sha1'
-  );
+    digestAlgorithm: 'http://www.w3.org/2000/09/xmldsig#sha1',
+  });
   console.debug('XPath ref:', refXPath);
   signer.computeSignature(xmlForSignature, {
     prefix: '',

--- a/servidor/services/nfceEmitter.js
+++ b/servidor/services/nfceEmitter.js
@@ -1198,6 +1198,7 @@ const emitPdvSaleFiscal = async ({ sale, pdv, store, emissionDate, environment, 
     idAttribute: 'Id',
     canonicalizationAlgorithm: 'http://www.w3.org/TR/2001/REC-xml-c14n-20010315',
     signatureAlgorithm: 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+    digestAlgorithm: 'http://www.w3.org/2000/09/xmldsig#sha1',
   });
   signer.keyInfoProvider = {
     getKeyInfo: () => `<X509Data><X509Certificate>${certB64}</X509Certificate></X509Data>`,


### PR DESCRIPTION
## Summary
- configure the NFC-e XML signer to explicitly use the SEFAZ-required SHA-1 digest algorithm

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbe2ede4588323890c17cf3e7ebc4e