### PR TITLE
Add bank account registration flow

### DIFF
--- a/pages/admin/admin-financeiro-contabil-cadastro-conta-corrente.html
+++ b/pages/admin/admin-financeiro-contabil-cadastro-conta-corrente.html
@@ -108,7 +108,7 @@
             <div class="flex items-center gap-2">
               <button type="reset" id="bank-account-reset" class="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 transition">
                 <i class="fas fa-undo"></i>
-                Descartar alterações
+                <span id="bank-account-reset-label">Descartar alterações</span>
               </button>
               <button type="submit" id="bank-account-submit" class="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary/90 transition">
                 <i class="fas fa-save"></i>
@@ -137,11 +137,12 @@
                   <th scope="col" class="px-4 py-3">Documento</th>
                   <th scope="col" class="px-4 py-3">Chave Pix</th>
                   <th scope="col" class="px-4 py-3">Atualizado em</th>
+                  <th scope="col" class="px-4 py-3 text-right">Ações</th>
                 </tr>
               </thead>
               <tbody id="bank-account-table-body" class="divide-y divide-gray-100">
                 <tr>
-                  <td colspan="6" class="px-4 py-6 text-center text-sm text-gray-500">Nenhuma conta cadastrada no momento.</td>
+                  <td colspan="7" class="px-4 py-6 text-center text-sm text-gray-500">Nenhuma conta cadastrada no momento.</td>
                 </tr>
               </tbody>
             </table>

--- a/pages/admin/admin-financeiro-contabil-cadastro-conta-corrente.html
+++ b/pages/admin/admin-financeiro-contabil-cadastro-conta-corrente.html
@@ -24,7 +24,7 @@
           </div>
         </header>
 
-        <section class="bg-white rounded-xl shadow-sm border border-gray-100 p-6 space-y-6">
+        <form id="bank-account-form" class="bg-white rounded-xl shadow-sm border border-gray-100 p-6 space-y-6">
           <div class="space-y-1">
             <h2 class="text-lg font-semibold text-gray-800">Identificação da conta</h2>
             <p class="text-sm text-gray-600">Informe os dados conforme cadastro bancário oficial para garantir validação junto à instituição financeira.</p>
@@ -33,17 +33,13 @@
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label for="account-company" class="block text-sm font-medium text-gray-700 mb-1">Empresa da conta<span class="text-red-500"> *</span></label>
-              <select id="account-company" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
-                <option value="">Selecione a empresa</option>
-                <option value="matriz">E o Bicho Comércio de Alimentos Ltda. (Matriz)</option>
-                <option value="filial-centro">E o Bicho Comércio de Alimentos Ltda. (Filial Centro)</option>
-                <option value="filial-sul">E o Bicho Logística e Serviços Ltda. (Filial Sul)</option>
-                <option value="holding">E o Bicho Participações S.A.</option>
+              <select id="account-company" name="company" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
+                <option value="">Carregando empresas...</option>
               </select>
             </div>
             <div>
               <label for="bank-code" class="block text-sm font-medium text-gray-700 mb-1">Banco (código Bacen)<span class="text-red-500"> *</span></label>
-              <select id="bank-code" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
+              <select id="bank-code" name="bankCode" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
                 <option value="">Carregando lista oficial de bancos...</option>
               </select>
               <p class="mt-1 text-xs text-gray-500">Lista atualizada com dados do Sistema de Pagamentos Brasileiro (Bacen/Febraban).</p>
@@ -53,76 +49,74 @@
           <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
               <label for="agency" class="block text-sm font-medium text-gray-700 mb-1">Agência<span class="text-red-500"> *</span></label>
-              <input type="text" id="agency" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="0001" required>
+              <input type="text" id="agency" name="agency" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="0001" required>
             </div>
             <div>
               <label for="account-number" class="block text-sm font-medium text-gray-700 mb-1">Conta<span class="text-red-500"> *</span></label>
-              <input type="text" id="account-number" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="12345" required>
+              <input type="text" id="account-number" name="accountNumber" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="12345" required>
             </div>
             <div>
               <label for="account-digit" class="block text-sm font-medium text-gray-700 mb-1">Dígito verificador</label>
-              <input type="text" id="account-digit" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="0">
+              <input type="text" id="account-digit" name="accountDigit" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="0">
             </div>
           </div>
 
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label for="account-type" class="block text-sm font-medium text-gray-700 mb-1">Tipo de conta<span class="text-red-500"> *</span></label>
-              <select id="account-type" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
+              <select id="account-type" name="accountType" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20">
                 <option value="corrente">Conta Corrente</option>
