### PR TITLE
Compact PDV appointment import filter UI

### DIFF
--- a/pages/admin/admin-pdv.html
+++ b/pages/admin/admin-pdv.html
@@ -10,41 +10,41 @@
 <body class="bg-gray-100">
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 min-h-screen">
+    <main class="container mx-auto px-4 py-6 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>
             </aside>
 
             <div class="md:col-span-4 space-y-6">
-                <section class="bg-white border border-gray-100 rounded-xl shadow-sm p-6 space-y-6">
-                    <div class="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
-                        <div>
-                            <h1 class="text-2xl font-bold text-gray-800">PDV</h1>
-                            <p class="text-sm text-gray-600">Selecione a empresa e o ponto de venda para operar o caixa.</p>
+                <section class="bg-white border border-gray-100 rounded-xl shadow-sm p-4 space-y-4">
+                    <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                        <div class="flex flex-col gap-1">
+                            <h1 class="text-xl font-semibold text-gray-800">PDV</h1>
+                            <p class="text-xs text-gray-600">Selecione a empresa e o ponto de venda para operar o caixa.</p>
                         </div>
-                        <div class="flex items-center gap-3 text-xs text-gray-500">
-                            <i class="fas fa-cash-register text-primary"></i>
-                            <span>Movimentação registrada diretamente no PDV</span>
+                        <div class="flex items-center gap-2 rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-[11px] text-gray-500">
+                            <i class="fas fa-cash-register text-primary text-xs"></i>
+                            <span class="font-medium uppercase tracking-wide">Movimentação direta no PDV</span>
                         </div>
                     </div>
 
-                    <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
-                        <div>
-                            <label for="company-select" class="block text-sm font-semibold text-gray-700 mb-1">Empresa</label>
-                            <select id="company-select" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
+                    <div class="grid grid-cols-1 gap-3 lg:grid-cols-2">
+                        <div class="space-y-1">
+                            <label for="company-select" class="block text-[13px] font-semibold text-gray-700">Empresa</label>
+                            <select id="company-select" class="w-full rounded-lg border border-gray-200 px-3 py-1.5 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
                                 <option value="">Selecione uma empresa</option>
                             </select>
                         </div>
-                        <div>
-                            <label for="pdv-select" class="block text-sm font-semibold text-gray-700 mb-1">PDV</label>
-                            <select id="pdv-select" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" disabled>
+                        <div class="space-y-1">
+                            <label for="pdv-select" class="block text-[13px] font-semibold text-gray-700">PDV</label>
+                            <select id="pdv-select" class="w-full rounded-lg border border-gray-200 px-3 py-1.5 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" disabled>
                                 <option value="">Selecione um PDV</option>
                             </select>
                         </div>
                     </div>
 
-                    <p id="pdv-selection-hint" class="text-xs text-gray-500">Escolha a empresa para carregar os PDVs disponíveis.</p>
+                    <p id="pdv-selection-hint" class="text-[11px] text-gray-500">Escolha a empresa para carregar os PDVs disponíveis.</p>
                 </section>
 
                 <section class="bg-white border border-gray-100 rounded-xl shadow-sm p-6 space-y-6">

--- a/pages/admin/admin-pdv.html
+++ b/pages/admin/admin-pdv.html
@@ -16,9 +16,9 @@
                 <div id="admin-sidebar-placeholder"></div>
             </aside>
 
-            <div class="md:col-span-4 space-y-6">
-                <section class="bg-white border border-gray-100 rounded-xl shadow-sm p-4 space-y-4">
-                    <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div class="md:col-span-4 space-y-4">
+                <section class="bg-white border border-gray-100 rounded-xl shadow-sm p-4 space-y-3">
+                    <div class="flex flex-col gap-2.5 lg:flex-row lg:items-center lg:justify-between">
                         <div class="flex flex-col gap-1">
                             <h1 class="text-xl font-semibold text-gray-800">PDV</h1>
                             <p class="text-xs text-gray-600">Selecione a empresa e o ponto de venda para operar o caixa.</p>
