### PR TITLE
Unify staff portal with admin navigation

### DIFF
--- a/components/account/account-sidebar.html
+++ b/components/account/account-sidebar.html
@@ -34,7 +34,7 @@
     <!-- Este ID é usado por checkAdminLink() para esconder se não for admin -->
     <a href="/pages/admin.html" id="admin-link" class="flex items-center p-3 text-gray-600 hover:bg-gray-100 rounded-lg transition-colors hidden">
       <i class="fas fa-user-shield w-6 text-center"></i>
-      <span class="ml-3 font-medium">Administrador</span>
+      <span class="ml-3 font-medium">Painel Interno</span>
     </a>
 
     <!-- Novo link: visível para funcionario, admin e admin_master -->

--- a/components/admin/sidebar.html
+++ b/components/admin/sidebar.html
@@ -155,10 +155,62 @@
               </span>
               <i class="fas fa-chevron-down text-xs text-gray-500 transition-transform" data-chevron></i>
             </button>
-            <div class="mt-2 space-y-2 pl-4 hidden" data-accordion-content>
+            <div class="mt-2 space-y-3 pl-4 hidden" data-accordion-content>
               <a href="/pages/admin/admin-gerir-funcionarios.html" class="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
                 <span class="inline-flex items-center gap-2"><i class="fas fa-id-badge text-gray-400"></i>Cadastro de Funcionários</span>
               </a>
+
+              <div>
+                <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-medium text-gray-700 rounded-lg hover:bg-gray-50 transition" data-accordion-button>
+                  <span class="inline-flex items-center gap-2">
+                    <i class="fas fa-briefcase text-primary"></i>
+                    Portal do Funcionário
+                  </span>
+                  <i class="fas fa-chevron-down text-xs text-gray-500 transition-transform" data-chevron></i>
+                </button>
+                <div class="mt-2 space-y-2 pl-4 hidden" data-accordion-content>
+                  <a href="/pages/funcionarios.html" class="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
+                    <span class="inline-flex items-center gap-2"><i class="fas fa-gauge text-gray-400"></i>Painel do Funcionário</span>
+                  </a>
+                  <a href="/pages/funcionarios/banho-e-tosa.html" class="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
+                    <span class="inline-flex items-center gap-2"><i class="fas fa-calendar-days text-gray-400"></i>Agenda Banho &amp; Tosa</span>
+                  </a>
+
+                  <div>
+                    <button type="button" class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm font-medium text-gray-700 rounded-lg hover:bg-gray-50 transition" data-accordion-button>
+                      <span class="inline-flex items-center gap-2">
+                        <i class="fas fa-stethoscope text-primary"></i>
+                        Veterinário
+                      </span>
+                      <i class="fas fa-chevron-down text-xs text-gray-500 transition-transform" data-chevron></i>
+                    </button>
+                    <div class="mt-2 space-y-2 pl-4 hidden" data-accordion-content>
+                      <a href="/pages/funcionarios/veterinario.html" class="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
+                        <span class="inline-flex items-center gap-2"><i class="fas fa-notes-medical text-gray-400"></i>Painel Veterinário</span>
+                      </a>
+                      <a href="/pages/funcionarios/vet-ficha-clinica.html" class="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
+                        <span class="inline-flex items-center gap-2"><i class="fas fa-file-medical text-gray-400"></i>Ficha Clínica</span>
+                      </a>
+                      <a href="/pages/funcionarios/vet-documentos.html" class="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
+                        <span class="inline-flex items-center gap-2"><i class="fas fa-folder-open text-gray-400"></i>Documentos</span>
+                      </a>
+                      <a href="/pages/funcionarios/vet-receitas.html" class="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
+                        <span class="inline-flex items-center gap-2"><i class="fas fa-prescription-bottle-medical text-gray-400"></i>Receitas</span>
+                      </a>
+                      <a href="/pages/funcionarios/vet-assinatura.html" class="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
+                        <span class="inline-flex items-center gap-2"><i class="fas fa-signature text-gray-400"></i>Assinatura Digital</span>
+                      </a>
+                    </div>
+                  </div>
+
+                  <a href="/pages/funcionarios/comissoes.html" class="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
+                    <span class="inline-flex items-center gap-2"><i class="fas fa-coins text-gray-400"></i>Minhas Comissões</span>
+                  </a>
+                  <a href="/pages/funcionarios/clientes.html" class="flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 hover:bg-gray-50 transition">
+                    <span class="inline-flex items-center gap-2"><i class="fas fa-users text-gray-400"></i>Clientes</span>
+                  </a>
+                </div>
+              </div>
             </div>
           </div>
           <div>

