### PR TITLE
Refactor admin tab layout

### DIFF
--- a/components/admin/header.html
+++ b/components/admin/header.html
@@ -37,25 +37,4 @@
         <span class="font-semibold text-sm">Administrador</span>
       </div>
     </div>
-
-    <div class="border-t border-gray-100 bg-white/80">
-      <div class="container mx-auto px-4">
-        <div class="flex items-center gap-2 overflow-x-auto py-2" data-admin-tab-list role="tablist" aria-label="Abas do painel administrativo">
-          <div class="flex items-center" data-tab-item data-tab-id="dashboard">
-            <button
-              id="admin-tab-trigger-dashboard"
-              type="button"
-              role="tab"
-              aria-selected="true"
-              aria-controls="admin-tab-dashboard"
-              data-tab-trigger
-              data-tab-id="dashboard"
-              class="admin-tab-trigger inline-flex items-center gap-2 rounded-lg border border-transparent bg-white px-3 py-2 text-xs font-semibold text-gray-600 shadow-sm transition hover:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-primary/20"
-            >
-              <span class="truncate">Painel Principal</span>
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
   </header>

--- a/pages/admin.html
+++ b/pages/admin.html
@@ -8,66 +8,83 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
     <link rel="stylesheet" href="../src/output.css">
 </head>
-<body class="bg-gray-100" data-admin-tabs-root>
+<body class="app bg-gray-100" data-admin-tabs-root>
 
     <div id="admin-header-placeholder"></div>
 
-    <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
-        <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
-
-            <aside class="md:col-span-4">
+    <main class="app-main px-4 pb-8 pt-1">
+        <div class="flex flex-1 min-h-0 flex-col gap-6 lg:flex-row">
+            <aside class="lg:w-72 lg:flex-none">
                 <div id="admin-sidebar-placeholder"></div>
             </aside>
 
-            <div class="md:col-span-4">
-                <div class="relative" data-admin-tab-panels>
-                    <section id="admin-tab-dashboard" role="tabpanel" aria-labelledby="admin-tab-trigger-dashboard" data-tab-panel data-tab-id="dashboard" class="admin-tab-panel">
-                        <div class="rounded-2xl bg-white p-6 shadow">
-                            <h1 class="mb-6 text-2xl font-bold text-gray-800">Painel Principal</h1>
-
-                            <div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-
-                                <a href="admin/admin-produtos.html" class="block rounded-lg border-2 border-transparent bg-gray-50 p-6 shadow-sm transition-all duration-300 hover:border-primary hover:shadow-lg">
-                                    <div class="flex items-center space-x-4">
-                                        <div class="rounded-full bg-primary/10 p-3">
-                                            <i class="fas fa-box-open text-2xl text-primary"></i>
-                                        </div>
-                                        <div>
-                                            <h3 class="text-lg font-bold text-gray-800">Gerir Produtos</h3>
-                                            <p class="text-sm text-gray-600">Adicionar e editar produtos</p>
-                                        </div>
-                                    </div>
-                                </a>
-                                <a href="#" class="block rounded-lg border-2 border-transparent bg-gray-50 p-6 shadow-sm transition-all duration-300 hover:border-primary hover:shadow-lg">
-                                    <div class="flex items-center space-x-4">
-                                        <div class="rounded-full bg-primary/10 p-3">
-                                            <i class="fas fa-receipt text-2xl text-primary"></i>
-                                        </div>
-                                        <div>
-                                            <h3 class="text-lg font-bold text-gray-800">Ver Pedidos</h3>
-                                            <p class="text-sm text-gray-600">Visualizar pedidos dos clientes</p>
-                                        </div>
-                                    </div>
-                                </a>
-
-                                <a href="#" class="block rounded-lg border-2 border-transparent bg-gray-50 p-6 shadow-sm transition-all duration-300 hover:border-primary hover:shadow-lg">
-                                    <div class="flex items-center space-x-4">
-                                        <div class="rounded-full bg-primary/10 p-3">
-                                            <i class="fas fa-users text-2xl text-primary"></i>
-                                        </div>
-                                        <div>
-                                            <h3 class="text-lg font-bold text-gray-800">Gerir Clientes</h3>
-                                            <p class="text-sm text-gray-600">Consultar lista de clientes</p>
-                                        </div>
-                                    </div>
-                                </a>
-
-                            </div>
+            <div class="flex-1 min-h-0">
+                <div class="tabs-root">
+                    <div class="flex items-center gap-2 overflow-x-auto pb-4" data-admin-tab-list role="tablist" aria-label="Abas do painel administrativo">
+                        <div data-tab-item data-tab-id="dashboard">
+                            <button
+                              id="admin-tab-trigger-dashboard"
+                              type="button"
+                              role="tab"
+                              aria-selected="true"
+                              aria-controls="admin-tab-dashboard"
+                              data-tab-trigger
+                              data-tab-id="dashboard"
+                              class="tab-trigger inline-flex items-center gap-2 px-3 py-2 text-xs font-semibold is-active"
+                            >
+                              <span class="truncate">Painel Principal</span>
+                            </button>
                         </div>
