### PR TITLE
Handle legacy token sources in auth middleware

### DIFF
--- a/servidor/middlewares/authMiddleware.js
+++ b/servidor/middlewares/authMiddleware.js
@@ -1,23 +1,19 @@
 const jwt = require('jsonwebtoken');
+const { getRequestToken } = require('./getRequestToken');
 
 function authMiddleware(req, res, next) {
-    const authHeader = req.headers['authorization'];
-    if (!authHeader) {
-        return res.status(401).json({ message: 'Token não fornecido' });
-    }
+  const token = getRequestToken(req);
+  if (!token) {
+    return res.status(401).json({ message: 'Token não fornecido' });
+  }
 
-    const token = authHeader.split(' ')[1]; // formato: "Bearer xxx"
-    if (!token) {
-        return res.status(401).json({ message: 'Token inválido' });
-    }
-
-    try {
-        const decoded = jwt.verify(token, process.env.JWT_SECRET);
-        req.user = decoded; // agora o usuário está disponível no req.user
-        next();
-    } catch (error) {
-        return res.status(403).json({ message: 'Token inválido ou expirado' });
-    }
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded;
+    return next();
+  } catch (error) {
+    return res.status(403).json({ message: 'Token inválido ou expirado' });
+  }
 }
 
 module.exports = authMiddleware;

--- a/servidor/middlewares/getRequestToken.js
+++ b/servidor/middlewares/getRequestToken.js
@@ -1,0 +1,94 @@
+const BEARER_PREFIX = /^bearer\s+/i;
+
+function normalizeToken(rawToken) {
+  if (!rawToken || typeof rawToken !== 'string') {
+    return '';
+  }
+  const trimmed = rawToken.trim();
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed.replace(BEARER_PREFIX, '');
+}
+
+function extractFromAuthorization(headerValue) {
+  if (!headerValue) {
+    return '';
+  }
+  const normalized = headerValue.trim();
+  if (!normalized) {
+    return '';
+  }
+  if (normalized.includes(' ')) {
+    const [, token] = normalized.split(' ');
+    return normalizeToken(token || '');
+  }
+  return normalizeToken(normalized);
+}
+
+function extractFromCookies(cookieHeader) {
+  if (!cookieHeader || typeof cookieHeader !== 'string') {
+    return '';
+  }
+  const entries = cookieHeader.split(';');
+  for (const entry of entries) {
+    const [rawKey, ...rawValue] = entry.split('=');
+    const key = rawKey?.trim().toLowerCase();
+    if (!key || rawValue.length === 0) {
+      continue;
+    }
+    if (!['auth_token', 'token', 'jwt'].includes(key)) {
+      continue;
+    }
+    const joined = rawValue.join('=').trim();
+    if (!joined) {
+      continue;
+    }
+    try {
+      return normalizeToken(decodeURIComponent(joined));
+    } catch (_) {
+      return normalizeToken(joined);
+    }
+  }
+  return '';
+}
+
+function getRequestToken(req) {
+  if (!req || typeof req !== 'object') {
+    return '';
+  }
+
+  const headerToken =
+    extractFromAuthorization(req.headers?.authorization) ||
+    normalizeToken(req.headers?.['x-access-token']) ||
+    normalizeToken(req.headers?.token);
+  if (headerToken) {
+    return headerToken;
+  }
+
+  if (req.query && typeof req.query.token === 'string') {
+    const queryToken = normalizeToken(req.query.token);
+    if (queryToken) {
+      return queryToken;
+    }
+  }
+
+  if (req.cookies) {
+    for (const key of ['auth_token', 'token', 'jwt']) {
+      const value = req.cookies[key];
+      const normalized = normalizeToken(value);
+      if (normalized) {
+        return normalized;
+      }
+    }
+  }
+
+  const cookieHeader = extractFromCookies(req.headers?.cookie);
+  if (cookieHeader) {
+    return cookieHeader;
+  }
+
+  return '';
+}
+
+module.exports = { getRequestToken };

--- a/servidor/middlewares/getRequestToken.js
+++ b/servidor/middlewares/getRequestToken.js
@@ -1,55 +1,232 @@
 const BEARER_PREFIX = /^bearer\s+/i;
+const NAMED_PREFIX = /^(token|jwt|auth[_-]?token|access[_-]?token|authorization)\s*[:=]\s*/i;
 
