### PR TITLE
Reduce spacing between headers and page titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         </div>
     </div>
 
-    <main class="pt-[150px]">
+    <main data-header-offset="site">
 
     <div class="bg-gray-200 text-black text-center py-3 text-sm">
         <p>Frete grátis para compras acima de R$ 100,00</p>

--- a/pages/admin.html
+++ b/pages/admin.html
@@ -12,7 +12,7 @@
 
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
             <aside class="md:col-span-4">

--- a/pages/admin.html
+++ b/pages/admin.html
@@ -12,7 +12,7 @@
 
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
             <aside class="md:col-span-4">

--- a/pages/admin/admin-cadastro-pdv.html
+++ b/pages/admin/admin-cadastro-pdv.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-cadastro-pdv.html
+++ b/pages/admin/admin-cadastro-pdv.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-categorias.html
+++ b/pages/admin/admin-categorias.html
@@ -10,7 +10,7 @@
 </head>
 <body class="bg-gray-100">
     <div id="admin-header-placeholder"></div>
-    <main class="container mx-auto px-4 py-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-categorias.html
+++ b/pages/admin/admin-categorias.html
@@ -10,7 +10,7 @@
 </head>
 <body class="bg-gray-100">
     <div id="admin-header-placeholder"></div>
-    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-depositos.html
+++ b/pages/admin/admin-depositos.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-depositos.html
+++ b/pages/admin/admin-depositos.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-destaques.html
+++ b/pages/admin/admin-destaques.html
@@ -12,7 +12,7 @@
 
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
             <aside class="md:col-span-4">

--- a/pages/admin/admin-destaques.html
+++ b/pages/admin/admin-destaques.html
@@ -12,7 +12,7 @@
 
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
             <aside class="md:col-span-4">

--- a/pages/admin/admin-empresa-configuracoes-pdv.html
+++ b/pages/admin/admin-empresa-configuracoes-pdv.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-empresa-configuracoes-pdv.html
+++ b/pages/admin/admin-empresa-configuracoes-pdv.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-entregas.html
+++ b/pages/admin/admin-entregas.html
@@ -13,7 +13,7 @@
 
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-entregas.html
+++ b/pages/admin/admin-entregas.html
@@ -13,7 +13,7 @@
 
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-financeiro-meios-pagamento.html
+++ b/pages/admin/admin-financeiro-meios-pagamento.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
       <aside class="md:col-span-4">
         <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-financeiro-meios-pagamento.html
+++ b/pages/admin/admin-financeiro-meios-pagamento.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 py-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
       <aside class="md:col-span-4">
         <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-fiscal-icms-simples.html
+++ b/pages/admin/admin-fiscal-icms-simples.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
       <aside class="md:col-span-4">
         <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-fiscal-icms-simples.html
+++ b/pages/admin/admin-fiscal-icms-simples.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 py-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
       <aside class="md:col-span-4">
         <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-fiscal-regras.html
+++ b/pages/admin/admin-fiscal-regras.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-fiscal-regras.html
+++ b/pages/admin/admin-fiscal-regras.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-gerir-funcionarios.html
+++ b/pages/admin/admin-gerir-funcionarios.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
       <aside class="md:col-span-4">
         <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-gerir-funcionarios.html
+++ b/pages/admin/admin-gerir-funcionarios.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 py-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
       <aside class="md:col-span-4">
         <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-importar.html
+++ b/pages/admin/admin-importar.html
@@ -12,7 +12,7 @@
 
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-importar.html
+++ b/pages/admin/admin-importar.html
@@ -12,7 +12,7 @@
 
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-nossas-lojas.html
+++ b/pages/admin/admin-nossas-lojas.html
@@ -13,7 +13,7 @@
 
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-nossas-lojas.html
+++ b/pages/admin/admin-nossas-lojas.html
@@ -13,7 +13,7 @@
 
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-pdv.html
+++ b/pages/admin/admin-pdv.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 pt-2 pb-6 min-h-screen">
+    <main class="container mx-auto px-4 pt-1 pb-6 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-pdv.html
+++ b/pages/admin/admin-pdv.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 pt-3 pb-6 min-h-screen">
+    <main class="container mx-auto px-4 pt-2 pb-6 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-4">
                 <div id="admin-sidebar-placeholder"></div>

--- a/pages/admin/admin-produto-editar.html
+++ b/pages/admin/admin-produto-editar.html
@@ -12,7 +12,7 @@
 
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
             <aside class="md:col-span-4">

--- a/pages/admin/admin-produto-editar.html
+++ b/pages/admin/admin-produto-editar.html
@@ -12,7 +12,7 @@
 
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
             <aside class="md:col-span-4">

--- a/pages/admin/admin-produtos.html
+++ b/pages/admin/admin-produtos.html
@@ -11,7 +11,7 @@
 
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
             <aside class="md:col-span-4">

--- a/pages/admin/admin-produtos.html
+++ b/pages/admin/admin-produtos.html
@@ -11,7 +11,7 @@
 
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
             <aside class="md:col-span-4">