--- a/pages/funcionarios.html
+++ b/pages/funcionarios.html
@@ -10,36 +10,37 @@
 </head>
 <body class="bg-gray-100">
 
-  <!-- Header específico de Funcionários -->
-  <div id="func-header-placeholder"></div>
+  <div id="admin-header-placeholder"></div>
 
   <main class="container mx-auto px-4 py-8 min-h-screen">
-    <!-- Menu horizontal abaixo do cabeçalho -->
-    <div class="mb-6" id="func-sidebar-placeholder"></div>
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
-    <!-- Conteúdo -->
-    <section class="">
-      <div class="bg-white rounded-lg shadow p-6">
-        <div class="flex items-center gap-3 mb-4">
-          <i class="fas fa-wrench text-gray-400 text-2xl"></i>
-          <h1 class="text-2xl font-bold text-gray-800">Funcionários</h1>
+      <aside class="md:col-span-4">
+        <div id="admin-sidebar-placeholder"></div>
+      </aside>
+
+      <section class="md:col-span-4">
+        <div class="bg-white rounded-lg shadow p-6">
+          <div class="flex items-center gap-3 mb-4">
+            <i class="fas fa-wrench text-gray-400 text-2xl"></i>
+            <h1 class="text-2xl font-bold text-gray-800">Funcionários</h1>
+          </div>
+          <p class="text-gray-600">
+            Esta área está <strong>em manutenção</strong>. Em breve, mais funcionalidades estarão disponíveis.
+          </p>
         </div>
-        <p class="text-gray-600">
-          Esta área está <strong>em manutenção</strong>. Em breve, mais funcionalidades estarão disponíveis.
-        </p>
-      </div>
-    </section>
+      </section>
+    </div>
   </main>
 
   <div id="modal-placeholder"></div>
   <div id="confirm-modal-placeholder"></div>
-  <div id="func-footer-placeholder"></div>
+  <div id="admin-footer-placeholder"></div>
 
   <script>var basePath = '../';</script>
   <script src="../scripts/core/config.js"></script>
   <script src="../scripts/core/ui.js"></script>
   <script src="../scripts/core/main.js"></script>
-  <!-- Guarda/validação de acesso de Funcionários -->
-  <script src="../scripts/funcionarios/funcionarios.js"></script>
+  <script src="../scripts/admin/admin.js"></script>
 </body>
 </html>

--- a/pages/funcionarios/banho-e-tosa.html
+++ b/pages/funcionarios/banho-e-tosa.html
@@ -8,16 +8,17 @@
   <link rel="stylesheet" href="../../src/output.css">
 </head>
 <body class="bg-gray-100">
-  <!-- Header dos Funcionários -->
-  <div id="func-header-placeholder"></div>
+  <div id="admin-header-placeholder"></div>
 
   <main class="container mx-auto px-4 py-8 min-h-screen">
-    <!-- Sidebar agora como faixa horizontal abaixo do cabeçalho -->
-    <div class="mb-6" id="func-sidebar-placeholder"></div>
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
-    <!-- Conteúdo ocupa 100% da largura -->
-    <section>
-      <div class="bg-white rounded-xl shadow-sm ring-1 ring-black/5">
+      <aside class="md:col-span-4">
+        <div id="admin-sidebar-placeholder"></div>
+      </aside>
+
+      <section class="md:col-span-4">
+        <div class="bg-white rounded-xl shadow-sm ring-1 ring-black/5">
         <!-- Filtros -->
         <div class="agenda-toolbar px-6 py-4 border-b bg-white sticky top-0 z-20 no-print flex flex-col md:flex-row md:items-center md:justify-between gap-4">
           <div class="flex items-center gap-3">
@@ -66,16 +67,16 @@
         <div id="agenda-wrapper" class="relative overflow-x-auto">
           <div id="agenda-list" class="min-w-[720px]"></div>
         </div>
-      </div>
-    </section>
+        </div>
+      </section>
+    </div>
   </main>
 
   <!-- Modais compartilhados -->
   <div id="modal-placeholder"></div>
   <div id="confirm-modal-placeholder"></div>
 