@@ -29,7 +29,7 @@
                         </div>
                     </div>
 
-                    <div class="grid grid-cols-1 gap-3 lg:grid-cols-2">
+                    <div class="grid grid-cols-1 gap-2.5 lg:grid-cols-2">
                         <div class="space-y-1">
                             <label for="company-select" class="block text-[13px] font-semibold text-gray-700">Empresa</label>
                             <select id="company-select" class="w-full rounded-lg border border-gray-200 px-3 py-1.5 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">

--- a/pages/admin/admin-pdv.html
+++ b/pages/admin/admin-pdv.html
@@ -559,35 +559,31 @@
             </div>
             <div class="flex-1 overflow-y-auto px-6 py-5">
                 <div class="space-y-4">
-                    <div id="pdv-appointment-presets" class="grid gap-3 sm:grid-cols-3">
-                        <button type="button" class="flex flex-col items-start gap-1 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-left transition hover:border-primary hover:bg-primary/5" data-appointment-preset="today">
-                            <span class="text-xs font-semibold uppercase tracking-wide text-gray-500">Hoje</span>
-                            <span id="pdv-appointment-kpi-today" class="text-2xl font-semibold text-gray-800">0</span>
-                        </button>
-                        <button type="button" class="flex flex-col items-start gap-1 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-left transition hover:border-primary hover:bg-primary/5" data-appointment-preset="week">
-                            <span class="text-xs font-semibold uppercase tracking-wide text-gray-500">Semana</span>
-                            <span id="pdv-appointment-kpi-week" class="text-2xl font-semibold text-gray-800">0</span>
-                        </button>
-                        <button type="button" class="flex flex-col items-start gap-1 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-left transition hover:border-primary hover:bg-primary/5" data-appointment-preset="month">
-                            <span class="text-xs font-semibold uppercase tracking-wide text-gray-500">Mês</span>
-                            <span id="pdv-appointment-kpi-month" class="text-2xl font-semibold text-gray-800">0</span>
-                        </button>
-                    </div>
-                    <div class="flex flex-col gap-3 rounded-xl border border-gray-200 bg-gray-50 p-4 sm:flex-row sm:items-end sm:justify-between">
-                        <div class="grid flex-1 grid-cols-1 gap-3 sm:grid-cols-2">
-                            <label class="flex flex-col gap-1 text-sm font-medium text-gray-700" for="pdv-appointment-start">
-                                Início do período
-                                <input id="pdv-appointment-start" type="date" class="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
+                    <div class="rounded-xl border border-gray-200 bg-gray-50 p-4">
+                        <div id="pdv-appointment-presets" class="flex flex-wrap items-center gap-2">
+                            <button type="button" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-semibold text-gray-600 transition hover:border-primary hover:text-primary" data-appointment-preset="today">
+                                Hoje
+                            </button>
+                            <button type="button" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-semibold text-gray-600 transition hover:border-primary hover:text-primary" data-appointment-preset="week">
+                                Semana
+                            </button>
+                            <button type="button" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-semibold text-gray-600 transition hover:border-primary hover:text-primary" data-appointment-preset="month">
+                                Mês
+                            </button>
+                            <span class="hidden h-4 w-px bg-gray-300 sm:inline-block"></span>
+                            <label class="flex items-center gap-2 text-sm font-medium text-gray-700" for="pdv-appointment-start">
+                                <span class="text-xs font-semibold uppercase tracking-wide text-gray-500">Início</span>
+                                <input id="pdv-appointment-start" type="date" class="w-32 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
                             </label>
-                            <label class="flex flex-col gap-1 text-sm font-medium text-gray-700" for="pdv-appointment-end">
-                                Fim do período
-                                <input id="pdv-appointment-end" type="date" class="rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
+                            <label class="flex items-center gap-2 text-sm font-medium text-gray-700" for="pdv-appointment-end">
+                                <span class="text-xs font-semibold uppercase tracking-wide text-gray-500">Fim</span>
+                                <input id="pdv-appointment-end" type="date" class="w-32 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
                             </label>