-                <option value="conta-pagamento">Conta de Pagamento</option>
-                <option value="conta-investimento">Conta Investimento</option>
+                <option value="conta_pagamento">Conta de Pagamento</option>
+                <option value="conta_investimento">Conta Investimento</option>
               </select>
             </div>
             <div>
               <label for="pix-key" class="block text-sm font-medium text-gray-700 mb-1">Chave Pix</label>
-              <input type="text" id="pix-key" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="CNPJ, e-mail ou chave aleatória">
+              <input type="text" id="pix-key" name="pixKey" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="CNPJ, e-mail ou chave aleatória">
             </div>
           </div>
 
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label for="company-cnpj" class="block text-sm font-medium text-gray-700 mb-1">CNPJ da conta<span class="text-red-500"> *</span></label>
-              <input type="text" id="company-cnpj" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="00.000.000/0001-00" required>
+              <input type="text" id="company-cnpj" name="documentNumber" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="00.000.000/0001-00" required>
             </div>
             <div>
               <label for="account-alias" class="block text-sm font-medium text-gray-700 mb-1">Nome interno</label>
-              <input type="text" id="account-alias" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="Conta matriz - pagamentos">
+              <input type="text" id="account-alias" name="alias" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="Conta matriz - pagamentos">
             </div>
           </div>
 
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label for="initial-balance" class="block text-sm font-medium text-gray-700 mb-1">Saldo inicial (R$)</label>
-              <input type="text" id="initial-balance" inputmode="decimal" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="0,00">
+              <input type="text" id="initial-balance" name="initialBalance" inputmode="decimal" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="0,00">
               <p class="mt-1 text-xs text-gray-500">Utilize vírgula para separar centavos, conforme padrão brasileiro.</p>
             </div>
             <div>
               <label for="daily-cdi" class="block text-sm font-medium text-gray-700 mb-1">CDI diário (%)</label>
-              <input type="number" step="0.01" id="daily-cdi" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="0,11">
+              <input type="number" step="0.01" id="daily-cdi" name="dailyCdi" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="0,11">
               <p class="mt-1 text-xs text-gray-500">Informe a taxa projetada de rendimento diário para aplicações automáticas.</p>
             </div>
           </div>
-        </section>
 
-        <section class="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
-          <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div class="pt-4 border-t border-gray-100 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
             <div class="flex items-center gap-2 text-xs text-gray-500">
               <i class="fas fa-clock text-gray-400"></i>
-              Última atualização de saldo importada: há 2 horas
+              <span id="bank-account-status">Nenhum envio realizado ainda.</span>
             </div>
             <div class="flex items-center gap-2">
-              <button type="button" class="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 transition">
+              <button type="reset" id="bank-account-reset" class="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 transition">
                 <i class="fas fa-undo"></i>
                 Descartar alterações
               </button>
-              <button type="button" class="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary/90 transition">
+              <button type="submit" id="bank-account-submit" class="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary/90 transition">
                 <i class="fas fa-save"></i>
-                Salvar conta
+                <span id="bank-account-submit-label">Salvar conta</span>
               </button>
             </div>
           </div>
-        </section>
+        </form>
       </div>
     </div>
   </main>
@@ -136,83 +130,6 @@
   <script src="../../scripts/core/ui.js"></script>
   <script src="../../scripts/core/main.js"></script>
   <script src="../../scripts/admin/admin.js"></script>
