### PR TITLE
Ajusta layout das telas embedadas no painel administrativo

### DIFF
--- a/scripts/admin/admin.js
+++ b/scripts/admin/admin.js
@@ -70,6 +70,12 @@ async function checkAdminAccess() {
         if (mainGrid) {
           mainGrid.classList.add('admin-embedded-grid');
         }
+
+        const mainElement = document.querySelector('main');
+        if (mainElement) {
+          mainElement.classList.remove('container', 'mx-auto', 'px-4', 'py-8', 'min-h-screen');
+          mainElement.classList.add('admin-embedded-main');
+        }
       };
 
       if (document.readyState === 'loading') {

--- a/src/input.css
+++ b/src/input.css
@@ -1234,21 +1234,21 @@
   }
 
   body.admin-embedded .admin-tab-iframe-wrapper {
-    @apply bg-transparent;
+    @apply bg-transparent overflow-visible;
   }
 
   body.admin-embedded[data-admin-tabs-root] {
-    @apply h-full;
+    @apply min-h-0;
   }
 
   .admin-tab-panel {
-    @apply h-full;
+    @apply min-h-0;
   }
 
   .admin-tab-iframe {
     display: block;
     width: 100%;
-    height: 100%;
+    height: auto;
     min-height: 0;
     border: 0;
   }

--- a/src/input.css
+++ b/src/input.css
@@ -1205,8 +1205,12 @@
     @apply bg-transparent;
   }
 
+  body.admin-embedded {
+    @apply min-h-screen;
+  }
+
   body.admin-embedded main {
-    @apply mx-0 w-full max-w-full px-0 pt-1 pb-4;
+    @apply mx-0 w-full max-w-none px-0 pt-0 pb-3;
   }
 
   body.admin-embedded main.container {
@@ -1214,7 +1218,7 @@
   }
 
   body.admin-embedded .admin-embedded-main {
-    @apply w-full max-w-none px-2 sm:px-3 lg:px-4 pt-3 pb-6 min-h-screen;
+    @apply w-full max-w-none px-1.5 sm:px-2 lg:px-3 pt-1.5 pb-4 min-h-[calc(100vh-1rem)];
   }
 
   body.admin-embedded .admin-embedded-main > .admin-embedded-grid {
@@ -1226,7 +1230,7 @@
   }
 
   body.admin-embedded .admin-embedded-grid {
-    @apply gap-3;
+    @apply gap-2 sm:gap-3;
   }
 
   body.admin-embedded .admin-tab-iframe-wrapper {

--- a/src/input.css
+++ b/src/input.css
@@ -1213,6 +1213,18 @@
     @apply max-w-none;
   }
 
+  body.admin-embedded .admin-embedded-main {
+    @apply w-full max-w-none px-4 sm:px-6 lg:px-8 pt-6 pb-10 min-h-screen;
+  }
+
+  body.admin-embedded .admin-embedded-main > .admin-embedded-grid {
+    @apply w-full max-w-none;
+  }
+
+  body.admin-embedded .admin-embedded-main > .admin-embedded-grid > * {
+    @apply w-full max-w-none;
+  }
+
   body.admin-embedded .admin-embedded-grid {
     @apply gap-4;
   }

