### PR TITLE
Add crediário payment option and accounting account selection

### DIFF
--- a/pages/admin/admin-financeiro-meios-pagamento.html
+++ b/pages/admin/admin-financeiro-meios-pagamento.html
@@ -51,24 +51,44 @@
                     <p class="text-xs text-gray-500 mt-1">Os parâmetros fiscais e contábeis herdam da empresa selecionada.</p>
                   </div>
 
-                  <div class="grid grid-cols-1 md:grid-cols-12 gap-4">
-                    <div class="md:col-span-4">
-                      <label for="payment-code" class="block text-sm font-medium text-gray-700 mb-1">Código</label>
-                      <div class="relative">
-                        <input type="text" id="payment-code" class="w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm font-semibold text-gray-700" readonly>
-                        <span class="absolute inset-y-0 right-3 flex items-center text-gray-400 text-xs">Automático</span>
-                      </div>
+                <div class="grid grid-cols-1 md:grid-cols-12 gap-4">
+                  <div class="md:col-span-4">
+                    <label for="payment-code" class="block text-sm font-medium text-gray-700 mb-1">Código</label>
+                    <div class="relative">
+                      <input type="text" id="payment-code" class="w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm font-semibold text-gray-700" readonly>
+                      <span class="absolute inset-y-0 right-3 flex items-center text-gray-400 text-xs">Automático</span>
                     </div>
-                    <div class="md:col-span-8">
-                      <label for="payment-name" class="block text-sm font-medium text-gray-700 mb-1">Nome do meio de pagamento <span class="text-red-500">*</span></label>
-                      <input type="text" id="payment-name" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="Ex.: Cartão de Crédito" required>
-                    </div>
+                  </div>
+                  <div class="md:col-span-8">
+                    <label for="payment-name" class="block text-sm font-medium text-gray-700 mb-1">Nome do meio de pagamento <span class="text-red-500">*</span></label>
+                    <input type="text" id="payment-name" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" placeholder="Ex.: Cartão de Crédito" required>
+                  </div>
+                </div>
+
+                <div>
+                  <label for="payment-accounting-account" class="block text-sm font-medium text-gray-700 mb-1">Conta contábil</label>
+                  <div class="space-y-2">
+                    <input
+                      type="text"
+                      id="payment-accounting-account-search"
+                      class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20"
+                      placeholder="Pesquise pelo nome ou código da conta"
+                      autocomplete="off"
+                    >
+                    <select
+                      id="payment-accounting-account"
+                      class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20"
+                    >
+                      <option value="">Carregando contas contábeis...</option>
+                    </select>
+                    <p id="payment-accounting-account-status" class="text-xs text-gray-500">Digite para filtrar e selecione a conta desejada.</p>
                   </div>
                 </div>
               </div>
+            </div>
 
-              <div class="space-y-4">
-                <h2 class="text-lg font-semibold text-gray-800">Tipo de recebimento</h2>
+            <div class="space-y-4">
+              <h2 class="text-lg font-semibold text-gray-800">Tipo de recebimento</h2>
                 <p class="text-sm text-gray-600">Defina como o pagamento será processado para ajustar repasses e prazos.</p>
 
                 <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
@@ -83,6 +103,10 @@
                   <label class="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-700 has-[:checked]:border-primary has-[:checked]:text-primary">
                     <span>Crédito</span>
                     <input type="radio" name="payment-type" value="credito" class="text-primary focus:ring-primary">
+                  </label>
+                  <label class="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-700 has-[:checked]:border-primary has-[:checked]:text-primary">
+                    <span>Crediário</span>
+                    <input type="radio" name="payment-type" value="crediario" class="text-primary focus:ring-primary">
                   </label>
                 </div>
 
@@ -157,9 +181,35 @@
                       Os campos abaixo atualizam o desconto de cada parcela instantaneamente.
                     </div>
                     <div id="credito-preview-list" class="space-y-2"></div>
+                </div>
+              </div>
+
+              <div id="crediario-section" class="space-y-4 hidden">
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <div class="md:col-span-1">
+                    <label for="crediario-installments" class="block text-sm font-medium text-gray-700 mb-1">Parcelas máximas</label>
+                    <input type="number" id="crediario-installments" min="1" max="24" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" value="6">
+                  </div>
+                  <div class="md:col-span-1">
+                    <label for="crediario-days" class="block text-sm font-medium text-gray-700 mb-1">Prazo médio de recebimento (dias)</label>
+                    <input type="number" id="crediario-days" min="0" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" value="30">
+                  </div>
+                  <div class="md:col-span-1">
+                    <label for="crediario-interest" class="block text-sm font-medium text-gray-700 mb-1">Juros padrão (%)</label>
+                    <input type="number" id="crediario-interest" min="0" step="0.01" class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" value="0">
+                  </div>
+                </div>
+                <div class="rounded-lg border border-amber-100 bg-amber-50 px-4 py-3">
+                  <div class="flex items-center gap-3 text-amber-700">
+                    <i class="fas fa-file-invoice-dollar text-lg"></i>
+                    <div>
+                      <p class="text-sm font-semibold">Resumo do crediário</p>
+                      <p id="crediario-preview" class="text-sm text-amber-800">Configure parcelas, prazo e juros para o crediário.</p>
+                    </div>
                   </div>
                 </div>
               </div>
+            </div>
 
               <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between border-t border-gray-100 pt-4">
                 <p class="text-xs text-gray-500">Campos marcados com <span class="text-red-500">*</span> são obrigatórios.</p>

--- a/pages/admin/admin-financeiro-meios-pagamento.html
+++ b/pages/admin/admin-financeiro-meios-pagamento.html
@@ -65,23 +65,44 @@
                   </div>
                 </div>
 