-  <script>
-    (function populateBanks() {
-      const bankSelect = document.getElementById('bank-code');
-      if (!bankSelect) return;
-
-      fetch('../../data/bancos.json')
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error('Falha ao carregar bancos: ' + response.status);
-          }
-          return response.json();
-        })
-        .then((banks) => {
-          const normalized = Array.isArray(banks)
-            ? banks
-                .map((bank) => {
-                  const code = bank?.code;
-                  const ispb = bank?.ispb;
-                  if (code === null && !ispb) {
-                    return null;
-                  }
-
-                  const bankCode = code !== null && code !== undefined
-                    ? String(code).padStart(3, '0')
-                    : String(ispb);
-                  const bankName = bank?.fullName || bank?.name;
-
-                  if (!bankCode || !bankName) {
-                    return null;
-                  }
-
-                  return {
-                    code: bankCode,
-                    name: bankName,
-                  };
-                })
-                .filter(Boolean)
-            : [];
-
-          const uniqueBanks = normalized.reduce((registry, bank) => {
-            if (!registry.has(bank.code)) {
-              registry.set(bank.code, bank);
-            }
-            return registry;
-          }, new Map());
-
-          const orderedBanks = Array.from(uniqueBanks.values()).sort((a, b) =>
-            a.code.localeCompare(b.code)
-          );
-
-          bankSelect.innerHTML = '<option value="">Selecione um banco</option>';
-
-          orderedBanks.forEach((bank) => {
-            const option = document.createElement('option');
-            option.value = bank.code;
-            option.textContent = `${bank.code} - ${bank.name}`;
-            bankSelect.appendChild(option);
-          });
-
-          if (orderedBanks.length === 0) {
-            throw new Error('Lista de bancos vazia');
-          }
-        })
-        .catch((error) => {
-          console.error(error);
-          bankSelect.innerHTML = '';
-          const fallbackOption = document.createElement('option');
-          fallbackOption.value = '341';
-          fallbackOption.textContent = '341 - Itaú Unibanco S.A.';
-          bankSelect.appendChild(fallbackOption);
-
-          const helper = document.createElement('p');
-          helper.className = 'mt-1 text-xs text-red-500';
-          helper.textContent = 'Não foi possível carregar a lista completa. Utilize o código Bacen ou ISPB manualmente.';
-          bankSelect.insertAdjacentElement('afterend', helper);
-        });
-    })();
-  </script>
+  <script src="../../scripts/admin/admin-financeiro-contabil-cadastro-conta-corrente.js"></script>
 </body>
 </html>

--- a/pages/admin/admin-financeiro-contabil-cadastro-conta-corrente.html
+++ b/pages/admin/admin-financeiro-contabil-cadastro-conta-corrente.html
@@ -117,6 +117,36 @@
             </div>
           </div>
         </form>
+
+        <section class="bg-white rounded-xl shadow-sm border border-gray-100 p-6 space-y-4">
+          <div class="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 class="text-lg font-semibold text-gray-800">Contas cadastradas</h2>
+              <p class="text-sm text-gray-600">Visualize as contas correntes disponíveis para conciliação e operações financeiras.</p>
+            </div>
+            <div class="text-xs text-gray-500" id="bank-account-list-status">Carregando contas cadastradas...</div>
+          </div>
+
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 text-sm" aria-live="polite" aria-busy="true" id="bank-account-table">
+              <thead class="bg-gray-50">
+                <tr class="text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  <th scope="col" class="px-4 py-3">Empresa</th>
+                  <th scope="col" class="px-4 py-3">Banco</th>
+                  <th scope="col" class="px-4 py-3">Agência / Conta</th>
+                  <th scope="col" class="px-4 py-3">Documento</th>
+                  <th scope="col" class="px-4 py-3">Chave Pix</th>
+                  <th scope="col" class="px-4 py-3">Atualizado em</th>
+                </tr>
+              </thead>
+              <tbody id="bank-account-table-body" class="divide-y divide-gray-100">
+                <tr>
+                  <td colspan="6" class="px-4 py-6 text-center text-sm text-gray-500">Nenhuma conta cadastrada no momento.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
       </div>
     </div>
   </main>

