### PR TITLE
Add searchable navigation to admin dashboard header

### DIFF
--- a/components/admin/header.html
+++ b/components/admin/header.html
@@ -1,6 +1,6 @@
   <header class="bg-white shadow-sm">
-    <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-      <div class="flex items-center gap-4">
+    <div class="container mx-auto px-4 py-3 flex flex-col gap-3 md:flex-row md:items-center md:gap-6">
+      <div class="flex items-center gap-4 md:w-auto">
         <button type="button" data-admin-sidebar-trigger class="inline-flex h-11 w-11 items-center justify-center rounded-xl border border-gray-200 bg-white text-gray-600 shadow-sm transition hover:bg-gray-50 hover:text-gray-800 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2">
           <span class="sr-only">Abrir menu administrativo</span>
           <i class="fas fa-bars text-lg"></i>
@@ -10,7 +10,29 @@
         </a>
       </div>
 
-      <div class="flex items-center text-gray-500">
+      <div data-admin-screen-search class="w-full md:flex-1">
+        <label for="admin-screen-search-input" class="sr-only">Pesquisar telas</label>
+        <div class="relative">
+          <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4 text-gray-400">
+            <i class="fas fa-magnifying-glass"></i>
+          </span>
+          <input
+            id="admin-screen-search-input"
+            type="search"
+            autocomplete="off"
+            placeholder="Buscar telas do painel"
+            data-admin-screen-search-input
+            class="w-full rounded-xl border border-gray-200 bg-white py-2.5 pl-11 pr-4 text-sm text-gray-700 shadow-sm placeholder:text-gray-400 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+          >
+          <div data-admin-screen-search-results class="absolute left-0 right-0 top-full z-50 mt-2 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl hidden">
+            <div data-empty-state class="px-4 py-6 text-sm text-gray-500">Comece a digitar para encontrar uma tela.</div>
+            <ul data-results-list class="max-h-80 divide-y divide-gray-100 overflow-auto"></ul>
+            <div data-no-results class="hidden px-4 py-6 text-sm text-gray-500">Nenhuma tela encontrada para essa pesquisa.</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="flex items-center text-gray-500 md:ml-auto">
         <span class="border-r border-gray-300 h-6 mr-4"></span>
         <span class="font-semibold text-sm">Administrador</span>
       </div>

--- a/src/output.css
+++ b/src/output.css
@@ -2034,6 +2034,9 @@
   .pl-10 {
     padding-left: calc(var(--spacing) * 10);
   }
+  .pl-11 {
+    padding-left: calc(var(--spacing) * 11);
+  }
   .text-center {
     text-align: center;
   }
@@ -2436,6 +2439,12 @@
   .ring-2 {
     --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-primary\/10 {
+    --tw-shadow-color: color-mix(in srgb, #7A9A55 10%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-primary) 10%, transparent) var(--tw-shadow-alpha), transparent);
+    }
   }
   .ring-amber-100 {
     --tw-ring-color: var(--color-amber-100);
@@ -3690,6 +3699,11 @@
       align-items: center;
     }
   }
+  .sm\:items-end {
+    @media (width >= 40rem) {
+      align-items: flex-end;
+    }
+  }
   .sm\:items-start {
     @media (width >= 40rem) {
       align-items: flex-start;
@@ -3796,6 +3810,11 @@
       margin-top: calc(var(--spacing) * 0);
     }
   }
+  .md\:ml-auto {
+    @media (width >= 48rem) {
+      margin-left: auto;
+    }
+  }
   .md\:block {
     @media (width >= 48rem) {
       display: block;
@@ -3831,6 +3850,11 @@
       width: 420px;
     }
   }
+  .md\:w-auto {
+    @media (width >= 48rem) {
+      width: auto;
+    }
+  }
   .md\:max-w-lg {
     @media (width >= 48rem) {
       max-width: var(--container-lg);
@@ -3844,6 +3868,11 @@
   .md\:max-w-xs {
     @media (width >= 48rem) {
       max-width: var(--container-xs);
+    }
+  }
+  .md\:flex-1 {
+    @media (width >= 48rem) {
+      flex: 1;
     }
   }
   .md\:grid-cols-1 {
@@ -3904,6 +3933,11 @@
   .md\:justify-end {
     @media (width >= 48rem) {
       justify-content: flex-end;
+    }
+  }
+  .md\:gap-6 {
+    @media (width >= 48rem) {
+      gap: calc(var(--spacing) * 6);
     }
   }
   .md\:space-x-4 {
@@ -4069,6 +4103,11 @@
   .lg\:justify-between {
     @media (width >= 64rem) {
       justify-content: space-between;
+    }
+  }
+  .lg\:gap-8 {
+    @media (width >= 64rem) {
+      gap: calc(var(--spacing) * 8);
     }
   }
   .lg\:p-6 {


### PR DESCRIPTION
## Summary
- add a search input and dropdown results to the admin header so users can jump to pages without opening the sidebar
- load admin screen metadata from the sidebar and wire up keyboard-friendly navigation for the new search panel
- rebuild the generated Tailwind CSS to ship the utilities required by the search dropdown

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd7ea9d6cc8323bd4f488003aa82ab