### PR TITLE
Fix admin tabs for employee pages

### DIFF
--- a/scripts/admin/admin-tabs.js
+++ b/scripts/admin/admin-tabs.js
@@ -182,7 +182,7 @@
       panel.className = 'admin-tab-panel hidden';
 
       const frameWrapper = document.createElement('div');
-      frameWrapper.className = 'relative overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm';
+      frameWrapper.className = 'relative w-full admin-tab-iframe-wrapper';
 
       const loader = document.createElement('div');
       loader.className = 'absolute inset-0 flex items-center justify-center bg-white/80';
@@ -237,6 +237,12 @@
       }
     }
 
+    function isTabEligible(pathname) {
+      if (!pathname) return false;
+      const allowedPrefixes = ['/pages/admin/', '/pages/funcionarios/'];
+      return allowedPrefixes.some((prefix) => pathname.startsWith(prefix));
+    }
+
     function openTab(href, label) {
       const normalized = normalizeHref(href);
       if (!normalized) {
@@ -244,7 +250,7 @@
         return;
       }
 
-      if (!normalized.includes('/pages/admin/')) {
+      if (!isTabEligible(normalized)) {
         window.location.href = normalized;
         return;
       }
@@ -336,7 +342,7 @@
       if (!href || href === '#' || href.startsWith('mailto:') || href.startsWith('tel:')) return false;
       const normalized = normalizeHref(href);
       if (!normalized) return false;
-      if (!normalized.includes('/pages/admin/')) return false;
+      if (!isTabEligible(normalized)) return false;
       return true;
     }
 

--- a/src/input.css
+++ b/src/input.css
@@ -1206,11 +1206,19 @@
   }
 
   body.admin-embedded main {
-    @apply min-h-0 px-4 py-6;
+    @apply min-h-0 w-full px-4 py-6;
+  }
+
+  body.admin-embedded main.container {
+    @apply max-w-full;
   }
 
   body.admin-embedded .admin-embedded-grid {
     @apply block gap-6;
+  }
+
+  body.admin-embedded .admin-tab-iframe-wrapper {
+    @apply bg-transparent;
   }
 
   body.admin-embedded[data-admin-tabs-root] {

--- a/src/output.css
+++ b/src/output.css
@@ -5322,12 +5322,19 @@
   }
   body.admin-embedded main {
     min-height: calc(var(--spacing) * 0);
+    width: 100%;
     padding-inline: calc(var(--spacing) * 4);
     padding-block: calc(var(--spacing) * 6);
+  }
+  body.admin-embedded main.container {
+    max-width: 100%;
   }
   body.admin-embedded .admin-embedded-grid {
     display: block;
     gap: calc(var(--spacing) * 6);
+  }
+  body.admin-embedded .admin-tab-iframe-wrapper {
+    background-color: transparent;
   }
   body.admin-embedded[data-admin-tabs-root] {
     height: 100%;


### PR DESCRIPTION
## Summary
- allow the admin tab system to open staff pages alongside the admin ones
- remove the iframe framing styles so embedded pages keep their original layout
- adjust embedded layout styles so pages use the full width of the viewport

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd8bdddaf48323aeaa5235858cdcad