-                    </section>
+                    </div>
+
+                    <div class="tab-panels" data-admin-tab-panels>
+                        <section id="admin-tab-dashboard" role="tabpanel" aria-labelledby="admin-tab-trigger-dashboard" data-tab-panel data-tab-id="dashboard" class="tab-panel">
+                            <div class="rounded-2xl bg-white p-6 shadow">
+                                <h1 class="mb-6 text-2xl font-bold text-gray-800">Painel Principal</h1>
+
+                                <div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+
+                                    <a href="admin/admin-produtos.html" class="block rounded-lg border-2 border-transparent bg-gray-50 p-6 shadow-sm transition-all duration-300 hover:border-primary hover:shadow-lg">
+                                        <div class="flex items-center space-x-4">
+                                            <div class="rounded-full bg-primary/10 p-3">
+                                                <i class="fas fa-box-open text-2xl text-primary"></i>
+                                            </div>
+                                            <div>
+                                                <h3 class="text-lg font-bold text-gray-800">Gerir Produtos</h3>
+                                                <p class="text-sm text-gray-600">Adicionar e editar produtos</p>
+                                            </div>
+                                        </div>
+                                    </a>
+                                    <a href="#" class="block rounded-lg border-2 border-transparent bg-gray-50 p-6 shadow-sm transition-all duration-300 hover:border-primary hover:shadow-lg">
+                                        <div class="flex items-center space-x-4">
+                                            <div class="rounded-full bg-primary/10 p-3">
+                                                <i class="fas fa-receipt text-2xl text-primary"></i>
+                                            </div>
+                                            <div>
+                                                <h3 class="text-lg font-bold text-gray-800">Ver Pedidos</h3>
+                                                <p class="text-sm text-gray-600">Visualizar pedidos dos clientes</p>
+                                            </div>
+                                        </div>
+                                    </a>
+
+                                    <a href="#" class="block rounded-lg border-2 border-transparent bg-gray-50 p-6 shadow-sm transition-all duration-300 hover:border-primary hover:shadow-lg">
+                                        <div class="flex items-center space-x-4">
+                                            <div class="rounded-full bg-primary/10 p-3">
+                                                <i class="fas fa-users text-2xl text-primary"></i>
+                                            </div>
+                                            <div>
+                                                <h3 class="text-lg font-bold text-gray-800">Gerir Clientes</h3>
+                                                <p class="text-sm text-gray-600">Consultar lista de clientes</p>
+                                            </div>
+                                        </div>
+                                    </a>
+
+                                </div>
+                            </div>
+                        </section>
+                    </div>
                 </div>
             </div>
-
         </div>
     </main>
 
@@ -75,7 +92,7 @@
     <div id="confirm-modal-placeholder"></div>
 
     <div id="admin-footer-placeholder"></div>
-    
+
     <script>var basePath = '../';</script>
     <script src="../scripts/core/config.js"></script>
     <script src="../scripts/core/ui.js"></script>

--- a/scripts/admin/admin-tabs.js
+++ b/scripts/admin/admin-tabs.js
@@ -32,53 +32,9 @@
     let counter = 0;
     let persistReady = false;
 
-    const BASE_TRIGGER_CLASSES = [
-      'admin-tab-trigger',
-      'inline-flex',
-      'items-center',
-      'gap-2',
-      'rounded-lg',
-      'border',
-      'border-transparent',
-      'bg-white',
-      'px-3',
-      'py-2',
-      'text-xs',
-      'font-semibold',
-      'text-gray-600',
-      'shadow-sm',
-      'transition',
-      'hover:bg-primary/10',
-      'focus:outline-none',
-      'focus:ring-2',
-      'focus:ring-primary/20',
-    ];
-
-    const ACTIVE_TRIGGER_CLASSES = [
-      'border-primary/30',
-      'bg-primary/10',
-      'text-primary',
-      'shadow',
-    ];
-
-    const INACTIVE_TRIGGER_CLASSES = [
-      'border-transparent',
-      'bg-white',
-      'text-gray-600',
-      'shadow-sm',
-    ];
-
     function applyTriggerState(trigger, isActive) {
       if (!trigger) return;
-
-      ACTIVE_TRIGGER_CLASSES.forEach((cls) => {
-        trigger.classList.toggle(cls, isActive);
-      });
-
-      INACTIVE_TRIGGER_CLASSES.forEach((cls) => {
-        trigger.classList.toggle(cls, !isActive);
-      });
-
+      trigger.classList.toggle('is-active', isActive);
       trigger.setAttribute('aria-selected', isActive ? 'true' : 'false');
     }
 
@@ -158,11 +114,11 @@
 
       const trigger = document.createElement('button');
       trigger.type = 'button';
-      BASE_TRIGGER_CLASSES.forEach((cls) => trigger.classList.add(cls));
+      trigger.className = 'tab-trigger inline-flex items-center gap-2 px-3 py-2 text-xs font-semibold';
       trigger.dataset.tabTrigger = 'true';
 
       const labelSpan = document.createElement('span');
