### PR TITLE
Fix modal height to avoid viewport overflow

### DIFF
--- a/src/input.css
+++ b/src/input.css
@@ -1003,24 +1003,25 @@
   .modal-shell {
     width: 100%;
     height: auto;
-    min-height: calc(100vh - 1.5rem);
+    max-height: calc(100vh - 1.5rem);
+    overflow-y: auto;
   }
 
   @media (min-width: 768px) {
     .modal-shell {
-      min-height: calc(100vh - 4rem);
+      max-height: calc(100vh - 4rem);
     }
   }
 
   @media (min-width: 1536px) {
     .modal-shell {
-      min-height: calc(100vh - 6rem);
+      max-height: calc(100vh - 6rem);
     }
   }
 
   @media (max-width: 767px) {
     .modal-shell {
-      min-height: 100vh;
+      max-height: 100vh;
     }
   }
 

--- a/src/output.css
+++ b/src/output.css
@@ -5280,21 +5280,22 @@
   .modal-shell {
     width: 100%;
     height: auto;
-    min-height: calc(100vh - 1.5rem);
+    max-height: calc(100vh - 1.5rem);
+    overflow-y: auto;
   }
   @media (min-width: 768px) {
     .modal-shell {
-      min-height: calc(100vh - 4rem);
+      max-height: calc(100vh - 4rem);
     }
   }
   @media (min-width: 1536px) {
     .modal-shell {
-      min-height: calc(100vh - 6rem);
+      max-height: calc(100vh - 6rem);
     }
   }
   @media (max-width: 767px) {
     .modal-shell {
-      min-height: 100vh;
+      max-height: 100vh;
     }
   }
   @media (width >= 48rem) {


### PR DESCRIPTION
## Summary
- limit modal containers to the viewport height and enable internal scrolling to keep modals fully visible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e03d8e2d6883239eba0e9f64ff588d