--- a/scripts/admin/admin-financeiro-contabil-cadastro-conta-corrente.js
+++ b/scripts/admin/admin-financeiro-contabil-cadastro-conta-corrente.js
@@ -1,0 +1,354 @@
+(function () {
+  const API_BASE =
+    (typeof API_CONFIG !== 'undefined' && API_CONFIG && API_CONFIG.BASE_URL) || '/api';
+  const BASE_PATH = typeof window.basePath === 'string' ? window.basePath : '../../';
+
+  const selectors = {
+    form: '#bank-account-form',
+    company: '#account-company',
+    bank: '#bank-code',
+    agency: '#agency',
+    accountNumber: '#account-number',
+    accountDigit: '#account-digit',
+    accountType: '#account-type',
+    pixKey: '#pix-key',
+    documentNumber: '#company-cnpj',
+    alias: '#account-alias',
+    initialBalance: '#initial-balance',
+    dailyCdi: '#daily-cdi',
+    status: '#bank-account-status',
+    submitButton: '#bank-account-submit',
+    submitLabel: '#bank-account-submit-label',
+  };
+
+  const state = {
+    companies: [],
+    saving: false,
+  };
+
+  const elements = {};
+
+  const initElements = () => {
+    Object.entries(selectors).forEach(([key, selector]) => {
+      elements[key] = document.querySelector(selector);
+    });
+  };
+
+  const notify = (message, type = 'info') => {
+    if (typeof window.showToast === 'function') {
+      window.showToast(message, type);
+      return;
+    }
+    if (type === 'error') {
+      console.error(message);
+    } else {
+      console.log(message);
+    }
+  };
+
+  const getToken = () => {
+    try {
+      const stored = localStorage.getItem('loggedInUser');
+      if (!stored) return '';
+      const parsed = JSON.parse(stored);
+      return parsed?.token || '';
+    } catch (error) {
+      console.warn('Não foi possível obter o token do usuário logado.', error);
+      return '';
+    }
+  };
+
+  const parseCurrency = (value) => {
+    if (value === undefined || value === null || value === '') return 0;
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    const normalized = String(value)
+      .trim()
+      .replace(/\s+/g, '')
+      .replace(/\.(?=\d{3}(?:\D|$))/g, '')
+      .replace(',', '.')
+      .replace(/[^0-9.+-]/g, '');
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : 0;
+  };
+
+  const parsePercentage = (value) => {
+    if (value === undefined || value === null || value === '') return 0;
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+    return parseCurrency(value);
+  };
+
+  const sanitizeString = (value) => (typeof value === 'string' ? value.trim() : '');
+
+  const updateStatus = (message) => {
+    if (elements.status) {
+      elements.status.textContent = message || 'Nenhum envio realizado ainda.';
+    }
+  };
+
+  const setSavingState = (saving) => {
+    state.saving = saving;
+    if (elements.submitButton) {
+      elements.submitButton.disabled = saving;
+      elements.submitButton.classList.toggle('opacity-60', saving);
+      elements.submitButton.classList.toggle('pointer-events-none', saving);
+    }
+    if (elements.submitLabel) {
+      elements.submitLabel.textContent = saving ? 'Salvando...' : 'Salvar conta';
+    }
+  };
+
+  const parseErrorResponse = async (response) => {
+    try {
+      const data = await response.json();
+      if (data?.message) return data.message;
+    } catch (error) {
+      // ignore
+    }
+    return null;
+  };
+
+  const buildCompanyLabel = (company) => {
+    if (!company || typeof company !== 'object') return 'Empresa sem identificação';
+    const nome = company.nome || company.nomeFantasia || company.razaoSocial || company.apelido || '';
+    const documento = company.cnpj || company.cpf || '';
+    if (nome && documento) {
+      return `${nome} (${documento})`;
+    }
+    return nome || documento || 'Empresa sem identificação';
+  };
+
+  const loadCompanies = async () => {
+    const select = elements.company;
+    if (!select) return;
+
+    select.innerHTML = '<option value="">Carregando empresas...</option>';
+
+    try {
+      const headers = {};
+      const token = getToken();
+      if (token) headers.Authorization = `Bearer ${token}`;
+
+      const response = await fetch(`${API_BASE}/stores`, { headers });
+      if (!response.ok) {
+        throw new Error(`Falha ao carregar empresas (${response.status})`);
+      }
+
+      const data = await response.json();
+      state.companies = Array.isArray(data) ? data : [];
+
+      if (!state.companies.length) {
+        select.innerHTML = '<option value="">Nenhuma empresa cadastrada</option>';
+        notify('Cadastre empresas antes de vincular uma conta corrente.', 'warning');
+        return;
+      }
+
+      select.innerHTML = '<option value="">Selecione a empresa</option>';
+      state.companies.forEach((company) => {
+        if (!company || !company._id) return;
+        const option = document.createElement('option');
+        option.value = company._id;
+        option.textContent = buildCompanyLabel(company);
+        select.appendChild(option);
+      });
+    } catch (error) {
+      console.error('Erro ao carregar empresas:', error);
+      select.innerHTML = '<option value="">Não foi possível carregar as empresas</option>';
+      notify('Não foi possível carregar as empresas. Tente novamente mais tarde.', 'error');
+    }
+  };
+
+  const loadBanks = async () => {
+    const select = elements.bank;
+    if (!select) return;
+
+    try {
+      const response = await fetch(`${BASE_PATH}data/bancos.json`, { cache: 'no-cache' });
+      if (!response.ok) {
+        throw new Error(`Falha ao carregar bancos (${response.status})`);
+      }
+
+      const banks = await response.json();
+      const normalized = Array.isArray(banks)
+        ? banks
+            .map((bank) => {
+              const code = bank?.code;
+              const ispb = bank?.ispb;
+              if (code === null && !ispb) {
+                return null;
+              }
+
+              const bankCode = code !== null && code !== undefined
+                ? String(code).padStart(3, '0')
+                : String(ispb || '').trim();
+              const bankName = bank?.fullName || bank?.name;
+
+              if (!bankCode || !bankName) {
+                return null;
+              }
+
+              return {
+                code: bankCode,
+                name: bankName,
+              };
+            })
+            .filter(Boolean)
+        : [];
+
+      const uniqueBanks = normalized.reduce((registry, bank) => {
+        if (!registry.has(bank.code)) {
+          registry.set(bank.code, bank);
+        }
+        return registry;
+      }, new Map());
+
+      const orderedBanks = Array.from(uniqueBanks.values()).sort((a, b) =>
+        a.code.localeCompare(b.code)
+      );
+
+      select.innerHTML = '<option value="">Selecione um banco</option>';
+      orderedBanks.forEach((bank) => {
+        const option = document.createElement('option');
+        option.value = bank.code;
+        option.textContent = `${bank.code} - ${bank.name}`;
+        option.dataset.bankName = bank.name;
+        select.appendChild(option);
+      });
+
+      if (!orderedBanks.length) {
+        throw new Error('Lista de bancos vazia');
+      }
+    } catch (error) {
+      console.error('Erro ao carregar bancos:', error);
+      select.innerHTML = '';
+      const fallbackOption = document.createElement('option');
+      fallbackOption.value = '341';
+      fallbackOption.dataset.bankName = 'Itaú Unibanco S.A.';
+      fallbackOption.textContent = '341 - Itaú Unibanco S.A.';
+      select.appendChild(fallbackOption);
+
+      const helper = document.createElement('p');
+      helper.className = 'mt-1 text-xs text-red-500';
+      helper.textContent = 'Não foi possível carregar a lista completa. Utilize o código Bacen ou ISPB manualmente.';
+      select.insertAdjacentElement('afterend', helper);
+    }
+  };
+
+  const buildPayload = () => {
+    const company = sanitizeString(elements.company?.value);
+    const bankCode = sanitizeString(elements.bank?.value);
+    const agency = sanitizeString(elements.agency?.value);
+    const accountNumber = sanitizeString(elements.accountNumber?.value);
+    const accountDigit = sanitizeString(elements.accountDigit?.value);
+    const accountType = sanitizeString(elements.accountType?.value || 'corrente');
+    const pixKey = sanitizeString(elements.pixKey?.value);
+    const documentNumber = sanitizeString(elements.documentNumber?.value);
+    const alias = sanitizeString(elements.alias?.value);
+    const initialBalance = parseCurrency(elements.initialBalance?.value);
+    const dailyCdi = parsePercentage(elements.dailyCdi?.value);
+
+    const selectedBankOption = elements.bank?.options?.[elements.bank.selectedIndex] || null;
+    const bankName = selectedBankOption?.dataset?.bankName
+      || sanitizeString(selectedBankOption?.textContent || '').split('-').slice(1).join('-').trim();
+
+    return {
+      company,
+      bankCode,
+      bankName,
+      agency,
+      accountNumber,
+      accountDigit,
+      accountType,
+      pixKey,
+      documentNumber,
+      alias,
+      initialBalance,
+      dailyCdi,
+    };
+  };
+
+  const validatePayload = (payload) => {
+    if (!payload.company) {
+      throw new Error('Selecione a empresa proprietária da conta.');
+    }
+    if (!payload.bankCode) {
+      throw new Error('Selecione o banco da conta corrente.');
+    }
+    if (!payload.agency) {
+      throw new Error('Informe a agência bancária.');
+    }
+    if (!payload.accountNumber) {
+      throw new Error('Informe o número da conta bancária.');
+    }
+    if (!payload.documentNumber) {
+      throw new Error('Informe o CNPJ ou documento vinculado à conta.');
+    }
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (state.saving) return;
+
+    try {
+      const payload = buildPayload();
+      validatePayload(payload);
+
+      setSavingState(true);
+      const token = getToken();
+      const headers = { 'Content-Type': 'application/json' };
+      if (token) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+
+      const response = await fetch(`${API_BASE}/bank-accounts`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const message = (await parseErrorResponse(response)) || 'Não foi possível salvar a conta bancária.';
+        throw new Error(message);
+      }
+
+      notify('Conta bancária salva com sucesso!', 'success');
+      const now = new Date();
+      updateStatus(`Conta salva em ${now.toLocaleString('pt-BR')}`);
+      if (elements.form) {
+        elements.form.reset();
+      }
+      if (elements.company) {
+        elements.company.value = '';
+      }
+      if (elements.bank) {
+        elements.bank.value = '';
+      }
+    } catch (error) {
+      notify(error?.message || 'Não foi possível salvar a conta bancária.', 'error');
+    } finally {
+      setSavingState(false);
+    }
+  };
+
+  const handleReset = () => {
+    updateStatus('Nenhum envio realizado ainda.');
+    setSavingState(false);
+  };
+
+  const init = () => {
+    initElements();
+    if (!elements.form) return;
+
+    loadBanks();
+    loadCompanies();
+
+    elements.form.addEventListener('submit', handleSubmit);
+    elements.form.addEventListener('reset', handleReset);
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+})();

--- a/servidor/models/BankAccount.js
+++ b/servidor/models/BankAccount.js
@@ -1,0 +1,32 @@
+const mongoose = require('mongoose');
+
+const bankAccountSchema = new mongoose.Schema(
+  {
+    company: { type: mongoose.Schema.Types.ObjectId, ref: 'Store', required: true },
+    bankCode: { type: String, required: true, trim: true },
+    bankName: { type: String, trim: true },
+    agency: { type: String, required: true, trim: true },
+    accountNumber: { type: String, required: true, trim: true },
+    accountDigit: { type: String, trim: true },
+    accountType: {
+      type: String,
+      enum: ['corrente', 'conta_pagamento', 'conta_investimento'],
+      required: true,
+    },
+    pixKey: { type: String, trim: true },
+    documentNumber: { type: String, required: true, trim: true },
+    alias: { type: String, trim: true },
+    initialBalance: { type: Number, default: 0 },
+    dailyCdi: { type: Number, default: 0 },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+bankAccountSchema.index(
+  { company: 1, bankCode: 1, agency: 1, accountNumber: 1, accountDigit: 1 },
+  { unique: true, sparse: true }
+);
+
+module.exports = mongoose.model('BankAccount', bankAccountSchema);

--- a/servidor/routes/bankAccounts.js
+++ b/servidor/routes/bankAccounts.js
@@ -261,4 +261,25 @@ router.put('/:id', requireAuth, authorizeRoles('admin', 'admin_master'), async (
   }
 });
 
+router.delete('/:id', requireAuth, authorizeRoles('admin', 'admin_master'), async (req, res) => {
+  try {
+    const { id } = req.params;
+    if (!id || !mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ message: 'Identificador inválido.' });
+    }
+
+    const account = await BankAccount.findById(id);
+    if (!account) {
+      return res.status(404).json({ message: 'Conta bancária não encontrada.' });
+    }
+
+    await account.deleteOne();
+
+    res.json({ message: 'Conta bancária excluída com sucesso.' });
+  } catch (error) {
+    console.error('Erro ao excluir conta bancária:', error);
+    res.status(500).json({ message: 'Erro ao excluir conta bancária.' });
+  }
+});
+
 module.exports = router;