-      labelSpan.className = 'max-w-[12rem] truncate';
+      labelSpan.className = 'truncate';
       labelSpan.textContent = safeLabel;
       trigger.appendChild(labelSpan);
 
@@ -287,7 +243,7 @@
       panel.dataset.tabId = id;
       panel.setAttribute('role', 'tabpanel');
       panel.setAttribute('aria-labelledby', `admin-tab-trigger-${id}`);
-      panel.className = 'admin-tab-panel hidden';
+      panel.className = 'tab-panel hidden';
       panel.dataset.embeddedPanel = 'true';
 
       const frameWrapper = document.createElement('div');

--- a/scripts/admin/admin.js
+++ b/scripts/admin/admin.js
@@ -73,7 +73,7 @@ async function checkAdminAccess() {
 
         const mainElement = document.querySelector('main');
         if (mainElement) {
-          mainElement.classList.remove('container', 'mx-auto', 'px-4', 'py-8', 'min-h-screen');
+          mainElement.classList.remove('container', 'mx-auto', 'px-4', 'py-8', 'pb-8', 'pt-1', 'min-h-screen');
           mainElement.classList.add('admin-embedded-main');
         }
       };

--- a/src/input.css
+++ b/src/input.css
@@ -97,6 +97,39 @@
     }
     /* Garante que o wrapper ocupe toda a linha */
     .awesomplete { width: 100%; }
+
+    .app {
+        @apply min-h-screen flex flex-col;
+    }
+
+    .app-main {
+        @apply flex-1 min-h-0 flex flex-col;
+    }
+
+    .tabs-root {
+        display: grid;
+        grid-template-rows: auto 1fr;
+        height: 100%;
+        min-height: 0;
+        width: 100%;
+        min-width: 0;
+    }
+
+    .tab-panels {
+        @apply flex-1 min-h-0 flex flex-col;
+        width: 100%;
+        min-width: 0;
+    }
+
+    .tab-panel {
+        height: 100%;
+        overflow: auto;
+        background: transparent;
+        padding: 0;
+        margin: 0;
+        width: 100%;
+        max-width: none;
+    }
     @keyframes fillIndicator {
         from { width: 0; }
         to { width: 40px; }
@@ -1268,7 +1301,7 @@
     @apply min-h-0;
   }
 
-  .admin-tab-panel {
+  .tab-panel {
     @apply min-h-0;
   }
 

--- a/src/output.css
+++ b/src/output.css
@@ -812,6 +812,9 @@
   .max-h-screen {
     max-height: 100vh;
   }
+  .min-h-0 {
+    min-height: calc(var(--spacing) * 0);
+  }
   .min-h-\[2\.5rem\] {
     min-height: 2.5rem;
   }
@@ -961,9 +964,6 @@
   }
   .max-w-5xl {
     max-width: var(--container-5xl);
-  }
-  .max-w-\[12rem\] {
-    max-width: 12rem;
   }
   .max-w-\[180px\] {
     max-width: 180px;
@@ -4135,6 +4135,16 @@
       width: calc(2/3 * 100%);
     }
   }
+  .lg\:w-72 {
+    @media (width >= 64rem) {
+      width: calc(var(--spacing) * 72);
+    }
+  }
+  .lg\:flex-none {
+    @media (width >= 64rem) {
+      flex: none;
+    }
+  }
   .lg\:grid-cols-2 {
     @media (width >= 64rem) {
       grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -4318,6 +4328,42 @@
   }
   .awesomplete {
     width: 100%;
+  }
+  .app {
+    display: flex;
+    min-height: 100vh;
+    flex-direction: column;
+  }
+  .app-main {
+    display: flex;
+    min-height: calc(var(--spacing) * 0);
+    flex: 1;
+    flex-direction: column;
+  }
+  .tabs-root {
+    display: grid;
+    grid-template-rows: auto 1fr;
+    height: 100%;
+    min-height: 0;
+    width: 100%;
+    min-width: 0;
+  }
+  .tab-panels {
+    display: flex;
+    min-height: calc(var(--spacing) * 0);
+    flex: 1;
+    flex-direction: column;
+    width: 100%;
+    min-width: 0;
+  }
+  .tab-panel {
+    height: 100%;
+    overflow: auto;
+    background: transparent;
+    padding: 0;
+    margin: 0;
+    width: 100%;
+    max-width: none;
   }
   @keyframes fillIndicator {
     from {
@@ -5463,7 +5509,7 @@
   body.admin-embedded[data-admin-tabs-root] {
     min-height: calc(var(--spacing) * 0);
   }
-  .admin-tab-panel {
+  .tab-panel {
     min-height: calc(var(--spacing) * 0);
   }
   .admin-tab-iframe {


### PR DESCRIPTION
## Summary
- restructure the admin landing page to use the new app/tabs layout and move the tab list out of the header
- add headless layout utilities for the tab system and update the tab script to drop baked-in borders, shadows, and max-width styles
- tweak the admin embedded adjustment script and rebuild Tailwind output

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dede3e5c408323945230da43b434d0