-  <!-- Footer dos Funcionários -->
-  <div id="func-footer-placeholder"></div>
+  <div id="admin-footer-placeholder"></div>
 
   <!-- Base path relativo à pasta /pages -->
   <script defer>var basePath = '../../';</script>
@@ -84,7 +85,7 @@
   <script defer src="../../scripts/core/config.js"></script>
   <script defer src="../../scripts/core/ui.js"></script>
   <script defer src="../../scripts/core/main.js"></script>
-  <script defer src="../../scripts/funcionarios/funcionarios.js"></script>
+  <script defer src="../../scripts/admin/admin.js"></script>
 
   <!-- Página: Banho e Tosa (modulada) -->
   <script type="module" src="../../scripts/funcionarios/banhoetosa/index.js"></script>

--- a/pages/funcionarios/clientes.html
+++ b/pages/funcionarios/clientes.html
@@ -9,30 +9,35 @@
   <link rel="stylesheet" href="../../src/output.css">
 </head>
 <body class="bg-gray-100">
-  <div id="func-header-placeholder"></div>
+  <div id="admin-header-placeholder"></div>
 
   <main class="container mx-auto px-4 py-8 min-h-screen">
-    <div class="mb-6" id="func-sidebar-placeholder"></div>
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
-    <section class="">
-      <div class="bg-white rounded-lg shadow p-6">
-        <div class="flex items-center gap-3 mb-4">
-          <i class="fas fa-users text-gray-400 text-2xl"></i>
-          <h1 class="text-2xl font-bold text-gray-800">Clientes</h1>
+      <aside class="md:col-span-4">
+        <div id="admin-sidebar-placeholder"></div>
+      </aside>
+
+      <section class="md:col-span-4">
+        <div class="bg-white rounded-lg shadow p-6">
+          <div class="flex items-center gap-3 mb-4">
+            <i class="fas fa-users text-gray-400 text-2xl"></i>
+            <h1 class="text-2xl font-bold text-gray-800">Clientes</h1>
+          </div>
+          <p class="text-gray-600">Em breve: listagem e ferramentas de clientes.</p>
         </div>
-        <p class="text-gray-600">Em breve: listagem e ferramentas de clientes.</p>
-      </div>
-    </section>
+      </section>
+    </div>
   </main>
 
   <div id="modal-placeholder"></div>
   <div id="confirm-modal-placeholder"></div>
-  <div id="func-footer-placeholder"></div>
+  <div id="admin-footer-placeholder"></div>
 
   <script>var basePath = '../../';</script>
   <script src="../../scripts/core/config.js"></script>
   <script src="../../scripts/core/ui.js"></script>
   <script src="../../scripts/core/main.js"></script>
-  <script src="../../scripts/funcionarios/funcionarios.js"></script>
+  <script src="../../scripts/admin/admin.js"></script>
 </body>
 </html>

--- a/pages/funcionarios/comissoes.html
+++ b/pages/funcionarios/comissoes.html
@@ -9,30 +9,35 @@
   <link rel="stylesheet" href="../../src/output.css">
 </head>
 <body class="bg-gray-100">
-  <div id="func-header-placeholder"></div>
+  <div id="admin-header-placeholder"></div>
 
   <main class="container mx-auto px-4 py-8 min-h-screen">
-    <div class="mb-6" id="func-sidebar-placeholder"></div>
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
-    <section class="">
-      <div class="bg-white rounded-lg shadow p-6">
-        <div class="flex items-center gap-3 mb-4">
-          <i class="fas fa-coins text-gray-400 text-2xl"></i>
-          <h1 class="text-2xl font-bold text-gray-800">Minhas Comissões</h1>
+      <aside class="md:col-span-4">
+        <div id="admin-sidebar-placeholder"></div>
+      </aside>
+
+      <section class="md:col-span-4">
+        <div class="bg-white rounded-lg shadow p-6">
+          <div class="flex items-center gap-3 mb-4">
+            <i class="fas fa-coins text-gray-400 text-2xl"></i>
+            <h1 class="text-2xl font-bold text-gray-800">Minhas Comissões</h1>
+          </div>
+          <p class="text-gray-600">Em breve: visão de comissões.</p>
         </div>