--- a/servidor/routes/bankAccounts.js
+++ b/servidor/routes/bankAccounts.js
@@ -1,0 +1,264 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const router = express.Router();
+
+const BankAccount = require('../models/BankAccount');
+const Store = require('../models/Store');
+const requireAuth = require('../middlewares/requireAuth');
+const authorizeRoles = require('../middlewares/authorizeRoles');
+
+const normalizeString = (value) => {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string') return value.trim();
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return '';
+};
+
+const sanitizeBankCode = (value) => {
+  const normalized = normalizeString(value);
+  if (!normalized) return '';
+  const digits = normalized.replace(/\D+/g, '');
+  if (!digits) return '';
+  if (digits.length === 8) return digits;
+  if (digits.length >= 3) return digits.slice(0, 3).padStart(3, '0');
+  return digits.padStart(3, '0');
+};
+
+const sanitizeAgency = (value) => normalizeString(value).replace(/\s+/g, '');
+const sanitizeAccountNumber = (value) => normalizeString(value).replace(/\s+/g, '');
+const sanitizeAccountDigit = (value) => normalizeString(value).replace(/\s+/g, '');
+const sanitizePixKey = (value) => normalizeString(value);
+
+const sanitizeDocument = (value) => {
+  const normalized = normalizeString(value);
+  const digits = normalized.replace(/[^0-9a-zA-Z]/g, '');
+  return digits || normalized;
+};
+
+const parseLocaleNumber = (value, fallback = 0) => {
+  if (value === undefined || value === null || value === '') return fallback;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value !== 'string') return fallback;
+  const normalized = value
+    .trim()
+    .replace(/\s+/g, '')
+    .replace(/\.(?=\d{3}(?:\D|$))/g, '')
+    .replace(',', '.')
+    .replace(/[^0-9.+-]/g, '');
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const normalizeAccountType = (value, fallback = 'corrente') => {
+  const normalized = normalizeString(value).toLowerCase().replace(/[^a-z]/g, '_');
+  if (['corrente', 'conta_pagamento', 'conta_investimento'].includes(normalized)) {
+    return normalized;
+  }
+  return fallback;
+};
+
+const buildPublicAccountPayload = (account) => {
+  if (!account) return null;
+  const plain = typeof account.toObject === 'function' ? account.toObject() : account;
+  return {
+    _id: plain._id,
+    company: plain.company,
+    bankCode: plain.bankCode,
+    bankName: plain.bankName,
+    agency: plain.agency,
+    accountNumber: plain.accountNumber,
+    accountDigit: plain.accountDigit,
+    accountType: plain.accountType,
+    pixKey: plain.pixKey,
+    documentNumber: plain.documentNumber,
+    alias: plain.alias,
+    initialBalance: plain.initialBalance,
+    dailyCdi: plain.dailyCdi,
+    createdAt: plain.createdAt,
+    updatedAt: plain.updatedAt,
+  };
+};
+
+router.get('/', requireAuth, authorizeRoles('admin', 'admin_master', 'funcionario'), async (req, res) => {
+  try {
+    const { company } = req.query;
+    const query = {};
+    if (company && mongoose.Types.ObjectId.isValid(company)) {
+      query.company = company;
+    }
+
+    const accounts = await BankAccount.find(query)
+      .sort({ createdAt: -1 })
+      .populate('company', 'nome nomeFantasia razaoSocial cnpj cpf inscricaoEstadual');
+
+    res.json({ accounts: accounts.map(buildPublicAccountPayload) });
+  } catch (error) {
+    console.error('Erro ao listar contas bancárias:', error);
+    res.status(500).json({ message: 'Erro ao listar contas bancárias.' });
+  }
+});
+
+router.get('/:id', requireAuth, authorizeRoles('admin', 'admin_master', 'funcionario'), async (req, res) => {
+  try {
+    const { id } = req.params;
+    if (!id || !mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ message: 'Identificador inválido.' });
+    }
+
+    const account = await BankAccount.findById(id).populate(
+      'company',
+      'nome nomeFantasia razaoSocial cnpj cpf inscricaoEstadual'
+    );
+
+    if (!account) {
+      return res.status(404).json({ message: 'Conta bancária não encontrada.' });
+    }
+
+    res.json(buildPublicAccountPayload(account));
+  } catch (error) {
+    console.error('Erro ao buscar conta bancária:', error);
+    res.status(500).json({ message: 'Erro ao buscar conta bancária.' });
+  }
+});
+
+router.post('/', requireAuth, authorizeRoles('admin', 'admin_master'), async (req, res) => {
+  try {
+    const company = normalizeString(req.body.company);
+    if (!company) {
+      return res.status(400).json({ message: 'Selecione a empresa proprietária da conta.' });
+    }
+
+    const storeExists = await Store.exists({ _id: company });
+    if (!storeExists) {
+      return res.status(404).json({ message: 'Empresa informada não foi encontrada.' });
+    }
+
+    const bankCode = sanitizeBankCode(req.body.bankCode);
+    if (!bankCode) {
+      return res.status(400).json({ message: 'Informe o código Bacen/ISPB do banco.' });
+    }
+
+    const agency = sanitizeAgency(req.body.agency);
+    if (!agency) {
+      return res.status(400).json({ message: 'Informe a agência bancária.' });
+    }
+
+    const accountNumber = sanitizeAccountNumber(req.body.accountNumber);
+    if (!accountNumber) {
+      return res.status(400).json({ message: 'Informe o número da conta bancária.' });
+    }
+
+    const accountDigit = sanitizeAccountDigit(req.body.accountDigit);
+    const accountType = normalizeAccountType(req.body.accountType);
+    const pixKey = sanitizePixKey(req.body.pixKey);
+    const documentNumber = sanitizeDocument(req.body.documentNumber);
+
+    if (!documentNumber) {
+      return res.status(400).json({ message: 'Informe o documento vinculado à conta.' });
+    }
+
+    const alias = normalizeString(req.body.alias);
+    const bankName = normalizeString(req.body.bankName);
+    const initialBalance = parseLocaleNumber(req.body.initialBalance, 0);
+    const dailyCdi = parseLocaleNumber(req.body.dailyCdi, 0);
+
+    const payload = {
+      company,
+      bankCode,
+      bankName,
+      agency,
+      accountNumber,
+      accountDigit,
+      accountType,
+      pixKey,
+      documentNumber,
+      alias,
+      initialBalance,
+      dailyCdi,
+    };
+
+    const created = await BankAccount.create(payload);
+    const populated = await created.populate('company', 'nome nomeFantasia razaoSocial cnpj cpf inscricaoEstadual');
+    res.status(201).json(buildPublicAccountPayload(populated));
+  } catch (error) {
+    if (error?.code === 11000) {
+      return res.status(409).json({ message: 'Já existe uma conta cadastrada com os mesmos dados para esta empresa.' });
+    }
+    console.error('Erro ao criar conta bancária:', error);
+    res.status(500).json({ message: 'Erro ao criar conta bancária.' });
+  }
+});
+
+router.put('/:id', requireAuth, authorizeRoles('admin', 'admin_master'), async (req, res) => {
+  try {
+    const { id } = req.params;
+    if (!id || !mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ message: 'Identificador inválido.' });
+    }
+
+    const existing = await BankAccount.findById(id);
+    if (!existing) {
+      return res.status(404).json({ message: 'Conta bancária não encontrada.' });
+    }
+
+    let company = normalizeString(req.body.company) || String(existing.company);
+    if (!company) {
+      return res.status(400).json({ message: 'Selecione a empresa proprietária da conta.' });
+    }
+
+    const companyExists = await Store.exists({ _id: company });
+    if (!companyExists) {
+      return res.status(404).json({ message: 'Empresa informada não foi encontrada.' });
+    }
+
+    const bankCode = sanitizeBankCode(req.body.bankCode) || existing.bankCode;
+    const agency = sanitizeAgency(req.body.agency) || existing.agency;
+    const accountNumber = sanitizeAccountNumber(req.body.accountNumber) || existing.accountNumber;
+    const accountDigit =
+      typeof req.body.accountDigit === 'undefined'
+        ? existing.accountDigit
+        : sanitizeAccountDigit(req.body.accountDigit);
+    const accountType = normalizeAccountType(req.body.accountType, existing.accountType);
+    const pixKey =
+      typeof req.body.pixKey === 'undefined'
+        ? existing.pixKey
+        : sanitizePixKey(req.body.pixKey);
+    const documentNumber = sanitizeDocument(req.body.documentNumber) || existing.documentNumber;
+    const alias =
+      typeof req.body.alias === 'undefined'
+        ? existing.alias
+        : normalizeString(req.body.alias);
+    const bankName =
+      typeof req.body.bankName === 'undefined'
+        ? existing.bankName
+        : normalizeString(req.body.bankName);
+    const initialBalance = parseLocaleNumber(req.body.initialBalance, existing.initialBalance || 0);
+    const dailyCdi = parseLocaleNumber(req.body.dailyCdi, existing.dailyCdi || 0);
+
+    existing.company = company;
+    existing.bankCode = bankCode;
+    existing.bankName = bankName;
+    existing.agency = agency;
+    existing.accountNumber = accountNumber;
+    existing.accountDigit = accountDigit;
+    existing.accountType = accountType;
+    existing.pixKey = pixKey;
+    existing.documentNumber = documentNumber;
+    existing.alias = alias;
+    existing.initialBalance = initialBalance;
+    existing.dailyCdi = dailyCdi;
+
+    await existing.save();
+    const populated = await existing.populate('company', 'nome nomeFantasia razaoSocial cnpj cpf inscricaoEstadual');
+
+    res.json(buildPublicAccountPayload(populated));
+  } catch (error) {
+    if (error?.code === 11000) {
+      return res.status(409).json({ message: 'Já existe uma conta cadastrada com os mesmos dados para esta empresa.' });
+    }
+    console.error('Erro ao atualizar conta bancária:', error);
+    res.status(500).json({ message: 'Erro ao atualizar conta bancária.' });
+  }
+});
+
+module.exports = router;

--- a/servidor/server.js
+++ b/servidor/server.js
@@ -45,6 +45,7 @@ const routes = [
   { path: '/api/pdvs', file: './routes/pdvs' },
   { path: '/api/deposits', file: './routes/deposits' },
   { path: '/api/payment-methods', file: './routes/paymentMethods' },
+  { path: '/api/bank-accounts', file: './routes/bankAccounts' },
   { path: '/api/jobs', file: './routes/jobs' },
   { path: '/api/addresses', file: './routes/addresses' },
   { path: '/api/shipping', file: './routes/shipping' },


### PR DESCRIPTION
## Summary
- wire the admin bank account form to real companies and bank data sources
- persist current account configuration via a new bankAccounts API with validation
- register the new backend route and supporting model for reuse

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de8f2e23288323b8e781618b1a10e3