--- a/pages/admin/admin-promocoes.html
+++ b/pages/admin/admin-promocoes.html
@@ -12,7 +12,7 @@
 
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
             <aside class="md:col-span-4">

--- a/pages/admin/admin-promocoes.html
+++ b/pages/admin/admin-promocoes.html
@@ -12,7 +12,7 @@
 
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+    <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
             <aside class="md:col-span-4">

--- a/pages/admin/admin-servicos-grupos.html
+++ b/pages/admin/admin-servicos-grupos.html
@@ -12,7 +12,7 @@
   <!-- Header Admin -->
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 py-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
       <!-- Barra Admin horizontal -->
       <aside class="md:col-span-4">

--- a/pages/admin/admin-servicos-grupos.html
+++ b/pages/admin/admin-servicos-grupos.html
@@ -12,7 +12,7 @@
   <!-- Header Admin -->
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
       <!-- Barra Admin horizontal -->
       <aside class="md:col-span-4">

--- a/pages/admin/admin-servicos.html
+++ b/pages/admin/admin-servicos.html
@@ -12,7 +12,7 @@
   <!-- Header Admin -->
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 py-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
       <!-- Barra Admin horizontal -->
       <aside class="md:col-span-4">

--- a/pages/admin/admin-servicos.html
+++ b/pages/admin/admin-servicos.html
@@ -12,7 +12,7 @@
   <!-- Header Admin -->
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
       <!-- Barra Admin horizontal -->
       <aside class="md:col-span-4">

--- a/pages/ajuda.html
+++ b/pages/ajuda.html
@@ -25,7 +25,7 @@
         </div>
     </div>
 
-    <main class="container mx-auto px-4 py-8 pt-[150px]">
+    <main class="container mx-auto px-4 pb-8" data-header-offset="site">
         <div class="container mx-auto px-4">
 
             <section class="text-center mb-10">

--- a/pages/alterar-senha.html
+++ b/pages/alterar-senha.html
@@ -17,7 +17,7 @@
   <!-- Cabeçalho (injetado por main.js) -->
   <div id="header-placeholder"></div>
 
-  <main class="container mx-auto px-4 py-8 pt-[200px]">
+  <main class="container mx-auto px-4 pb-8" data-header-offset="site">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
       <!-- Sidebar -->

--- a/pages/favoritos.html
+++ b/pages/favoritos.html
@@ -12,7 +12,7 @@
 
     <div id="header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 pt-[200px]">
+    <main class="container mx-auto px-4 pb-8" data-header-offset="site">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
             <aside class="md:col-span-1">
                 <div id="account-sidebar-placeholder"></div>

--- a/pages/funcionarios/banho-e-tosa.html
+++ b/pages/funcionarios/banho-e-tosa.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 py-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
       <aside class="md:col-span-4">

--- a/pages/funcionarios/banho-e-tosa.html
+++ b/pages/funcionarios/banho-e-tosa.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
       <aside class="md:col-span-4">

--- a/pages/funcionarios/clientes.html
+++ b/pages/funcionarios/clientes.html
@@ -11,7 +11,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 py-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
       <aside class="md:col-span-4">

--- a/pages/funcionarios/clientes.html
+++ b/pages/funcionarios/clientes.html
@@ -11,7 +11,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
       <aside class="md:col-span-4">

--- a/pages/funcionarios/comissoes.html
+++ b/pages/funcionarios/comissoes.html
@@ -11,7 +11,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 py-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
       <aside class="md:col-span-4">

--- a/pages/funcionarios/comissoes.html
+++ b/pages/funcionarios/comissoes.html
@@ -11,7 +11,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
       <aside class="md:col-span-4">

--- a/pages/funcionarios/vet-assinatura.html
+++ b/pages/funcionarios/vet-assinatura.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 py-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
       <aside class="md:col-span-4">

--- a/pages/funcionarios/vet-assinatura.html
+++ b/pages/funcionarios/vet-assinatura.html
@@ -10,7 +10,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
       <aside class="md:col-span-4">

--- a/pages/funcionarios/vet-documentos.html
+++ b/pages/funcionarios/vet-documentos.html
@@ -242,7 +242,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
       <aside class="md:col-span-4">

--- a/pages/funcionarios/vet-documentos.html
+++ b/pages/funcionarios/vet-documentos.html
@@ -242,7 +242,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 py-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
       <aside class="md:col-span-4">

--- a/pages/funcionarios/vet-ficha-clinica.html
+++ b/pages/funcionarios/vet-ficha-clinica.html
@@ -12,7 +12,7 @@
 <body class="bg-gray-100">
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-6 min-h-screen">
+    <main class="container mx-auto px-4 pt-3 pb-6 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-6 lg:gap-8">
 
             <aside class="md:col-span-4">

--- a/pages/funcionarios/vet-ficha-clinica.html
+++ b/pages/funcionarios/vet-ficha-clinica.html
@@ -12,7 +12,7 @@
 <body class="bg-gray-100">
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 pt-3 pb-6 min-h-screen">
+    <main class="container mx-auto px-4 pt-1 pb-6 min-h-screen">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-6 lg:gap-8">
 
             <aside class="md:col-span-4">