-        <p class="text-gray-600">Em breve: visão de comissões.</p>
-      </div>
-    </section>
+      </section>
+    </div>
   </main>
 
   <div id="modal-placeholder"></div>
   <div id="confirm-modal-placeholder"></div>
-  <div id="func-footer-placeholder"></div>
+  <div id="admin-footer-placeholder"></div>
 
   <script>var basePath = '../../';</script>
   <script src="../../scripts/core/config.js"></script>
   <script src="../../scripts/core/ui.js"></script>
   <script src="../../scripts/core/main.js"></script>
-  <script src="../../scripts/funcionarios/funcionarios.js"></script>
+  <script src="../../scripts/admin/admin.js"></script>
 </body>
 </html>

--- a/pages/funcionarios/vet-assinatura.html
+++ b/pages/funcionarios/vet-assinatura.html
@@ -8,30 +8,35 @@
   <link rel="stylesheet" href="../../src/output.css">
 </head>
 <body class="bg-gray-100">
-  <div id="func-header-placeholder"></div>
+  <div id="admin-header-placeholder"></div>
 
   <main class="container mx-auto px-4 py-8 min-h-screen">
-    <div class="mb-6" id="func-sidebar-placeholder"></div>
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
-    <section class="bg-white rounded-xl shadow-sm ring-1 ring-black/5 p-6">
-      <div class="flex items-center gap-3 mb-4">
-        <i class="fas fa-signature text-primary"></i>
-        <h1 class="text-xl font-semibold text-gray-800">Assinatura</h1>
-      </div>
-      <div class="rounded-lg border border-dashed border-gray-300 p-8 text-center">
-        <p class="text-gray-500">Em breve — estamos preparando esta área.</p>
-      </div>
-    </section>
+      <aside class="md:col-span-4">
+        <div id="admin-sidebar-placeholder"></div>
+      </aside>
+
+      <section class="md:col-span-4 bg-white rounded-xl shadow-sm ring-1 ring-black/5 p-6">
+        <div class="flex items-center gap-3 mb-4">
+          <i class="fas fa-signature text-primary"></i>
+          <h1 class="text-xl font-semibold text-gray-800">Assinatura</h1>
+        </div>
+        <div class="rounded-lg border border-dashed border-gray-300 p-8 text-center">
+          <p class="text-gray-500">Em breve — estamos preparando esta área.</p>
+        </div>
+      </section>
+    </div>
   </main>
 
   <div id="modal-placeholder"></div>
   <div id="confirm-modal-placeholder"></div>
-  <div id="func-footer-placeholder"></div>
+  <div id="admin-footer-placeholder"></div>
 
   <script>var basePath = '../../';</script>
   <script src="../../scripts/core/config.js"></script>
   <script src="../../scripts/core/ui.js"></script>
   <script src="../../scripts/core/main.js"></script>
-  <script src="../../scripts/funcionarios/funcionarios.js"></script>
+  <script src="../../scripts/admin/admin.js"></script>
 </body>
 </html>

--- a/pages/funcionarios/vet-documentos.html
+++ b/pages/funcionarios/vet-documentos.html
@@ -240,12 +240,16 @@
   </style>
 </head>
 <body class="bg-gray-100">
-  <div id="func-header-placeholder"></div>
+  <div id="admin-header-placeholder"></div>
 
   <main class="container mx-auto px-4 py-8 min-h-screen">
-    <div class="mb-6" id="func-sidebar-placeholder"></div>
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
-    <section class="bg-white rounded-xl shadow-sm ring-1 ring-black/5 p-6">
+      <aside class="md:col-span-4">
+        <div id="admin-sidebar-placeholder"></div>
+      </aside>
+
+      <section class="md:col-span-4 bg-white rounded-xl shadow-sm ring-1 ring-black/5 p-6">
       <div class="flex items-start gap-3">
         <div class="h-12 w-12 rounded-xl bg-primary/10 text-primary grid place-items-center text-xl">
           <i class="fas fa-file-lines"></i>
@@ -389,18 +393,19 @@
 
         <div id="vet-doc-list" class="mt-6 space-y-4"></div>
       </div>
-    </section>
+      </section>
+    </div>
   </main>
 
   <div id="modal-placeholder"></div>
   <div id="confirm-modal-placeholder"></div>