--- a/src/input.css
+++ b/src/input.css
@@ -1206,7 +1206,7 @@
   }
 
   body.admin-embedded main {
-    @apply mx-0 w-full max-w-full px-0 pt-3 pb-6;
+    @apply mx-0 w-full max-w-full px-0 pt-1 pb-4;
   }
 
   body.admin-embedded main.container {
@@ -1214,7 +1214,7 @@
   }
 
   body.admin-embedded .admin-embedded-main {
-    @apply w-full max-w-none px-4 sm:px-6 lg:px-8 pt-6 pb-10 min-h-screen;
+    @apply w-full max-w-none px-2 sm:px-3 lg:px-4 pt-3 pb-6 min-h-screen;
   }
 
   body.admin-embedded .admin-embedded-main > .admin-embedded-grid {
@@ -1226,7 +1226,7 @@
   }
 
   body.admin-embedded .admin-embedded-grid {
-    @apply gap-4;
+    @apply gap-3;
   }
 
   body.admin-embedded .admin-tab-iframe-wrapper {

--- a/src/output.css
+++ b/src/output.css
@@ -5325,8 +5325,8 @@
     width: 100%;
     max-width: 100%;
     padding-inline: calc(var(--spacing) * 0);
-    padding-top: calc(var(--spacing) * 3);
-    padding-bottom: calc(var(--spacing) * 6);
+    padding-top: calc(var(--spacing) * 1);
+    padding-bottom: calc(var(--spacing) * 4);
   }
   body.admin-embedded main.container {
     max-width: none;
@@ -5335,14 +5335,14 @@
     min-height: 100vh;
     width: 100%;
     max-width: none;
-    padding-inline: calc(var(--spacing) * 4);
-    padding-top: calc(var(--spacing) * 6);
-    padding-bottom: calc(var(--spacing) * 10);
+    padding-inline: calc(var(--spacing) * 2);
+    padding-top: calc(var(--spacing) * 3);
+    padding-bottom: calc(var(--spacing) * 6);
     @media (width >= 40rem) {
-      padding-inline: calc(var(--spacing) * 6);
+      padding-inline: calc(var(--spacing) * 3);
     }
     @media (width >= 64rem) {
-      padding-inline: calc(var(--spacing) * 8);
+      padding-inline: calc(var(--spacing) * 4);
     }
   }
   body.admin-embedded .admin-embedded-main > .admin-embedded-grid {
@@ -5354,7 +5354,7 @@
     max-width: none;
   }
   body.admin-embedded .admin-embedded-grid {
-    gap: calc(var(--spacing) * 4);
+    gap: calc(var(--spacing) * 3);
   }
   body.admin-embedded .admin-tab-iframe-wrapper {
     background-color: transparent;

--- a/src/output.css
+++ b/src/output.css
@@ -5320,29 +5320,32 @@
   body.admin-embedded {
     background-color: transparent;
   }
+  body.admin-embedded {
+    min-height: 100vh;
+  }
   body.admin-embedded main {
     margin-inline: calc(var(--spacing) * 0);
     width: 100%;
-    max-width: 100%;
+    max-width: none;
     padding-inline: calc(var(--spacing) * 0);
-    padding-top: calc(var(--spacing) * 1);
-    padding-bottom: calc(var(--spacing) * 4);
+    padding-top: calc(var(--spacing) * 0);
+    padding-bottom: calc(var(--spacing) * 3);
   }
   body.admin-embedded main.container {
     max-width: none;
   }
   body.admin-embedded .admin-embedded-main {
-    min-height: 100vh;
+    min-height: calc(100vh - 1rem);
     width: 100%;
     max-width: none;
-    padding-inline: calc(var(--spacing) * 2);
-    padding-top: calc(var(--spacing) * 3);
-    padding-bottom: calc(var(--spacing) * 6);
+    padding-inline: calc(var(--spacing) * 1.5);
+    padding-top: calc(var(--spacing) * 1.5);
+    padding-bottom: calc(var(--spacing) * 4);
     @media (width >= 40rem) {
-      padding-inline: calc(var(--spacing) * 3);
+      padding-inline: calc(var(--spacing) * 2);
     }
     @media (width >= 64rem) {
-      padding-inline: calc(var(--spacing) * 4);
+      padding-inline: calc(var(--spacing) * 3);
     }
   }
   body.admin-embedded .admin-embedded-main > .admin-embedded-grid {
@@ -5354,7 +5357,10 @@
     max-width: none;
   }
   body.admin-embedded .admin-embedded-grid {
-    gap: calc(var(--spacing) * 3);
+    gap: calc(var(--spacing) * 2);
+    @media (width >= 40rem) {
+      gap: calc(var(--spacing) * 3);
+    }
   }
   body.admin-embedded .admin-tab-iframe-wrapper {
     background-color: transparent;

--- a/src/output.css
+++ b/src/output.css
@@ -5363,18 +5363,19 @@
     }
   }
   body.admin-embedded .admin-tab-iframe-wrapper {
+    overflow: visible;
     background-color: transparent;
   }
   body.admin-embedded[data-admin-tabs-root] {
-    height: 100%;
+    min-height: calc(var(--spacing) * 0);
   }
   .admin-tab-panel {
-    height: 100%;
+    min-height: calc(var(--spacing) * 0);
   }
   .admin-tab-iframe {
     display: block;
     width: 100%;
-    height: 100%;
+    height: auto;
     min-height: 0;
     border: 0;
   }

--- a/src/output.css
+++ b/src/output.css
@@ -5331,6 +5331,28 @@
   body.admin-embedded main.container {
     max-width: none;
   }
+  body.admin-embedded .admin-embedded-main {
+    min-height: 100vh;
+    width: 100%;
+    max-width: none;
+    padding-inline: calc(var(--spacing) * 4);
+    padding-top: calc(var(--spacing) * 6);
+    padding-bottom: calc(var(--spacing) * 10);
+    @media (width >= 40rem) {
+      padding-inline: calc(var(--spacing) * 6);
+    }
+    @media (width >= 64rem) {
+      padding-inline: calc(var(--spacing) * 8);
+    }
+  }
+  body.admin-embedded .admin-embedded-main > .admin-embedded-grid {
+    width: 100%;
+    max-width: none;
+  }
+  body.admin-embedded .admin-embedded-main > .admin-embedded-grid > * {
+    width: 100%;
+    max-width: none;
+  }
   body.admin-embedded .admin-embedded-grid {
     gap: calc(var(--spacing) * 4);
   }


### PR DESCRIPTION
## Summary
- remove classes de container ao carregar páginas administrativas embutidas em iframes
- adiciona estilos específicos para manter largura total e altura mínima nas telas embedadas
- recompila o CSS para refletir os novos utilitários de layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd969a307c8323b9322dfb588acfd4