+                            <button type="button" id="pdv-appointment-apply" class="inline-flex items-center gap-2 rounded-full bg-primary px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-secondary">
+                                <i class="fas fa-filter"></i>
+                                <span>Aplicar</span>
+                            </button>
                         </div>
-                        <button type="button" id="pdv-appointment-apply" class="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-secondary">
-                            <i class="fas fa-filter"></i>
-                            <span>Aplicar período</span>
-                        </button>
                     </div>
                     <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                         <p id="pdv-appointment-count" class="text-sm text-gray-600">0 atendimentos encontrados.</p>

--- a/pages/admin/admin-pdv.html
+++ b/pages/admin/admin-pdv.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-6 min-h-screen">
+    <main class="container mx-auto px-4 pt-3 pb-6 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-pdv.html
+++ b/pages/admin/admin-pdv.html
@@ -557,48 +557,52 @@
                     <i class="fas fa-times"></i>
                 </button>
             </div>
-            <div class="flex-1 overflow-y-auto px-6 py-5">
-                <div class="space-y-4">
-                    <div class="rounded-xl border border-gray-200 bg-gray-50 p-4">
-                        <div id="pdv-appointment-presets" class="flex flex-wrap items-center gap-2">
-                            <button type="button" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-semibold text-gray-600 transition hover:border-primary hover:text-primary" data-appointment-preset="today">
-                                Hoje
-                            </button>
-                            <button type="button" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-semibold text-gray-600 transition hover:border-primary hover:text-primary" data-appointment-preset="week">
-                                Semana
-                            </button>
-                            <button type="button" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-semibold text-gray-600 transition hover:border-primary hover:text-primary" data-appointment-preset="month">
-                                Mês
-                            </button>
-                            <span class="hidden h-4 w-px bg-gray-300 sm:inline-block"></span>
-                            <label class="flex items-center gap-2 text-sm font-medium text-gray-700" for="pdv-appointment-start">
-                                <span class="text-xs font-semibold uppercase tracking-wide text-gray-500">Início</span>
-                                <input id="pdv-appointment-start" type="date" class="w-32 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
-                            </label>
-                            <label class="flex items-center gap-2 text-sm font-medium text-gray-700" for="pdv-appointment-end">
-                                <span class="text-xs font-semibold uppercase tracking-wide text-gray-500">Fim</span>
-                                <input id="pdv-appointment-end" type="date" class="w-32 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
-                            </label>
-                            <button type="button" id="pdv-appointment-apply" class="inline-flex items-center gap-2 rounded-full bg-primary px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-secondary">
-                                <i class="fas fa-filter"></i>
-                                <span>Aplicar</span>
-                            </button>
+            <div class="flex-1 overflow-y-auto" data-appointment-scroll-container>
+                <div class="sticky top-0 z-10 border-b border-gray-100 bg-white/95 px-6 py-5 shadow-sm supports-[backdrop-filter]:backdrop-blur-sm">
+                    <div class="space-y-4">
+                        <div class="rounded-xl border border-gray-200 bg-gray-50 p-4">
+                            <div id="pdv-appointment-presets" class="flex flex-wrap items-center gap-2">
+                                <button type="button" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-semibold text-gray-600 transition hover:border-primary hover:text-primary" data-appointment-preset="today">
+                                    Hoje
+                                </button>
+                                <button type="button" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-semibold text-gray-600 transition hover:border-primary hover:text-primary" data-appointment-preset="week">
+                                    Semana
+                                </button>
+                                <button type="button" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-semibold text-gray-600 transition hover:border-primary hover:text-primary" data-appointment-preset="month">
+                                    Mês
+                                </button>
+                                <span class="hidden h-4 w-px bg-gray-300 sm:inline-block"></span>
+                                <label class="flex items-center gap-2 text-sm font-medium text-gray-700" for="pdv-appointment-start">
+                                    <span class="text-xs font-semibold uppercase tracking-wide text-gray-500">Início</span>
+                                    <input id="pdv-appointment-start" type="date" class="w-32 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
+                                </label>
+                                <label class="flex items-center gap-2 text-sm font-medium text-gray-700" for="pdv-appointment-end">
+                                    <span class="text-xs font-semibold uppercase tracking-wide text-gray-500">Fim</span>
+                                    <input id="pdv-appointment-end" type="date" class="w-32 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
+                                </label>
+                                <button type="button" id="pdv-appointment-apply" class="inline-flex items-center gap-2 rounded-full bg-primary px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-secondary">
+                                    <i class="fas fa-filter"></i>
+                                    <span>Aplicar</span>
+                                </button>
+                            </div>
                         </div>