-  <div id="func-footer-placeholder"></div>
+  <div id="admin-footer-placeholder"></div>
 
   <script>var basePath = '../../';</script>
   <script src="../../scripts/core/config.js"></script>
   <script src="../../scripts/core/ui.js"></script>
   <script src="../../scripts/core/main.js"></script>
-  <script src="../../scripts/funcionarios/funcionarios.js"></script>
+  <script src="../../scripts/admin/admin.js"></script>
   <script src="https://cdn.quilljs.com/1.3.7/quill.min.js"></script>
   <script type="module" src="../../scripts/funcionarios/vet/documentos.js"></script>
 </body>

--- a/pages/funcionarios/vet-ficha-clinica.html
+++ b/pages/funcionarios/vet-ficha-clinica.html
@@ -10,15 +10,19 @@
 </head>
 
 <body class="bg-gray-100">
-    <!-- Header global -->
-    <div id="func-header-placeholder"></div>
+    <div id="admin-header-placeholder"></div>
 
     <main class="container mx-auto px-4 py-6 min-h-screen">
-        <!-- Sidebar Funcionários -->
-        <div class="mb-4" id="func-sidebar-placeholder"></div>
+        <div class="grid grid-cols-1 md:grid-cols-4 gap-6 lg:gap-8">
+
+            <aside class="md:col-span-4">
+                <div id="admin-sidebar-placeholder"></div>
+            </aside>
+
+            <div class="md:col-span-4 space-y-4">
 
         <!-- TOP BAR da Ficha Clínica (Tutor/Pet e Ações do topo) -->
-        <section class="bg-white rounded-xl shadow-sm ring-1 ring-black/5 p-4 mb-4">
+        <section class="bg-white rounded-xl shadow-sm ring-1 ring-black/5 p-4">
             <div class="flex items-center gap-6">
                 <!-- Tutor -->
                 <div class="flex-1 min-w-[280px]">
@@ -331,19 +335,21 @@
                 </div>
             </aside>
         </div>
+            </div> <!-- /md:col-span-4 space-y-4 -->
+        </div> <!-- /grid -->
     </main>
 
     <!-- Modais/rodapé padrão -->
     <div id="modal-placeholder"></div>
     <div id="confirm-modal-placeholder"></div>
-    <div id="func-footer-placeholder"></div>
+    <div id="admin-footer-placeholder"></div>
 
     <!-- Scripts base do projeto -->
     <script>var basePath = '../../';</script>
     <script src="../../scripts/core/config.js"></script>
     <script src="../../scripts/core/ui.js"></script>
     <script src="../../scripts/core/main.js"></script>
-    <script src="../../scripts/funcionarios/funcionarios.js"></script>
+    <script src="../../scripts/admin/admin.js"></script>
     <script type="module" src="../../scripts/funcionarios/vet/ficha-clinica/index.js"></script>
 </body>
 

--- a/pages/funcionarios/vet-receitas.html
+++ b/pages/funcionarios/vet-receitas.html
@@ -240,12 +240,16 @@
   </style>
 </head>
 <body class="bg-gray-100">
-  <div id="func-header-placeholder"></div>
+  <div id="admin-header-placeholder"></div>
 
   <main class="container mx-auto px-4 py-8 min-h-screen">
-    <div class="mb-6" id="func-sidebar-placeholder"></div>
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
-    <section class="bg-white rounded-xl shadow-sm ring-1 ring-black/5 p-6">
+      <aside class="md:col-span-4">
+        <div id="admin-sidebar-placeholder"></div>
+      </aside>
+
+      <section class="md:col-span-4 bg-white rounded-xl shadow-sm ring-1 ring-black/5 p-6">
       <div class="flex items-start gap-3">
         <div class="h-12 w-12 rounded-xl bg-primary/10 text-primary grid place-items-center text-xl">
           <i class="fas fa-prescription-bottle-medical"></i>
@@ -389,18 +393,19 @@
 
         <div id="vet-rec-list" class="mt-6 space-y-4"></div>
       </div>
-    </section>
+      </section>
+    </div>
   </main>
 
   <div id="modal-placeholder"></div>
   <div id="confirm-modal-placeholder"></div>
-  <div id="func-footer-placeholder"></div>
+  <div id="admin-footer-placeholder"></div>
 
   <script>var basePath = '../../';</script>
   <script src="../../scripts/core/config.js"></script>
   <script src="../../scripts/core/ui.js"></script>
   <script src="../../scripts/core/main.js"></script>