-                <div>
-                  <label for="payment-accounting-account" class="block text-sm font-medium text-gray-700 mb-1">Conta contábil</label>
-                  <div class="space-y-2">
-                    <input
-                      type="text"
-                      id="payment-accounting-account-search"
-                      class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20"
-                      placeholder="Pesquise pelo nome ou código da conta"
-                      autocomplete="off"
-                    >
-                    <select
-                      id="payment-accounting-account"
-                      class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20"
-                    >
-                      <option value="">Carregando contas contábeis...</option>
-                    </select>
-                    <p id="payment-accounting-account-status" class="text-xs text-gray-500">Digite para filtrar e selecione a conta desejada.</p>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <label for="payment-accounting-account" class="block text-sm font-medium text-gray-700 mb-1">Conta contábil</label>
+                    <div class="space-y-2">
+                      <input
+                        type="text"
+                        id="payment-accounting-account-search"
+                        class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20"
+                        placeholder="Pesquise pelo nome ou código da conta"
+                        autocomplete="off"
+                      >
+                      <select
+                        id="payment-accounting-account"
+                        class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20"
+                      >
+                        <option value="">Carregando contas contábeis...</option>
+                      </select>
+                      <p id="payment-accounting-account-status" class="text-xs text-gray-500">Digite para filtrar e selecione a conta desejada.</p>
+                    </div>
+                  </div>
+                  <div>
+                    <label for="payment-bank-account" class="block text-sm font-medium text-gray-700 mb-1">Conta corrente</label>
+                    <div class="space-y-2">
+                      <input
+                        type="text"
+                        id="payment-bank-account-search"
+                        class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20"
+                        placeholder="Pesquise por banco, agência ou apelido"
+                        autocomplete="off"
+                      >
+                      <select
+                        id="payment-bank-account"
+                        class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20"
+                      >
+                        <option value="">Selecione uma empresa para carregar as contas</option>
+                      </select>
+                      <p id="payment-bank-account-status" class="text-xs text-gray-500">Digite para filtrar e selecione a conta corrente desejada.</p>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/scripts/admin/admin-financeiro-meios-pagamento.js
+++ b/scripts/admin/admin-financeiro-meios-pagamento.js
@@ -238,12 +238,30 @@
   const fetchAccountingAccounts = async (companyId) => {
     if (!elements.accountingAccountSelect) return;
 
+    const token = getToken();
+    if (!token) {
+      notify('Sua sessão expirou. Faça login novamente para carregar as contas contábeis.', 'error');
+      state.accountingAccounts = [];
+      state.filteredAccountingAccounts = [];
+      updateAccountingAccountOptions();
+      updateOverview();
+      return;
+    }
+
     setAccountingAccountLoading(true);
     try {
       const query = companyId ? `?company=${encodeURIComponent(companyId)}` : '';
-      const response = await fetch(`${API_BASE}/accounting-accounts${query}`);
+      const response = await fetch(`${API_BASE}/accounting-accounts${query}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
       if (!response.ok) {
-        throw new Error('Não foi possível carregar as contas contábeis.');
+        const message = await parseErrorResponse(
+          response,
+          'Não foi possível carregar as contas contábeis.'
+        );
+        throw new Error(message);
       }
       const payload = await response.json();
       state.accountingAccounts = Array.isArray(payload?.accounts) ? payload.accounts : [];

--- a/scripts/admin/admin-financeiro-meios-pagamento.js
+++ b/scripts/admin/admin-financeiro-meios-pagamento.js
@@ -11,6 +11,9 @@
     idInput: '#payment-method-id',
     companySelect: '#payment-company',
     companySummary: '#payment-company-summary',
+    accountingAccountSelect: '#payment-accounting-account',
+    accountingAccountSearch: '#payment-accounting-account-search',
+    accountingAccountStatus: '#payment-accounting-account-status',
     codeInput: '#payment-code',
     nameInput: '#payment-name',
     typeRadios: 'input[name="payment-type"]',
@@ -27,6 +30,11 @@
     creditoDays: '#credito-days',
     creditoDiscount: '#credito-discount',
     creditoPreviewList: '#credito-preview-list',
+    crediarioSection: '#crediario-section',
+    crediarioInstallments: '#crediario-installments',
+    crediarioDays: '#crediario-days',
+    crediarioInterest: '#crediario-interest',
+    crediarioPreview: '#crediario-preview',
     overview: '#payment-overview',
     methodsList: '#payment-methods-list',
     methodsEmptyState: '#payment-methods-empty',
@@ -39,8 +47,14 @@
     currentType: 'avista',
     methods: [],
     creditDiscounts: {},
+    accountingAccounts: [],
+    filteredAccountingAccounts: [],
+    accountingAccountSearchTerm: '',
+    selectedAccountingAccountId: '',
+    selectedAccountingAccount: null,
     saving: false,
     loadingMethods: false,
+    loadingAccounts: false,
     defaultEmptyStateHtml: '',
     editingId: '',
     editingCode: '',
@@ -66,6 +80,14 @@
     return Number.isFinite(parsed) ? parsed : fallback;
   };
 
+  const escapeHtml = (value) =>
+    String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+
   const formatPercentage = (value) => {
     const normalized = Math.max(0, parseNumber(value, 0));
     return `${normalized.toFixed(2).replace('.', ',')}%`;
@@ -82,6 +104,166 @@
     const discount = Math.max(0, parseNumber(value, 0));
     if (discount === 0) return 'Sem desconto aplicado';
     return `Desconto de ${formatPercentage(discount)}`;
+  };
+
+  const formatRate = (value) => {
+    const rate = Math.max(0, parseNumber(value, 0));
+    if (rate === 0) return 'Sem juros adicionais';
+    return `Juros de ${formatPercentage(rate)}`;
+  };
+
+  const buildAccountingAccountLabel = (account) => {
+    if (!account) return 'Conta contábil não informada';
+    const code = account.code ? escapeHtml(account.code) : '';
+    const name = account.name ? escapeHtml(account.name) : '';
+    if (code && name) return `${code} • ${name}`;
+    return name || code || 'Conta contábil';
+  };
+
+  const updateAccountingAccountStatus = () => {
+    if (!elements.accountingAccountStatus) return;
+
+    const statusEl = elements.accountingAccountStatus;
+    statusEl.classList.remove('text-amber-600');
+    statusEl.classList.add('text-gray-500');
+
+    if (state.loadingAccounts) {
+      statusEl.textContent = 'Carregando contas contábeis...';
+      return;
+    }
+
+    const total = Array.isArray(state.accountingAccounts) ? state.accountingAccounts.length : 0;
+    const filtered = Array.isArray(state.filteredAccountingAccounts)
+      ? state.filteredAccountingAccounts.length
+      : 0;
+
+    if (!total) {
+      statusEl.textContent = 'Nenhuma conta contábil encontrada.';
+      return;
+    }
+
+    if (!filtered) {
+      statusEl.textContent = 'Nenhuma conta corresponde à pesquisa.';
+      statusEl.classList.remove('text-gray-500');
+      statusEl.classList.add('text-amber-600');
+      return;
+    }
+
+    statusEl.textContent = `${filtered} conta(s) exibida(s).`;
+  };
+
+  const setAccountingAccountLoading = (loading) => {
+    state.loadingAccounts = loading;
+    if (elements.accountingAccountSelect) {
+      elements.accountingAccountSelect.disabled = loading;
+      elements.accountingAccountSelect.classList.toggle('opacity-60', loading);
+      elements.accountingAccountSelect.classList.toggle('pointer-events-none', loading);
+    }
+    updateAccountingAccountStatus();
+  };
+
+  const updateAccountingAccountOptions = () => {
+    if (!elements.accountingAccountSelect) return;
+
+    const accounts = Array.isArray(state.accountingAccounts) ? state.accountingAccounts : [];
+    const term = (state.accountingAccountSearchTerm || '').trim().toLowerCase();
+    const filtered = !term
+      ? accounts
+      : accounts.filter((account) => {
+          const name = (account?.name || '').toLowerCase();
+          const code = (account?.code || '').toLowerCase();
+          return name.includes(term) || code.includes(term);
+        });
+
+    state.filteredAccountingAccounts = filtered;
+
+    const options = [];
+    if (!filtered.length) {
+      options.push('<option value="">Nenhuma conta encontrada</option>');
+    } else {
+      options.push('<option value="">Selecione uma conta contábil</option>');
+      filtered.forEach((account) => {
+        options.push(`<option value="${escapeHtml(account._id)}">${buildAccountingAccountLabel(account)}</option>`);
+      });
+    }
+
+    const selectedId = state.selectedAccountingAccountId || '';
+    let selectedAccount = null;
+    if (selectedId) {
+      selectedAccount = accounts.find((account) => String(account._id) === String(selectedId)) || null;
+      if (selectedAccount) {
+        state.selectedAccountingAccount = selectedAccount;
+      }
+    }
+
+    const selectedInFiltered = filtered.some((account) => String(account._id) === String(selectedId));
+    if (selectedId && !selectedInFiltered) {
+      const fallback =
+        selectedAccount ||
+        state.selectedAccountingAccount ||
+        accounts.find((account) => String(account._id) === String(selectedId));
+      if (fallback) {
+        options.push(
+          `<option value="${escapeHtml(fallback._id)}">${buildAccountingAccountLabel(fallback)} (selecionada)</option>`
+        );
+      }
+    }
+
+    elements.accountingAccountSelect.innerHTML = options.join('');
+    elements.accountingAccountSelect.value = selectedId;
+    updateAccountingAccountStatus();
+  };
+
+  const handleAccountingAccountSearch = (event) => {
+    state.accountingAccountSearchTerm = event.target.value || '';
+    updateAccountingAccountOptions();
+  };
+
+  const handleAccountingAccountSelectChange = (event) => {
+    const selectedId = event.target.value || '';
+    state.selectedAccountingAccountId = selectedId;
+    if (!selectedId) {
+      state.selectedAccountingAccount = null;
+      updateOverview();
+      return;
+    }
+
+    const match = state.accountingAccounts.find((account) => String(account._id) === String(selectedId));
+    if (match) {
+      state.selectedAccountingAccount = match;
+    }
+    updateOverview();
+  };
+
+  const fetchAccountingAccounts = async (companyId) => {
+    if (!elements.accountingAccountSelect) return;
+
+    setAccountingAccountLoading(true);
+    try {
+      const query = companyId ? `?company=${encodeURIComponent(companyId)}` : '';
+      const response = await fetch(`${API_BASE}/accounting-accounts${query}`);
+      if (!response.ok) {
+        throw new Error('Não foi possível carregar as contas contábeis.');
+      }
+      const payload = await response.json();
+      state.accountingAccounts = Array.isArray(payload?.accounts) ? payload.accounts : [];
+      if (state.selectedAccountingAccountId) {
+        const match = state.accountingAccounts.find(
+          (account) => String(account._id) === String(state.selectedAccountingAccountId)
+        );
+        if (match) {
+          state.selectedAccountingAccount = match;
+        }
+      }
+    } catch (error) {
+      console.error('Erro ao carregar contas contábeis:', error);
+      notify(error.message || 'Erro ao carregar contas contábeis.', 'error');
+      state.accountingAccounts = [];
+    } finally {
+      setAccountingAccountLoading(false);
+      updateAccountingAccountOptions();
+      updateOverview();
+    }
   };
 
   const getSelectedCompany = () =>
@@ -204,6 +386,11 @@
 
     const company = getSelectedCompany();
     const companyName = company ? company.nome || company.nomeFantasia || 'Empresa selecionada' : '—';
+    const selectedAccount = state.selectedAccountingAccountId
+      ? state.accountingAccounts.find((account) => String(account._id) === String(state.selectedAccountingAccountId)) ||
+        state.selectedAccountingAccount
+      : null;
+    const accountLabel = selectedAccount ? buildAccountingAccountLabel(selectedAccount) : 'Não vinculada';
 
     const buildRow = (label, value) => `
       <div class="flex items-start justify-between gap-4">
@@ -218,6 +405,7 @@
       elements.overview.innerHTML = `
         <div class="space-y-3">
           ${buildRow('Empresa', companyName)}
+          ${buildRow('Conta contábil', accountLabel)}
           ${buildRow('Modalidade', 'À vista')}
           ${buildRow('Prazo', days)}
           ${buildRow('Desconto', discount)}
@@ -232,9 +420,27 @@
       elements.overview.innerHTML = `
         <div class="space-y-3">
           ${buildRow('Empresa', companyName)}
+          ${buildRow('Conta contábil', accountLabel)}
           ${buildRow('Modalidade', 'Débito')}
           ${buildRow('Prazo', days)}
           ${buildRow('Desconto', discount)}
+        </div>
+      `;
+      return;
+    }
+
+    if (state.currentType === 'crediario') {
+      const installments = Math.max(1, parseNumber(elements.crediarioInstallments?.value, 1));
+      const days = formatDays(elements.crediarioDays?.value);
+      const rate = formatRate(elements.crediarioInterest?.value);
+      elements.overview.innerHTML = `
+        <div class="space-y-3">
+          ${buildRow('Empresa', companyName)}
+          ${buildRow('Conta contábil', accountLabel)}
+          ${buildRow('Modalidade', 'Crediário')}
+          ${buildRow('Parcelas', `${installments}x`)}
+          ${buildRow('Prazo médio', days)}
+          ${buildRow('Juros', rate)}
         </div>
       `;
       return;
@@ -259,6 +465,7 @@
     elements.overview.innerHTML = `
       <div class="space-y-3">
         ${buildRow('Empresa', companyName)}
+        ${buildRow('Conta contábil', accountLabel)}
         ${buildRow('Modalidade', 'Crédito')}
         ${buildRow('Parcelas', `${installments}x`)}
         ${buildRow('Prazo', days)}
@@ -331,11 +538,20 @@
     });
   };
 