-                    </div>
-                    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                        <p id="pdv-appointment-count" class="text-sm text-gray-600">0 atendimentos encontrados.</p>
-                        <div class="flex items-center gap-2">
-                            <button type="button" id="pdv-appointment-reload" class="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-semibold text-gray-600 transition hover:border-primary hover:text-primary">
-                                <i class="fas fa-rotate"></i>
-                                <span>Atualizar lista</span>
-                            </button>
+                        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                            <p id="pdv-appointment-count" class="text-sm text-gray-600">0 atendimentos encontrados.</p>
+                            <div class="flex items-center gap-2">
+                                <button type="button" id="pdv-appointment-reload" class="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-semibold text-gray-600 transition hover:border-primary hover:text-primary">
+                                    <i class="fas fa-rotate"></i>
+                                    <span>Atualizar lista</span>
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </div>
-                <div class="mt-5 space-y-3">
-                    <div id="pdv-appointment-loading" class="hidden rounded-xl border border-dashed border-gray-300 bg-white px-4 py-4 text-sm text-gray-500">Carregando atendimentos da agenda...</div>
-                    <div id="pdv-appointment-empty" class="hidden rounded-xl border border-dashed border-gray-300 bg-white px-4 py-4 text-sm text-gray-500">Nenhum atendimento encontrado para o período selecionado.</div>
-                    <div id="pdv-appointment-list" class="space-y-3"></div>
+                <div class="px-6 py-5">
+                    <div class="space-y-3">
+                        <div id="pdv-appointment-loading" class="hidden rounded-xl border border-dashed border-gray-300 bg-white px-4 py-4 text-sm text-gray-500">Carregando atendimentos da agenda...</div>
+                        <div id="pdv-appointment-empty" class="hidden rounded-xl border border-dashed border-gray-300 bg-white px-4 py-4 text-sm text-gray-500">Nenhum atendimento encontrado para o período selecionado.</div>
+                        <div id="pdv-appointment-list" class="space-y-3"></div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/scripts/admin/admin-pdv.js
+++ b/scripts/admin/admin-pdv.js
@@ -1891,9 +1891,6 @@
       elements.appointmentModal?.querySelector('[data-appointment-dismiss="backdrop"]') || null;
     elements.appointmentClose = document.getElementById('pdv-appointment-close');
     elements.appointmentPresets = document.getElementById('pdv-appointment-presets');
-    elements.appointmentKpiToday = document.getElementById('pdv-appointment-kpi-today');
-    elements.appointmentKpiWeek = document.getElementById('pdv-appointment-kpi-week');
-    elements.appointmentKpiMonth = document.getElementById('pdv-appointment-kpi-month');
     elements.appointmentStart = document.getElementById('pdv-appointment-start');
     elements.appointmentEnd = document.getElementById('pdv-appointment-end');
     elements.appointmentApply = document.getElementById('pdv-appointment-apply');
@@ -7351,7 +7348,6 @@
     const storeId = getActiveAppointmentStoreId();
     if (!storeId) {
       state.appointmentMetrics = { today: 0, week: 0, month: 0 };
-      renderAppointmentMetrics();
       return;
     }
     const presets = ['today', 'week', 'month'];
