### PR TITLE
Fix default open state for admin sidebar accordions

### DIFF
--- a/components/admin/sidebar.html
+++ b/components/admin/sidebar.html
@@ -159,23 +159,23 @@
               <a href="/pages/admin/admin-gerir-funcionarios.html" class="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
                 <span class="inline-flex items-center gap-2"><i class="fas fa-id-badge text-gray-400"></i>Cadastro de Funcionários</span>
               </a>
-              <div>
-                <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-medium text-gray-700 rounded-lg hover:bg-gray-50 transition" data-accordion-button>
-                  <span class="inline-flex items-center gap-2">
-                    <i class="fas fa-user-group text-primary"></i>
-                    Clientes
-                  </span>
-                  <i class="fas fa-chevron-down text-xs text-gray-500 transition-transform" data-chevron></i>
-                </button>
-                <div class="mt-2 space-y-2 pl-4 hidden" data-accordion-content>
-                  <a href="#" class="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
-                    <span class="inline-flex items-center gap-2"><i class="fas fa-address-book text-gray-400"></i>Gerir Clientes</span>
-                  </a>
-                  <a href="#" class="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
-                    <span class="inline-flex items-center gap-2"><i class="fas fa-clipboard-list text-gray-400"></i>Relação de pedidos</span>
-                  </a>
-                </div>
-              </div>
+            </div>
+          </div>
+          <div>
+            <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-medium text-gray-700 rounded-lg hover:bg-gray-50 transition" data-accordion-button>
+              <span class="inline-flex items-center gap-2">
+                <i class="fas fa-user-group text-primary"></i>
+                Clientes
+              </span>
+              <i class="fas fa-chevron-down text-xs text-gray-500 transition-transform" data-chevron></i>
+            </button>
+            <div class="mt-2 space-y-2 pl-4 hidden" data-accordion-content>
+              <a href="#" class="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
+                <span class="inline-flex items-center gap-2"><i class="fas fa-address-book text-gray-400"></i>Gerir Clientes</span>
+              </a>
+              <a href="#" class="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
+                <span class="inline-flex items-center gap-2"><i class="fas fa-clipboard-list text-gray-400"></i>Relação de pedidos</span>
+              </a>
             </div>
           </div>
           <div>

--- a/components/admin/sidebar.html
+++ b/components/admin/sidebar.html
@@ -11,7 +11,7 @@
 
     <nav class="flex-1 overflow-y-auto p-4 space-y-4">
       <div>
-        <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-semibold text-gray-700 rounded-lg hover:bg-gray-50 transition" data-accordion-button data-default-open="true">
+        <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-semibold text-gray-700 rounded-lg hover:bg-gray-50 transition" data-accordion-button>
           <span class="inline-flex items-center gap-2">
             <i class="fas fa-warehouse text-primary"></i>
             Retaguarda
@@ -20,7 +20,7 @@
         </button>
         <div class="mt-2 space-y-3 pl-4 hidden" data-accordion-content>
           <div>
-            <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-medium text-gray-700 rounded-lg hover:bg-gray-50 transition" data-accordion-button data-default-open="true">
+            <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-medium text-gray-700 rounded-lg hover:bg-gray-50 transition" data-accordion-button>
               <span class="inline-flex items-center gap-2">
                 <i class="fas fa-building text-primary"></i>
                 Empresa
@@ -87,7 +87,7 @@
       </div>
 
       <div>
-        <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-semibold text-gray-700 rounded-lg hover:bg-gray-50 transition" data-accordion-button data-default-open="true">
+        <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-semibold text-gray-700 rounded-lg hover:bg-gray-50 transition" data-accordion-button>
           <span class="inline-flex items-center gap-2">
             <i class="fas fa-shopping-basket text-primary"></i>
             Compras
@@ -96,7 +96,7 @@
         </button>
         <div class="mt-2 space-y-3 pl-4 hidden" data-accordion-content>
           <div>
-            <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-medium text-gray-700 rounded-lg hover:bg-gray-50 transition" data-accordion-button data-default-open="true">
+            <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-medium text-gray-700 rounded-lg hover:bg-gray-50 transition" data-accordion-button>
               <span class="inline-flex items-center gap-2">
                 <i class="fas fa-boxes text-primary"></i>
                 Estoque

--- a/components/admin/sidebar.html
+++ b/components/admin/sidebar.html
@@ -201,6 +201,21 @@
       <div>
         <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-semibold text-gray-700 rounded-lg hover:bg-gray-50 transition" data-accordion-button>
           <span class="inline-flex items-center gap-2">
+            <i class="fas fa-paw text-primary"></i>
+            PetShop
+          </span>
+          <i class="fas fa-chevron-down text-xs text-gray-500 transition-transform" data-chevron></i>
+        </button>
+        <div class="mt-2 space-y-2 pl-4 hidden" data-accordion-content>
+          <a href="/pages/admin/admin-destaques.html" class="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
+            <span class="inline-flex items-center gap-2"><i class="fas fa-star text-gray-400"></i>Destaques</span>
+          </a>
+        </div>
+      </div>
+
+      <div>
+        <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-semibold text-gray-700 rounded-lg hover:bg-gray-50 transition" data-accordion-button>
+          <span class="inline-flex items-center gap-2">
             <i class="fas fa-cash-register text-primary"></i>
             Vendas
           </span>


### PR DESCRIPTION
## Summary
- remove default-open flags from Empresa and Estoque accordion buttons so only the active section expands

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd6762b0c48323a3eb916cd4aad3a8