-  <script src="../../scripts/funcionarios/funcionarios.js"></script>
+  <script src="../../scripts/admin/admin.js"></script>
   <script src="https://cdn.quilljs.com/1.3.7/quill.min.js"></script>
   <script type="module" src="../../scripts/funcionarios/vet/receitas.js"></script>
 </body>

--- a/pages/funcionarios/veterinario.html
+++ b/pages/funcionarios/veterinario.html
@@ -9,30 +9,35 @@
   <link rel="stylesheet" href="../../src/output.css">
 </head>
 <body class="bg-gray-100">
-  <div id="func-header-placeholder"></div>
+  <div id="admin-header-placeholder"></div>
 
   <main class="container mx-auto px-4 py-8 min-h-screen">
-    <div class="mb-6" id="func-sidebar-placeholder"></div>
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
-    <section class="">
-      <div class="bg-white rounded-lg shadow p-6">
-        <div class="flex items-center gap-3 mb-4">
-          <i class="fas fa-stethoscope text-gray-400 text-2xl"></i>
-          <h1 class="text-2xl font-bold text-gray-800">Veterinário</h1>
+      <aside class="md:col-span-4">
+        <div id="admin-sidebar-placeholder"></div>
+      </aside>
+
+      <section class="md:col-span-4">
+        <div class="bg-white rounded-lg shadow p-6">
+          <div class="flex items-center gap-3 mb-4">
+            <i class="fas fa-stethoscope text-gray-400 text-2xl"></i>
+            <h1 class="text-2xl font-bold text-gray-800">Veterinário</h1>
+          </div>
+          <p class="text-gray-600">Em breve: visão para Veterinário.</p>
         </div>
-        <p class="text-gray-600">Em breve: visão para Veterinário.</p>
-      </div>
-    </section>
+      </section>
+    </div>
   </main>
 
   <div id="modal-placeholder"></div>
   <div id="confirm-modal-placeholder"></div>
-  <div id="func-footer-placeholder"></div>
+  <div id="admin-footer-placeholder"></div>
 
   <script>var basePath = '../../';</script>
   <script src="../../scripts/core/config.js"></script>
   <script src="../../scripts/core/ui.js"></script>
   <script src="../../scripts/core/main.js"></script>
-  <script src="../../scripts/funcionarios/funcionarios.js"></script>
+  <script src="../../scripts/admin/admin.js"></script>
 </body>
 </html>

--- a/scripts/admin/admin.js
+++ b/scripts/admin/admin.js
@@ -9,7 +9,7 @@ async function checkAdminAccess() {
 
     // Sem login -> login
     if (!loggedInUser || !token) {
-      alert('Você precisa estar logado como administrador.');
+      alert('Você precisa estar logado para acessar o painel interno.');
       window.location.replace('/pages/login.html');
       return;
     }
@@ -29,10 +29,10 @@ async function checkAdminAccess() {
     const data = await resp.json();
     const role = data?.role;
 
-    // Libera somente admin e admin_master
-    const allowed = role === 'admin' || role === 'admin_master';
+    // Libera funcionários, admin e admin_master
+    const allowed = ['funcionario', 'admin', 'admin_master'].includes(role);
     if (!allowed) {
-      alert('Acesso negado. Esta área é restrita a administradores.');
+      alert('Acesso negado. Esta área é restrita a colaboradores autorizados.');
       // se quiser mandar para home em vez do login, troque a URL abaixo
       window.location.replace('/pages/login.html');
       return;

--- a/scripts/core/main.js
+++ b/scripts/core/main.js
@@ -757,7 +757,7 @@ function initializeFlyoutMenu() {
 }
 
 function checkAdminLink() {
-  return checkRoleLink('admin-link', ['admin','admin_master']);
+  return checkRoleLink('admin-link', ['funcionario','admin','admin_master']);
 }
 
 let __roleCachePromise = null;


### PR DESCRIPTION
## Summary
- allow staff roles to pass the admin access guard and expose the admin link for employees
- restructure the employee pages to use the admin header/sidebar and add their entries to the admin menu
- retitle the account sidebar link to reflect the shared internal panel

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68dd740192888323ad6a1fba93e07716