+  const updateCrediarioPreview = () => {
+    if (!elements.crediarioPreview) return;
+    const installments = Math.max(1, parseNumber(elements.crediarioInstallments?.value, 1));
+    const days = formatDays(elements.crediarioDays?.value);
+    const rate = formatRate(elements.crediarioInterest?.value);
+    elements.crediarioPreview.textContent = `${installments}x • ${days} • ${rate}`;
+  };
+
   const toggleSections = () => {
     const mapping = {
       avista: elements.avistaSection,
       debito: elements.debitoSection,
       credito: elements.creditoSection,
+      crediario: elements.crediarioSection,
     };
 
     Object.entries(mapping).forEach(([type, section]) => {
@@ -420,9 +636,23 @@
     if (state.editingId && state.editingCompanyId && state.editingCompanyId !== state.selectedCompanyId) {
       resetForm({ preserveCompany: true });
     }
+    state.selectedAccountingAccountId = '';
+    state.selectedAccountingAccount = null;
+    state.accountingAccountSearchTerm = '';
+    if (elements.accountingAccountSelect) {
+      elements.accountingAccountSelect.value = '';
+    }
+    if (elements.accountingAccountSearch) {
+      elements.accountingAccountSearch.value = '';
+    }
+    updateAccountingAccountOptions();
     updateCompanySummary();
     updateOverview();
-    await fetchPaymentMethods(state.selectedCompanyId);
+    await Promise.all([
+      fetchPaymentMethods(state.selectedCompanyId),
+      fetchAccountingAccounts(state.selectedCompanyId),
+    ]);
+    updateOverview();
   };
 
   const handleTypeChange = (event) => {
@@ -431,6 +661,7 @@
     updateAvistaPreview();
     updateDebitoPreview();
     updateCreditoPreview();
+    updateCrediarioPreview();
     updateOverview();
   };
 
@@ -455,6 +686,17 @@
       elements.companySelect.value = selectedCompanyId || '';
     }
 
+    state.selectedAccountingAccountId = '';
+    state.selectedAccountingAccount = null;
+    state.accountingAccountSearchTerm = '';
+    if (elements.accountingAccountSelect) {
+      elements.accountingAccountSelect.value = '';
+    }
+    if (elements.accountingAccountSearch) {
+      elements.accountingAccountSearch.value = '';
+    }
+    updateAccountingAccountOptions();
+
     if (elements.avistaDays) elements.avistaDays.value = 0;
     if (elements.avistaDiscount) elements.avistaDiscount.value = 0;
     if (elements.debitoDays) elements.debitoDays.value = 1;
@@ -462,6 +704,9 @@
     if (elements.creditoInstallments) elements.creditoInstallments.value = 3;
     if (elements.creditoDays) elements.creditoDays.value = 30;
     if (elements.creditoDiscount) elements.creditoDiscount.value = 2.49;
+    if (elements.crediarioInstallments) elements.crediarioInstallments.value = 6;
+    if (elements.crediarioDays) elements.crediarioDays.value = 30;
+    if (elements.crediarioInterest) elements.crediarioInterest.value = 0;
 
     const radios = Array.from(document.querySelectorAll(selectors.typeRadios));
     radios.forEach((radio) => {
@@ -473,6 +718,7 @@
     updateAvistaPreview();
     updateDebitoPreview();
     updateCreditoPreview();
+    updateCrediarioPreview();
     updateCompanySummary();
     updateOverview();
   };
@@ -507,9 +753,18 @@
           ? `Crédito • ${method.installments || 1}x`
           : method.type === 'debito'
           ? 'Débito'
+          : method.type === 'crediario'
+          ? `Crediário • ${method.installments || 1}x`
           : 'À vista';
 
       const details = [];
+      if (method.accountingAccount) {
+        const accountLabel = buildAccountingAccountLabel(method.accountingAccount);
+        details.push(
+          `<p class="text-xs text-gray-500"><span class="font-medium text-gray-600">Conta contábil:</span> ${accountLabel}</p>`
+        );
+      }
+
       if (method.type === 'credito') {
         const days = formatDays(method.days);
         const configs = Array.isArray(method.installmentConfigurations)
@@ -525,6 +780,11 @@
         } else {
           details.push('<p class="text-xs text-gray-500">Sem desconto aplicado.</p>');
         }
+      } else if (method.type === 'crediario') {
+        const installments = Math.max(1, parseNumber(method.installments, 1));
+        const days = formatDays(method.days);
+        const rate = formatRate(method.discount);
+        details.push(`<p class="text-xs text-gray-500">${installments}x • ${days} • ${rate}</p>`);
       } else {
         const days = formatDays(method.days);
         const discount = formatDiscount(method.discount);
@@ -620,6 +880,22 @@
       elements.companySelect.value = state.selectedCompanyId || '';
     }
 
+    const rawAccountingAccount =
+      typeof method.accountingAccount === 'object' && method.accountingAccount
+        ? method.accountingAccount._id || method.accountingAccount.id || method.accountingAccount.value
+        : method.accountingAccount;
+    state.selectedAccountingAccountId = rawAccountingAccount ? String(rawAccountingAccount) : '';
+    state.selectedAccountingAccount =
+      (typeof method.accountingAccount === 'object' && method.accountingAccount) || null;
+    state.accountingAccountSearchTerm = '';
+    if (elements.accountingAccountSearch) {
+      elements.accountingAccountSearch.value = '';
+    }
+    if (elements.accountingAccountSelect) {
+      elements.accountingAccountSelect.value = state.selectedAccountingAccountId;
+    }
+    updateAccountingAccountOptions();
+
     if (elements.nameInput) {
       elements.nameInput.value = method.name || '';
     }
@@ -637,11 +913,31 @@
       if (elements.avistaDiscount) elements.avistaDiscount.value = Math.max(0, parseNumber(method.discount, 0));
       if (elements.debitoDays) elements.debitoDays.value = Math.max(0, parseNumber(method.days, 1));
       if (elements.debitoDiscount) elements.debitoDiscount.value = Math.max(0, parseNumber(method.discount, 0));
+      if (elements.crediarioInstallments) elements.crediarioInstallments.value = Math.max(1, parseNumber(method.installments, 1));
+      if (elements.crediarioDays) elements.crediarioDays.value = Math.max(0, parseNumber(method.days, 30));
+      if (elements.crediarioInterest) elements.crediarioInterest.value = Math.max(0, parseNumber(method.discount, 0));
     } else if (state.currentType === 'debito') {
       if (elements.debitoDays) elements.debitoDays.value = Math.max(0, parseNumber(method.days, 1));
       if (elements.debitoDiscount) elements.debitoDiscount.value = Math.max(0, parseNumber(method.discount, 0));
       if (elements.avistaDays) elements.avistaDays.value = Math.max(0, parseNumber(method.days, 0));
       if (elements.avistaDiscount) elements.avistaDiscount.value = Math.max(0, parseNumber(method.discount, 0));
+      if (elements.crediarioInstallments) elements.crediarioInstallments.value = Math.max(1, parseNumber(method.installments, 1));
+      if (elements.crediarioDays) elements.crediarioDays.value = Math.max(0, parseNumber(method.days, 30));
+      if (elements.crediarioInterest) elements.crediarioInterest.value = Math.max(0, parseNumber(method.discount, 0));
+    } else if (state.currentType === 'crediario') {
+      const installments = Math.max(1, parseNumber(method.installments, 1));
+      const crediarioDays = Math.max(0, parseNumber(method.days, 30));
+      const rate = Math.max(0, parseNumber(method.discount, 0));
+      if (elements.crediarioInstallments) elements.crediarioInstallments.value = installments;
+      if (elements.crediarioDays) elements.crediarioDays.value = crediarioDays;
+      if (elements.crediarioInterest) elements.crediarioInterest.value = rate;
+      if (elements.avistaDays) elements.avistaDays.value = Math.max(0, parseNumber(method.days, 0));
+      if (elements.avistaDiscount) elements.avistaDiscount.value = Math.max(0, parseNumber(method.discount, 0));
+      if (elements.debitoDays) elements.debitoDays.value = Math.max(0, parseNumber(method.days, 1));
+      if (elements.debitoDiscount) elements.debitoDiscount.value = Math.max(0, parseNumber(method.discount, 0));
+      if (elements.creditoInstallments) elements.creditoInstallments.value = installments;
+      if (elements.creditoDays) elements.creditoDays.value = crediarioDays;
+      if (elements.creditoDiscount) elements.creditoDiscount.value = rate;
     } else {
       const configs = Array.isArray(method.installmentConfigurations)
         ? method.installmentConfigurations
@@ -676,6 +972,7 @@
     updateAvistaPreview();
     updateDebitoPreview();
     updateCreditoPreview();
+    updateCrediarioPreview();
     updateOverview();
     renderMethods();
   };