-function normalizeToken(rawToken) {
-  if (!rawToken || typeof rawToken !== 'string') {
+function coerceToString(rawValue) {
+  if (typeof rawValue === 'string') {
+    return rawValue;
+  }
+  if (rawValue == null) {
     return '';
   }
-  const trimmed = rawToken.trim();
-  if (!trimmed) {
-    return '';
+  if (typeof rawValue === 'number' || typeof rawValue === 'boolean' || typeof rawValue === 'bigint') {
+    return String(rawValue);
   }
-  return trimmed.replace(BEARER_PREFIX, '');
+  return '';
 }
 
-function extractFromAuthorization(headerValue) {
-  if (!headerValue) {
+function normalizeToken(rawToken) {
+  if (!rawToken) {
     return '';
   }
-  const normalized = headerValue.trim();
+  const coerced = coerceToString(rawToken);
+  if (!coerced) {
+    return '';
+  }
+
+  let normalized = coerced.trim();
   if (!normalized) {
     return '';
   }
-  if (normalized.includes(' ')) {
-    const [, token] = normalized.split(' ');
-    return normalizeToken(token || '');
+
+  normalized = normalized.replace(/^"+|"+$/g, '');
+  normalized = normalized.replace(/^'+|'+$/g, '');
+  normalized = normalized.replace(BEARER_PREFIX, '');
+  normalized = normalized.replace(NAMED_PREFIX, '');
+
+  return normalized.trim();
+}
+
+function safeParseJson(value) {
+  const source = coerceToString(value);
+  if (!source) {
+    return null;
   }
+  try {
+    const parsed = JSON.parse(source);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function extractTokenFromRecord(record, depth = 0) {
+  if (!record || typeof record !== 'object' || depth > 3) {
+    return '';
+  }
+
+  const directKeys = [
+    'token',
+    'authToken',
+    'accessToken',
+    'jwt',
+    'sessionToken',
+    'authorization',
+    'bearerToken'
+  ];
+
+  for (const key of directKeys) {
+    if (Object.prototype.hasOwnProperty.call(record, key)) {
+      const value = record[key];
+      const normalized = normalizeToken(value);
+      if (normalized) {
+        return normalized;
+      }
+    }
+  }
+
+  const nestedKeys = [
+    'user',
+    'usuario',
+    'session',
+    'auth',
+    'data',
+    'payload',
+    'value'
+  ];
+
+  for (const key of nestedKeys) {
+    if (record[key] && typeof record[key] === 'object') {
+      const nestedToken = extractTokenFromRecord(record[key], depth + 1);
+      if (nestedToken) {
+        return nestedToken;
+      }
+    }
+  }
+
+  return '';
+}
+
+function extractTokenFromValue(value) {
+  if (!value) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    const normalized = normalizeToken(value);
+    if (normalized) {
+      return normalized;
+    }
+    const parsed = safeParseJson(value);
+    if (parsed) {
+      return extractTokenFromRecord(parsed);
+    }
+    return '';
+  }
+
+  if (typeof value === 'object') {
+    return extractTokenFromRecord(value);
+  }
+
+  return normalizeToken(value);
+}
+
+function extractFromAuthorization(headerValue) {
+  const coerced = coerceToString(headerValue);
+  if (!coerced) {
+    return '';
+  }
+
+  const normalized = coerced.trim();
+  if (!normalized) {
+    return '';
+  }
+
+  const spaceIndex = normalized.indexOf(' ');
+  if (spaceIndex > -1) {
+    const token = normalized.slice(spaceIndex + 1);
+    const normalizedToken = normalizeToken(token);
+    if (normalizedToken) {
+      return normalizedToken;
+    }
+  }
+
+  const separatorMatch = normalized.match(/^(bearer|token|jwt|auth[_-]?token|access[_-]?token)[=:]/i);
+  if (separatorMatch) {
+    const [, prefix] = separatorMatch;
+    const token = normalized.slice(prefix.length + 1);
+    const normalizedToken = normalizeToken(token);
+    if (normalizedToken) {
+      return normalizedToken;
+    }
+  }
+
   return normalizeToken(normalized);
 }
 
 function extractFromCookies(cookieHeader) {
-  if (!cookieHeader || typeof cookieHeader !== 'string') {
+  const source = coerceToString(cookieHeader);
+  if (!source) {
     return '';
   }
-  const entries = cookieHeader.split(';');
+
+  const entries = source.split(';');
   for (const entry of entries) {
     const [rawKey, ...rawValue] = entry.split('=');
     const key = rawKey?.trim().toLowerCase();
     if (!key || rawValue.length === 0) {
       continue;
     }
-    if (!['auth_token', 'token', 'jwt'].includes(key)) {
-      continue;
-    }
     const joined = rawValue.join('=').trim();
     if (!joined) {
       continue;
     }
+
+    let decoded = joined;
     try {
-      return normalizeToken(decodeURIComponent(joined));
+      decoded = decodeURIComponent(joined);
     } catch (_) {
-      return normalizeToken(joined);
+      decoded = joined;
+    }
+
+    if (['auth_token', 'token', 'jwt', 'pdv_token', 'access_token', 'session_token'].includes(key)) {
+      const normalized = normalizeToken(decoded);
+      if (normalized) {
+        return normalized;
+      }
+    }
+
+    if (['loggedinuser', 'usuario', 'session', 'auth'].includes(key)) {
+      const extracted = extractTokenFromValue(decoded);
+      if (extracted) {
+        return extracted;
+      }
     }
   }
+
+  return '';
+}
+
+function extractFromHeaders(headers) {
+  if (!headers || typeof headers !== 'object') {
+    return '';
+  }
+
+  const authorization = headers.authorization || headers.Authorization;
+  const authorizationToken = extractFromAuthorization(authorization);
+  if (authorizationToken) {
+    return authorizationToken;
+  }
+
+  const headerKeys = [
+    'x-access-token',
+    'x-auth-token',
+    'auth-token',
+    'authorization-token',
+    'pdv-token',
+    'token',
+    'jwt',
+    'access-token'
+  ];
+
+  for (const key of headerKeys) {
+    if (key in headers) {
+      const candidate = normalizeToken(headers[key]);
+      if (candidate) {
+        return candidate;
+      }
+    }
+  }
+
   return '';
 }
 
@@ -58,27 +235,76 @@ function getRequestToken(req) {
     return '';
   }
 
-  const headerToken =
-    extractFromAuthorization(req.headers?.authorization) ||
-    normalizeToken(req.headers?.['x-access-token']) ||
-    normalizeToken(req.headers?.token);
+  const headerToken = extractFromHeaders(req.headers);
   if (headerToken) {
     return headerToken;
   }
 
-  if (req.query && typeof req.query.token === 'string') {
-    const queryToken = normalizeToken(req.query.token);
-    if (queryToken) {
-      return queryToken;
+  const queryToken = extractTokenFromRecord(req.query);
+  if (queryToken) {
+    return queryToken;
+  }
+
+  if (req.query) {
+    const queryStrings = [
+      req.query.token,
+      req.query.auth_token,
+      req.query.jwt,
+      req.query.access_token,
+      req.query.authorization
+    ];
+    for (const candidate of queryStrings) {
+      const normalized = normalizeToken(candidate);
+      if (normalized) {
+        return normalized;
+      }
+    }
+  }
+
+  const bodyToken = extractTokenFromRecord(req.body);
+  if (bodyToken) {
+    return bodyToken;
+  }
+
+  if (req.body) {
+    const bodyStrings = [
+      req.body?.token,
+      req.body?.auth_token,
+      req.body?.jwt,
+      req.body?.access_token,
+      req.body?.authorization
+    ];
+    for (const candidate of bodyStrings) {
+      const normalized = normalizeToken(candidate);
+      if (normalized) {
+        return normalized;
+      }
     }
   }
 
   if (req.cookies) {
-    for (const key of ['auth_token', 'token', 'jwt']) {
-      const value = req.cookies[key];
-      const normalized = normalizeToken(value);
-      if (normalized) {
-        return normalized;
+    for (const key of [
+      'auth_token',
+      'token',
+      'jwt',
+      'pdv_token',
+      'access_token',
+      'session_token'
+    ]) {
+      if (key in req.cookies) {
+        const normalized = normalizeToken(req.cookies[key]);
+        if (normalized) {
+          return normalized;
+        }
+      }
+    }
+
+    for (const key of ['loggedInUser', 'usuario', 'session', 'auth']) {
+      if (key in req.cookies) {
+        const extracted = extractTokenFromValue(req.cookies[key]);
+        if (extracted) {
+          return extracted;
+        }
       }
     }
   }

--- a/servidor/middlewares/requireAuth.js
+++ b/servidor/middlewares/requireAuth.js
@@ -1,21 +1,21 @@
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
+const { getRequestToken } = require('./getRequestToken');
 
 module.exports = async function requireAuth(req, res, next) {
   try {
-    const authHeader = req.headers['authorization'];
-    if (!authHeader) return res.status(401).json({ message: 'Token não fornecido' });
-
-    const token = authHeader.split(' ')[1];
-    if (!token) return res.status(401).json({ message: 'Token inválido' });
+    const token = getRequestToken(req);
+    if (!token) {
+      return res.status(401).json({ message: 'Token não fornecido' });
+    }
 
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
 
-    // Buscar usuário no banco (garante que não foi deletado ou alterado)
     const user = await User.findById(decoded.id);
-    if (!user) return res.status(401).json({ message: 'Usuário não encontrado' });
+    if (!user) {
+      return res.status(401).json({ message: 'Usuário não encontrado' });
+    }
 
-    // Anexa os dados do usuário no request
     req.user = {
       id: user._id.toString(),
       email: user.email,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
+import { ensureLegacyAuthSession } from "./legacy/ensure-legacy-auth";
 import { ensureLegacyApiConfig } from "./legacy/ensure-api-config";
 import "./styles/globals.css";
 
@@ -13,6 +14,7 @@ if (!rootElement) {
   throw new Error("Elemento raiz não encontrado");
 }
 
+ensureLegacyAuthSession();
 ensureLegacyApiConfig();
 
 createRoot(rootElement).render(


### PR DESCRIPTION
## Summary
- add a helper to extract auth tokens from headers, cookies or query params
- update the auth middleware stack to rely on the helper so legacy sessions are accepted

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e09a7e7dc483239755c30ceb9275a5