### PR TITLE
feat(pdv): deduct stock from configured deposit

### DIFF
--- a/scripts/admin/admin-pdv.js
+++ b/scripts/admin/admin-pdv.js
@@ -1498,6 +1498,14 @@
   const normalizeSaleRecordForPersist = (record) => {
     if (!record || typeof record !== 'object') return null;
     const createdAt = record.createdAt ? new Date(record.createdAt) : new Date();
+    const inventoryProcessed = Boolean(record.inventoryProcessed);
+    let inventoryProcessedAt = null;
+    if (record.inventoryProcessedAt) {
+      const processedAt = new Date(record.inventoryProcessedAt);
+      if (!Number.isNaN(processedAt.getTime())) {
+        inventoryProcessedAt = processedAt.toISOString();
+      }
+    }
     return {
       id: record.id ? String(record.id) : createUid(),
       type: record.type ? String(record.type) : 'venda',
@@ -1548,6 +1556,8 @@
       cancellationReason: record.cancellationReason ? String(record.cancellationReason) : '',
       cancellationAt: record.cancellationAt ? new Date(record.cancellationAt).toISOString() : null,
       cancellationAtLabel: record.cancellationAtLabel ? String(record.cancellationAtLabel) : '',
+      inventoryProcessed,
+      inventoryProcessedAt,
     };
   };
 
@@ -6756,6 +6766,8 @@
       cancellationReason: '',
       cancellationAt: null,
       cancellationAtLabel: '',
+      inventoryProcessed: false,
+      inventoryProcessedAt: null,
     };
   };
 

--- a/servidor/models/PdvState.js
+++ b/servidor/models/PdvState.js
@@ -70,6 +70,26 @@ const saleRecordSchema = new mongoose.Schema(
     cancellationReason: { type: String, trim: true },
     cancellationAt: { type: Date },
     cancellationAtLabel: { type: String, trim: true },
+    inventoryProcessed: { type: Boolean, default: false },
+    inventoryProcessedAt: { type: Date, default: null },
+  },
+  { _id: false }
+);
+
+const inventoryMovementSchema = new mongoose.Schema(
+  {
+    saleId: { type: String, trim: true, required: true },
+    deposit: { type: mongoose.Schema.Types.ObjectId, ref: 'Deposit', required: true },
+    processedAt: { type: Date, default: Date.now },
+    items: {
+      type: [
+        {
+          product: { type: mongoose.Schema.Types.ObjectId, ref: 'Product', required: true },
+          quantity: { type: Number, default: 0 },
+        },
+      ],
+      default: [],
+    },
   },
   { _id: false }
 );
@@ -126,6 +146,7 @@ const pdvStateSchema = new mongoose.Schema(
       fechamento: { type: String, trim: true, default: 'PM' },
       venda: { type: String, trim: true, default: 'PM' },
     },
+    inventoryMovements: { type: [inventoryMovementSchema], default: [] },
   },
   { timestamps: true }
 );


### PR DESCRIPTION
## Summary
- deduct product quantities from the PDV's configured deposit when completed sales are saved
- extend the PDV state schema to store inventory processing metadata
- persist the inventory processing flags in the admin PDV UI state so the backend can track processed sales

## Testing
- npm --prefix servidor test

------
https://chatgpt.com/codex/tasks/task_e_68ddc1afc1848323bbe1ff5b124947f9