@@ -779,12 +1076,20 @@
       payload.code = baseCode;
     }
 
+    payload.accountingAccount = state.selectedAccountingAccountId || null;
+
     if (state.currentType === 'avista') {
       payload.days = Math.max(0, parseNumber(elements.avistaDays?.value, 0));
       payload.discount = Math.max(0, parseNumber(elements.avistaDiscount?.value, 0));
+      payload.installments = 1;
     } else if (state.currentType === 'debito') {
       payload.days = Math.max(0, parseNumber(elements.debitoDays?.value, 1));
       payload.discount = Math.max(0, parseNumber(elements.debitoDiscount?.value, 0));
+      payload.installments = 1;
+    } else if (state.currentType === 'crediario') {
+      payload.days = Math.max(0, parseNumber(elements.crediarioDays?.value, 30));
+      payload.discount = Math.max(0, parseNumber(elements.crediarioInterest?.value, 0));
+      payload.installments = Math.max(1, parseNumber(elements.crediarioInstallments?.value, 1));
     } else {
       updateCreditDiscountsStructure();
       const installments = Math.max(1, parseNumber(elements.creditoInstallments?.value, 1));
@@ -844,6 +1149,9 @@
       elements.companySelect.addEventListener('change', handleCompanyChange);
     }
 
+    elements.accountingAccountSearch?.addEventListener('input', handleAccountingAccountSearch);
+    elements.accountingAccountSelect?.addEventListener('change', handleAccountingAccountSelectChange);
+
     const radios = Array.from(document.querySelectorAll(selectors.typeRadios));
     radios.forEach((radio) => radio.addEventListener('change', handleTypeChange));
 