@@ -7370,7 +7366,6 @@
         console.error('Erro ao atualizar indicadores de atendimentos:', error);
       }
     }
-    renderAppointmentMetrics();
   };
   const renderAppointmentFilters = () => {
     const filters = state.appointmentFilters || { preset: 'today', start: '', end: '' };
@@ -7381,9 +7376,10 @@
         const isActive = preset === filters.preset && preset !== 'custom';
         button.classList.toggle('border-primary', isActive);
         button.classList.toggle('text-primary', isActive);
-        button.classList.toggle('bg-primary/5', isActive);
+        button.classList.toggle('bg-primary/10', isActive);
         button.classList.toggle('border-gray-200', !isActive);
-        button.classList.toggle('bg-gray-50', !isActive);
+        button.classList.toggle('bg-white', !isActive);
+        button.classList.toggle('text-gray-600', !isActive);
       });
     }
     if (elements.appointmentStart) {
@@ -7396,17 +7392,6 @@
       const count = state.appointments.length;
       const label = count === 1 ? '1 atendimento encontrado.' : `${count} atendimentos encontrados.`;
       elements.appointmentCount.textContent = label;
-    }
-  };
-  const renderAppointmentMetrics = () => {
-    if (elements.appointmentKpiToday) {
-      elements.appointmentKpiToday.textContent = String(state.appointmentMetrics.today || 0);
-    }
-    if (elements.appointmentKpiWeek) {
-      elements.appointmentKpiWeek.textContent = String(state.appointmentMetrics.week || 0);
-    }
-    if (elements.appointmentKpiMonth) {
-      elements.appointmentKpiMonth.textContent = String(state.appointmentMetrics.month || 0);
     }
   };
   const renderAppointmentList = () => {
@@ -7524,7 +7509,6 @@
   };
   const renderAppointments = () => {
     renderAppointmentFilters();
-    renderAppointmentMetrics();
     renderAppointmentList();
   };
   const openAppointmentModal = async () => {

--- a/src/output.css
+++ b/src/output.css
@@ -1839,6 +1839,12 @@
       background-color: color-mix(in oklab, var(--color-white) 90%, transparent);
     }
   }
+  .bg-white\/95 {
+    background-color: color-mix(in srgb, #fff 95%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 95%, transparent);
+    }
+  }
   .bg-yellow-50 {
     background-color: var(--color-yellow-50);
   }
@@ -3642,6 +3648,13 @@
       }
     }
   }
+  .supports-\[backdrop-filter\]\:backdrop-blur-sm {
+    @supports (backdrop-filter: var(--tw)) {
+      --tw-backdrop-blur: blur(var(--blur-sm));
+      -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+      backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    }
+  }
   .sm\:col-span-1 {
     @media (width >= 40rem) {
       grid-column: span 1 / span 1;
@@ -3660,6 +3673,11 @@
   .sm\:inline {
     @media (width >= 40rem) {
       display: inline;
+    }
+  }
+  .sm\:inline-block {
+    @media (width >= 40rem) {
+      display: inline-block;
     }
   }
   .sm\:w-64 {
@@ -3700,11 +3718,6 @@
   .sm\:items-center {
     @media (width >= 40rem) {
       align-items: center;
-    }
-  }
-  .sm\:items-end {
-    @media (width >= 40rem) {
-      align-items: flex-end;
     }
   }
   .sm\:items-start {

--- a/src/output.css
+++ b/src/output.css
@@ -1183,6 +1183,9 @@
   .gap-2 {
     gap: calc(var(--spacing) * 2);
   }
+  .gap-2\.5 {
+    gap: calc(var(--spacing) * 2.5);
+  }
   .gap-3 {
     gap: calc(var(--spacing) * 3);
   }


### PR DESCRIPTION
## Summary
- condense the PDV appointment import filter into a compact toolbar with quick preset tags and inline date selectors
- remove KPI counters and update preset styling so active tags are highlighted without numeric badges

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd9ef613008323a1a192f8795826f1