--- a/pages/funcionarios/vet-receitas.html
+++ b/pages/funcionarios/vet-receitas.html
@@ -242,7 +242,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
       <aside class="md:col-span-4">

--- a/pages/funcionarios/vet-receitas.html
+++ b/pages/funcionarios/vet-receitas.html
@@ -242,7 +242,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 py-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
       <aside class="md:col-span-4">

--- a/pages/funcionarios/veterinario.html
+++ b/pages/funcionarios/veterinario.html
@@ -11,7 +11,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 py-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
       <aside class="md:col-span-4">

--- a/pages/funcionarios/veterinario.html
+++ b/pages/funcionarios/veterinario.html
@@ -11,7 +11,7 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 pt-4 pb-8 min-h-screen">
+  <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
       <aside class="md:col-span-4">

--- a/pages/menu-departments-item/product.html
+++ b/pages/menu-departments-item/product.html
@@ -11,7 +11,7 @@
 
     <div id="header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 pt-[200px]">
+    <main class="container mx-auto px-4 pb-8" data-header-offset="site">
 
         <nav class="mb-6 text-sm" aria-label="Breadcrumb">
             <ol id="breadcrumb-container" class="list-none p-0 inline-flex items-center space-x-2 text-gray-600">

--- a/pages/menu-departments-item/search.html
+++ b/pages/menu-departments-item/search.html
@@ -11,7 +11,7 @@
 
     <div id="header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 pt-[200px]">
+    <main class="container mx-auto px-4 pb-8" data-header-offset="site">
         
         <nav class="mb-4 text-sm" aria-label="Breadcrumb">
             <ol id="breadcrumb-container" class="list-none p-0 inline-flex items-center space-x-2">

--- a/pages/meus-dados.html
+++ b/pages/meus-dados.html
@@ -12,7 +12,7 @@
 
     <div id="header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 pt-[200px]">
+    <main class="container mx-auto px-4 pb-8" data-header-offset="site">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
             <aside class="md:col-span-1">

--- a/pages/meus-pedidos.html
+++ b/pages/meus-pedidos.html
@@ -12,7 +12,7 @@
 
     <div id="header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 pt-[200px]">
+    <main class="container mx-auto px-4 pb-8" data-header-offset="site">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
             <aside class="md:col-span-1">

--- a/pages/meus-pets.html
+++ b/pages/meus-pets.html
@@ -13,7 +13,7 @@
 
     <div id="header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 pt-[200px]">
+    <main class="container mx-auto px-4 pb-8" data-header-offset="site">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
             <aside class="md:col-span-1">

--- a/pages/nossas-lojas.html
+++ b/pages/nossas-lojas.html
@@ -11,7 +11,7 @@
 
     <div id="header-placeholder"></div>
 
-    <main class="container mx-auto px-4 py-8 pt-[200px]">
+    <main class="container mx-auto px-4 pb-8" data-header-offset="site">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
 
             <aside class="md:col-span-1">

--- a/pages/resetar-senha.html
+++ b/pages/resetar-senha.html
@@ -3,7 +3,7 @@
 <title>Redefinir Senha</title><link rel="stylesheet" href="../src/output.css">
 </head><body class="bg-gray-100">
 <div id="header-placeholder"></div>
-<main class="container mx-auto px-4 py-24">
+<main class="container mx-auto px-4 pb-24" data-header-offset="site">
   <div class="bg-white p-8 rounded-xl shadow max-w-md mx-auto">
     <h1 class="text-xl font-semibold mb-6 text-center">Defina sua nova senha</h1>
     <form id="form-reset" class="space-y-4">

--- a/pages/verificar-email.html
+++ b/pages/verificar-email.html
@@ -3,7 +3,7 @@
 <title>Verificar e-mail</title><link rel="stylesheet" href="../src/output.css">
 </head><body class="bg-gray-100">
 <div id="header-placeholder"></div>
-<main class="container mx-auto px-4 py-24 text-center">
+<main class="container mx-auto px-4 pb-24 text-center" data-header-offset="site">
   <div class="bg-white p-8 rounded-xl shadow max-w-xl mx-auto">
     <h1 class="text-xl font-semibold mb-2">Verificar e-mail</h1>
     <p id="msg" class="text-gray-700">Verificando…</p>

--- a/scripts/core/main.js
+++ b/scripts/core/main.js
@@ -415,7 +415,7 @@ function adjustSiteMainSpacing() {
 
     const headerTop = document.getElementById('header-top');
     const categoryNav = document.getElementById('category-nav');
-    const gap = 16;
+    const gap = 8;
 
     let offset = gap;
 


### PR DESCRIPTION
## Summary
- compute site header spacing dynamically so content sits just below the fixed header and category menu
- tag store and account pages to use the new spacing logic and strip oversized manual top padding
- trim the default top padding on admin and staff layouts so titles sit nearer to their headers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddabe7db5c8323b2c737cd46c13b4a