@@ -884,6 +1192,19 @@
       updateOverview();
     });
 
+    elements.crediarioInstallments?.addEventListener('input', () => {
+      updateCrediarioPreview();
+      updateOverview();
+    });
+    elements.crediarioDays?.addEventListener('input', () => {
+      updateCrediarioPreview();
+      updateOverview();
+    });
+    elements.crediarioInterest?.addEventListener('input', () => {
+      updateCrediarioPreview();
+      updateOverview();
+    });
+
     elements.resetButton?.addEventListener('click', (event) => {
       event.preventDefault();
       resetForm({ preserveCompany: true });
@@ -916,11 +1237,13 @@
     updateAvistaPreview();
     updateDebitoPreview();
     updateCreditoPreview();
+    updateCrediarioPreview();
     updateCompanySummary();
     updateOverview();
     renderMethods();
     bindEvents();
     fetchCompanies();
+    fetchAccountingAccounts();
   };
 
   document.addEventListener('DOMContentLoaded', initialize);

--- a/servidor/models/PaymentMethod.js
+++ b/servidor/models/PaymentMethod.js
@@ -23,6 +23,7 @@ const paymentMethodSchema = new mongoose.Schema(
       default: undefined,
     },
     accountingAccount: { type: mongoose.Schema.Types.ObjectId, ref: 'AccountingAccount' },
+    bankAccount: { type: mongoose.Schema.Types.ObjectId, ref: 'BankAccount' },
   },
   {
     timestamps: true,

--- a/servidor/models/PaymentMethod.js
+++ b/servidor/models/PaymentMethod.js
@@ -14,7 +14,7 @@ const paymentMethodSchema = new mongoose.Schema(
     company: { type: mongoose.Schema.Types.ObjectId, ref: 'Store', required: true },
     code: { type: String, trim: true },
     name: { type: String, required: true, trim: true },
-    type: { type: String, enum: ['avista', 'debito', 'credito'], required: true },
+    type: { type: String, enum: ['avista', 'debito', 'credito', 'crediario'], required: true },
     days: { type: Number, min: 0, default: 0 },
     discount: { type: Number, min: 0, default: 0 },
     installments: { type: Number, min: 1, default: 1 },
@@ -22,6 +22,7 @@ const paymentMethodSchema = new mongoose.Schema(
       type: [creditInstallmentSchema],
       default: undefined,
     },
+    accountingAccount: { type: mongoose.Schema.Types.ObjectId, ref: 'AccountingAccount' },
   },
   {
     timestamps: true,

--- a/servidor/routes/paymentMethods.js
+++ b/servidor/routes/paymentMethods.js
@@ -221,11 +221,15 @@ router.post('/', requireAuth, authorizeRoles('admin', 'admin_master'), async (re
     }
 
     const created = await PaymentMethod.create(payload);
-    const populated = await created
-      .populate('company', 'nome nomeFantasia razaoSocial cnpj cpf')
-      .populate('accountingAccount', 'name code')
-      .populate('bankAccount', 'alias bankName agency accountNumber accountDigit accountType');
-    res.status(201).json(populated);
+    await created.populate([
+      { path: 'company', select: 'nome nomeFantasia razaoSocial cnpj cpf' },
+      { path: 'accountingAccount', select: 'name code' },
+      {
+        path: 'bankAccount',
+        select: 'alias bankName agency accountNumber accountDigit accountType',
+      },
+    ]);
+    res.status(201).json(created);
   } catch (error) {
     console.error('Erro ao criar meio de pagamento:', error);
     res.status(500).json({ message: 'Erro ao criar meio de pagamento.' });
@@ -356,11 +360,15 @@ router.put('/:id', requireAuth, authorizeRoles('admin', 'admin_master'), async (
     }
 
     const saved = await existing.save();
-    const populated = await saved
-      .populate('company', 'nome nomeFantasia razaoSocial cnpj cpf')
-      .populate('accountingAccount', 'name code')
-      .populate('bankAccount', 'alias bankName agency accountNumber accountDigit accountType');
-    res.json(populated);
+    await saved.populate([
+      { path: 'company', select: 'nome nomeFantasia razaoSocial cnpj cpf' },
+      { path: 'accountingAccount', select: 'name code' },
+      {
+        path: 'bankAccount',
+        select: 'alias bankName agency accountNumber accountDigit accountType',
+      },
+    ]);
+    res.json(saved);
   } catch (error) {
     console.error('Erro ao atualizar meio de pagamento:', error);
     res.status(500).json({ message: 'Erro ao atualizar meio de pagamento.' });

--- a/servidor/routes/paymentMethods.js
+++ b/servidor/routes/paymentMethods.js
@@ -1,8 +1,11 @@
 const express = require('express');
+const mongoose = require('mongoose');
+
 const router = express.Router();
 
 const PaymentMethod = require('../models/PaymentMethod');
 const Store = require('../models/Store');
+const AccountingAccount = require('../models/AccountingAccount');
 const requireAuth = require('../middlewares/requireAuth');
 const authorizeRoles = require('../middlewares/authorizeRoles');
 
@@ -15,6 +18,26 @@ const parseNumber = (value, fallback = 0) => {
   if (value === undefined || value === null || value === '') return fallback;
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const VALID_TYPES = new Set(['avista', 'debito', 'credito', 'crediario']);
+
+const validateAccountingAccount = async (accountingAccountId) => {
+  if (!accountingAccountId) return null;
+  if (!mongoose.Types.ObjectId.isValid(accountingAccountId)) {
+    const error = new Error('Conta contábil selecionada é inválida.');
+    error.statusCode = 400;
+    throw error;
+  }
+
+  const accountExists = await AccountingAccount.exists({ _id: accountingAccountId });
+  if (!accountExists) {
+    const error = new Error('Conta contábil selecionada não foi encontrada.');
+    error.statusCode = 404;
+    throw error;
+  }
+
+  return accountingAccountId;
 };
 
 const extractNumericValue = (value) => {
@@ -77,7 +100,8 @@ router.get('/', async (req, res) => {
 
     const methods = await PaymentMethod.find(query)
       .sort({ createdAt: -1 })
-      .populate('company', 'nome nomeFantasia razaoSocial cnpj cpf');
+      .populate('company', 'nome nomeFantasia razaoSocial cnpj cpf')
+      .populate('accountingAccount', 'name code');
 
     res.json({ paymentMethods: methods });
   } catch (error) {
@@ -105,12 +129,20 @@ router.post('/', requireAuth, authorizeRoles('admin', 'admin_master'), async (re
       return res.status(404).json({ message: 'Empresa informada não foi encontrada.' });
     }
 
-    if (!['avista', 'debito', 'credito'].includes(type)) {
+    if (!VALID_TYPES.has(type)) {
       return res.status(400).json({ message: 'Tipo de recebimento inválido.' });
     }
 
     const rawCode = normalizeString(req.body.code);
     let code = rawCode && rawCode.toLowerCase() !== 'gerado automaticamente' ? rawCode : await generateNextCode(company);
+
+    let accountingAccountId = null;
+    try {
+      accountingAccountId = await validateAccountingAccount(normalizeString(req.body.accountingAccount));
+    } catch (validationError) {
+      const statusCode = validationError.statusCode || 400;
+      return res.status(statusCode).json({ message: validationError.message || 'Conta contábil inválida.' });
+    }
 
     let attempts = 0;
     while (await PaymentMethod.exists({ company, code }) && attempts < 5) {
@@ -147,10 +179,19 @@ router.post('/', requireAuth, authorizeRoles('admin', 'admin_master'), async (re
       if (installmentConfigurations.length) {
         payload.discount = installmentConfigurations[0].discount;
       }
+    } else if (type === 'crediario') {
+      const installments = Math.max(1, Math.min(24, parseNumber(req.body.installments, 1)));
+      payload.installments = installments;
+    }
+
+    if (accountingAccountId) {
+      payload.accountingAccount = accountingAccountId;
     }
 
     const created = await PaymentMethod.create(payload);
-    const populated = await created.populate('company', 'nome nomeFantasia razaoSocial cnpj cpf');
+    const populated = await created
+      .populate('company', 'nome nomeFantasia razaoSocial cnpj cpf')
+      .populate('accountingAccount', 'name code');
     res.status(201).json(populated);
   } catch (error) {
     console.error('Erro ao criar meio de pagamento:', error);
@@ -186,7 +227,7 @@ router.put('/:id', requireAuth, authorizeRoles('admin', 'admin_master'), async (
     }
 
     let type = normalizeString(req.body.type).toLowerCase();
-    if (!['avista', 'debito', 'credito'].includes(type)) {
+    if (!VALID_TYPES.has(type)) {
       type = existing.type;
     }
 
@@ -215,12 +256,28 @@ router.put('/:id', requireAuth, authorizeRoles('admin', 'admin_master'), async (
     const days = Math.max(0, parseNumber(req.body.days, existing.days || 0));
     let discount = Math.max(0, parseNumber(req.body.discount, existing.discount || 0));
 
+    let accountingAccountIdToApply = existing.accountingAccount ? String(existing.accountingAccount) : undefined;
+    if (Object.prototype.hasOwnProperty.call(req.body, 'accountingAccount')) {
+      const normalizedAccount = normalizeString(req.body.accountingAccount);
+      try {
+        accountingAccountIdToApply = await validateAccountingAccount(normalizedAccount);
+      } catch (validationError) {
+        const statusCode = validationError.statusCode || 400;
+        return res.status(statusCode).json({ message: validationError.message || 'Conta contábil inválida.' });
+      }
+
+      if (!accountingAccountIdToApply) {
+        accountingAccountIdToApply = undefined;
+      }
+    }
+
     existing.company = company;
     existing.code = candidateCode;
     existing.name = name;
     existing.type = type;
     existing.days = days;
     existing.discount = discount;
+    existing.accountingAccount = accountingAccountIdToApply;
 
     if (type === 'credito') {
       const installments = Math.max(1, Math.min(12, parseNumber(req.body.installments, existing.installments || 1)));
@@ -237,13 +294,22 @@ router.put('/:id', requireAuth, authorizeRoles('admin', 'admin_master'), async (
       }
       existing.markModified('installmentConfigurations');
     } else {
-      existing.installments = 1;
+      if (type === 'crediario') {
+        existing.installments = Math.max(
+          1,
+          Math.min(24, parseNumber(req.body.installments, existing.installments || 1))
+        );
+      } else {
+        existing.installments = 1;
+      }
       existing.installmentConfigurations = undefined;
       existing.markModified('installmentConfigurations');
     }
 
     const saved = await existing.save();
-    const populated = await saved.populate('company', 'nome nomeFantasia razaoSocial cnpj cpf');
+    const populated = await saved
+      .populate('company', 'nome nomeFantasia razaoSocial cnpj cpf')
+      .populate('accountingAccount', 'name code');
     res.json(populated);
   } catch (error) {
     console.error('Erro ao atualizar meio de pagamento:', error);

--- a/src/output.css
+++ b/src/output.css
@@ -10,6 +10,7 @@
     --color-red-50: oklch(97.1% 0.013 17.38);
     --color-red-100: oklch(93.6% 0.032 17.717);
     --color-red-200: oklch(88.5% 0.062 18.334);
+    --color-red-300: oklch(80.8% 0.114 19.571);
     --color-red-400: oklch(70.4% 0.191 22.216);
     --color-red-500: oklch(63.7% 0.237 25.331);
     --color-red-600: oklch(57.7% 0.245 27.325);
@@ -1006,6 +1007,9 @@
   .min-w-28 {
     min-width: calc(var(--spacing) * 28);
   }
+  .min-w-\[2\.25rem\] {
+    min-width: 2.25rem;
+  }
   .min-w-\[120px\] {
     min-width: 120px;
   }
@@ -1107,6 +1111,9 @@
   }
   .cursor-pointer {
     cursor: pointer;
+  }
+  .cursor-wait {
+    cursor: wait;
   }
   .resize {
     resize: both;
@@ -1569,6 +1576,9 @@
   .border-rose-500 {
     border-color: var(--color-rose-500);
   }
+  .border-sky-100 {
+    border-color: var(--color-sky-100);
+  }
   .border-sky-200 {
     border-color: var(--color-sky-200);
   }
@@ -2027,6 +2037,12 @@
   }
   .pb-6 {
     padding-bottom: calc(var(--spacing) * 6);
+  }
+  .pb-8 {
+    padding-bottom: calc(var(--spacing) * 8);
+  }
+  .pb-24 {
+    padding-bottom: calc(var(--spacing) * 24);
   }
   .pl-2 {
     padding-left: calc(var(--spacing) * 2);
@@ -2590,6 +2606,10 @@
   .outline-none {
     --tw-outline-style: none;
     outline-style: none;
+  }
+  .select-all {
+    -webkit-user-select: all;
+    user-select: all;
   }
   .select-none {
     -webkit-user-select: none;
@@ -3535,6 +3555,11 @@
       }
     }
   }
+  .focus\:ring-red-300 {
+    &:focus {
+      --tw-ring-color: var(--color-red-300);
+    }
+  }
   .focus\:ring-rose-200 {
     &:focus {
       --tw-ring-color: var(--color-rose-200);
@@ -3610,6 +3635,11 @@
       cursor: wait;
     }
   }
+  .disabled\:bg-red-400 {
+    &:disabled {
+      background-color: var(--color-red-400);
+    }
+  }
   .disabled\:opacity-50 {
     &:disabled {
       opacity: 50%;
@@ -3628,6 +3658,14 @@
   .has-\[\:checked\]\:border-primary {
     &:has(*:is(:checked)) {
       border-color: var(--color-primary);
+    }
+  }
+  .has-\[\:checked\]\:bg-primary\/5 {
+    &:has(*:is(:checked)) {
+      background-color: color-mix(in srgb, #7A9A55 5%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        background-color: color-mix(in oklab, var(--color-primary) 5%, transparent);
+      }
     }
   }
   .has-\[\:checked\]\:text-primary {
@@ -3862,6 +3900,11 @@
   .md\:w-1\/2 {
     @media (width >= 48rem) {
       width: calc(1/2 * 100%);
+    }
+  }
+  .md\:w-64 {
+    @media (width >= 48rem) {
+      width: calc(var(--spacing) * 64);
     }
   }
   .md\:w-\[420px\] {


### PR DESCRIPTION
## Summary
- add a searchable accounting account selector and new crediário configuration panel to the payment methods screen
- update client logic to load accounting accounts, handle the new crediário flow, and include account details throughout the UI
- extend payment method persistence to store the selected accounting account and support the new crediário type
- regenerate Tailwind output to expose utilities required by the new interface elements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68debdfe19ec83239c8a2fdaff31eea9