### PR TITLE
Fix RJ NFC-e QR code hash calculation

### DIFF
--- a/servidor/services/nfceEmitter.js
+++ b/servidor/services/nfceEmitter.js
@@ -322,7 +322,8 @@ const buildQrCodeRJ = ({ chNFe, tpAmb, idToken, csc }) => {
   const base = 'https://consultadfe.fazenda.rj.gov.br/consultaNFCe/QRCode';
   const idT = String(idToken ?? '').replace(/^0+/, '');
   const pSemHash = `${chNFe}|${versaoQR}|${tpAmb}|${idT}`;
-  const hashInput = `${pSemHash}|${csc}`.replace('||', '|');
+  const token = String(csc ?? '');
+  const hashInput = `${pSemHash}${token}`;
   const cHash = crypto
     .createHash('sha1')
     .update(hashInput, 'utf8')


### PR DESCRIPTION
## Summary
- correct the NFC-e QR Code hash composition for Rio de Janeiro to follow SEFAZ specification

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc6bdd4ca883239f1177cf3ea7c4d3