### PR TITLE
Atualiza identificação do consumidor na NFC-e

### DIFF
--- a/servidor/data/ibge-municipios.json
+++ b/servidor/data/ibge-municipios.json
@@ -1,0 +1,27857 @@
+[
+  {
+    "codigo": "1100015",
+    "municipio": "Alta Floresta D'Oeste",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100023",
+    "municipio": "Ariquemes",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100031",
+    "municipio": "Cabixi",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100049",
+    "municipio": "Cacoal",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100056",
+    "municipio": "Cerejeiras",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100064",
+    "municipio": "Colorado do Oeste",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100072",
+    "municipio": "Corumbiara",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100080",
+    "municipio": "Costa Marques",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100098",
+    "municipio": "Espigão D'Oeste",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100106",
+    "municipio": "Guajará-Mirim",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100114",
+    "municipio": "Jaru",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100122",
+    "municipio": "Ji-Paraná",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100130",
+    "municipio": "Machadinho D'Oeste",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100148",
+    "municipio": "Nova Brasilândia D'Oeste",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100155",
+    "municipio": "Ouro Preto do Oeste",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100189",
+    "municipio": "Pimenta Bueno",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100205",
+    "municipio": "Porto Velho",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100254",
+    "municipio": "Presidente Médici",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100262",
+    "municipio": "Rio Crespo",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100288",
+    "municipio": "Rolim de Moura",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100296",
+    "municipio": "Santa Luzia D'Oeste",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100304",
+    "municipio": "Vilhena",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100320",
+    "municipio": "São Miguel do Guaporé",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100338",
+    "municipio": "Nova Mamoré",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100346",
+    "municipio": "Alvorada D'Oeste",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100379",
+    "municipio": "Alto Alegre dos Parecis",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100403",
+    "municipio": "Alto Paraíso",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100452",
+    "municipio": "Buritis",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100502",
+    "municipio": "Novo Horizonte do Oeste",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100601",
+    "municipio": "Cacaulândia",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100700",
+    "municipio": "Campo Novo de Rondônia",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100809",
+    "municipio": "Candeias do Jamari",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100908",
+    "municipio": "Castanheiras",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100924",
+    "municipio": "Chupinguaia",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1100940",
+    "municipio": "Cujubim",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1101005",
+    "municipio": "Governador Jorge Teixeira",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1101104",
+    "municipio": "Itapuã do Oeste",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1101203",
+    "municipio": "Ministro Andreazza",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1101302",
+    "municipio": "Mirante da Serra",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1101401",
+    "municipio": "Monte Negro",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1101435",
+    "municipio": "Nova União",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1101450",
+    "municipio": "Parecis",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1101468",
+    "municipio": "Pimenteiras do Oeste",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1101476",
+    "municipio": "Primavera de Rondônia",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1101484",
+    "municipio": "São Felipe D'Oeste",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1101492",
+    "municipio": "São Francisco do Guaporé",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1101500",
+    "municipio": "Seringueiras",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1101559",
+    "municipio": "Teixeirópolis",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1101609",
+    "municipio": "Theobroma",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1101708",
+    "municipio": "Urupá",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1101757",
+    "municipio": "Vale do Anari",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1101807",
+    "municipio": "Vale do Paraíso",
+    "uf": "RO"
+  },
+  {
+    "codigo": "1200013",
+    "municipio": "Acrelândia",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200054",
+    "municipio": "Assis Brasil",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200104",
+    "municipio": "Brasiléia",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200138",
+    "municipio": "Bujari",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200179",
+    "municipio": "Capixaba",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200203",
+    "municipio": "Cruzeiro do Sul",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200252",
+    "municipio": "Epitaciolândia",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200302",
+    "municipio": "Feijó",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200328",
+    "municipio": "Jordão",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200336",
+    "municipio": "Mâncio Lima",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200344",
+    "municipio": "Manoel Urbano",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200351",
+    "municipio": "Marechal Thaumaturgo",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200385",
+    "municipio": "Plácido de Castro",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200393",
+    "municipio": "Porto Walter",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200401",
+    "municipio": "Rio Branco",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200427",
+    "municipio": "Rodrigues Alves",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200435",
+    "municipio": "Santa Rosa do Purus",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200450",
+    "municipio": "Senador Guiomard",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200500",
+    "municipio": "Sena Madureira",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200609",
+    "municipio": "Tarauacá",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200708",
+    "municipio": "Xapuri",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1200807",
+    "municipio": "Porto Acre",
+    "uf": "AC"
+  },
+  {
+    "codigo": "1300029",
+    "municipio": "Alvarães",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1300060",
+    "municipio": "Amaturá",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1300086",
+    "municipio": "Anamã",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1300102",
+    "municipio": "Anori",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1300144",
+    "municipio": "Apuí",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1300201",
+    "municipio": "Atalaia do Norte",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1300300",
+    "municipio": "Autazes",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1300409",
+    "municipio": "Barcelos",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1300508",
+    "municipio": "Barreirinha",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1300607",
+    "municipio": "Benjamin Constant",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1300631",
+    "municipio": "Beruri",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1300680",
+    "municipio": "Boa Vista do Ramos",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1300706",
+    "municipio": "Boca do Acre",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1300805",
+    "municipio": "Borba",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1300839",
+    "municipio": "Caapiranga",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1300904",
+    "municipio": "Canutama",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1301001",
+    "municipio": "Carauari",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1301100",
+    "municipio": "Careiro",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1301159",
+    "municipio": "Careiro da Várzea",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1301209",
+    "municipio": "Coari",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1301308",
+    "municipio": "Codajás",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1301407",
+    "municipio": "Eirunepé",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1301506",
+    "municipio": "Envira",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1301605",
+    "municipio": "Fonte Boa",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1301654",
+    "municipio": "Guajará",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1301704",
+    "municipio": "Humaitá",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1301803",
+    "municipio": "Ipixuna",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1301852",
+    "municipio": "Iranduba",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1301902",
+    "municipio": "Itacoatiara",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1301951",
+    "municipio": "Itamarati",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1302009",
+    "municipio": "Itapiranga",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1302108",
+    "municipio": "Japurá",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1302207",
+    "municipio": "Juruá",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1302306",
+    "municipio": "Jutaí",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1302405",
+    "municipio": "Lábrea",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1302504",
+    "municipio": "Manacapuru",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1302553",
+    "municipio": "Manaquiri",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1302603",
+    "municipio": "Manaus",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1302702",
+    "municipio": "Manicoré",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1302801",
+    "municipio": "Maraã",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1302900",
+    "municipio": "Maués",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1303007",
+    "municipio": "Nhamundá",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1303106",
+    "municipio": "Nova Olinda do Norte",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1303205",
+    "municipio": "Novo Airão",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1303304",
+    "municipio": "Novo Aripuanã",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1303403",
+    "municipio": "Parintins",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1303502",
+    "municipio": "Pauini",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1303536",
+    "municipio": "Presidente Figueiredo",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1303569",
+    "municipio": "Rio Preto da Eva",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1303601",
+    "municipio": "Santa Isabel do Rio Negro",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1303700",
+    "municipio": "Santo Antônio do Içá",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1303809",
+    "municipio": "São Gabriel da Cachoeira",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1303908",
+    "municipio": "São Paulo de Olivença",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1303957",
+    "municipio": "São Sebastião do Uatumã",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1304005",
+    "municipio": "Silves",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1304062",
+    "municipio": "Tabatinga",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1304104",
+    "municipio": "Tapauá",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1304203",
+    "municipio": "Tefé",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1304237",
+    "municipio": "Tonantins",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1304260",
+    "municipio": "Uarini",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1304302",
+    "municipio": "Urucará",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1304401",
+    "municipio": "Urucurituba",
+    "uf": "AM"
+  },
+  {
+    "codigo": "1400027",
+    "municipio": "Amajari",
+    "uf": "RR"
+  },
+  {
+    "codigo": "1400050",
+    "municipio": "Alto Alegre",
+    "uf": "RR"
+  },
+  {
+    "codigo": "1400100",
+    "municipio": "Boa Vista",
+    "uf": "RR"
+  },
+  {
+    "codigo": "1400159",
+    "municipio": "Bonfim",
+    "uf": "RR"
+  },
+  {
+    "codigo": "1400175",
+    "municipio": "Cantá",
+    "uf": "RR"
+  },
+  {
+    "codigo": "1400209",
+    "municipio": "Caracaraí",
+    "uf": "RR"
+  },
+  {
+    "codigo": "1400233",
+    "municipio": "Caroebe",
+    "uf": "RR"
+  },
+  {
+    "codigo": "1400282",
+    "municipio": "Iracema",
+    "uf": "RR"
+  },
+  {
+    "codigo": "1400308",
+    "municipio": "Mucajaí",
+    "uf": "RR"
+  },
+  {
+    "codigo": "1400407",
+    "municipio": "Normandia",
+    "uf": "RR"
+  },
+  {
+    "codigo": "1400456",
+    "municipio": "Pacaraima",
+    "uf": "RR"
+  },
+  {
+    "codigo": "1400472",
+    "municipio": "Rorainópolis",
+    "uf": "RR"
+  },
+  {
+    "codigo": "1400506",
+    "municipio": "São João da Baliza",
+    "uf": "RR"
+  },
+  {
+    "codigo": "1400605",
+    "municipio": "São Luiz",
+    "uf": "RR"
+  },
+  {
+    "codigo": "1400704",
+    "municipio": "Uiramutã",
+    "uf": "RR"
+  },
+  {
+    "codigo": "1500107",
+    "municipio": "Abaetetuba",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1500131",
+    "municipio": "Abel Figueiredo",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1500206",
+    "municipio": "Acará",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1500305",
+    "municipio": "Afuá",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1500347",
+    "municipio": "Água Azul do Norte",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1500404",
+    "municipio": "Alenquer",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1500503",
+    "municipio": "Almeirim",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1500602",
+    "municipio": "Altamira",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1500701",
+    "municipio": "Anajás",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1500800",
+    "municipio": "Ananindeua",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1500859",
+    "municipio": "Anapu",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1500909",
+    "municipio": "Augusto Corrêa",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1500958",
+    "municipio": "Aurora do Pará",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1501006",
+    "municipio": "Aveiro",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1501105",
+    "municipio": "Bagre",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1501204",
+    "municipio": "Baião",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1501253",
+    "municipio": "Bannach",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1501303",
+    "municipio": "Barcarena",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1501402",
+    "municipio": "Belém",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1501451",
+    "municipio": "Belterra",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1501501",
+    "municipio": "Benevides",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1501576",
+    "municipio": "Bom Jesus do Tocantins",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1501600",
+    "municipio": "Bonito",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1501709",
+    "municipio": "Bragança",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1501725",
+    "municipio": "Brasil Novo",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1501758",
+    "municipio": "Brejo Grande do Araguaia",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1501782",
+    "municipio": "Breu Branco",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1501808",
+    "municipio": "Breves",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1501907",
+    "municipio": "Bujaru",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1501956",
+    "municipio": "Cachoeira do Piriá",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1502004",
+    "municipio": "Cachoeira do Arari",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1502103",
+    "municipio": "Cametá",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1502152",
+    "municipio": "Canaã dos Carajás",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1502202",
+    "municipio": "Capanema",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1502301",
+    "municipio": "Capitão Poço",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1502400",
+    "municipio": "Castanhal",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1502509",
+    "municipio": "Chaves",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1502608",
+    "municipio": "Colares",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1502707",
+    "municipio": "Conceição do Araguaia",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1502756",
+    "municipio": "Concórdia do Pará",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1502764",
+    "municipio": "Cumaru do Norte",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1502772",
+    "municipio": "Curionópolis",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1502806",
+    "municipio": "Curralinho",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1502855",
+    "municipio": "Curuá",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1502905",
+    "municipio": "Curuçá",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1502939",
+    "municipio": "Dom Eliseu",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1502954",
+    "municipio": "Eldorado do Carajás",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1503002",
+    "municipio": "Faro",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1503044",
+    "municipio": "Floresta do Araguaia",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1503077",
+    "municipio": "Garrafão do Norte",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1503093",
+    "municipio": "Goianésia do Pará",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1503101",
+    "municipio": "Gurupá",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1503200",
+    "municipio": "Igarapé-Açu",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1503309",
+    "municipio": "Igarapé-Miri",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1503408",
+    "municipio": "Inhangapi",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1503457",
+    "municipio": "Ipixuna do Pará",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1503507",
+    "municipio": "Irituia",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1503606",
+    "municipio": "Itaituba",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1503705",
+    "municipio": "Itupiranga",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1503754",
+    "municipio": "Jacareacanga",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1503804",
+    "municipio": "Jacundá",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1503903",
+    "municipio": "Juruti",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1504000",
+    "municipio": "Limoeiro do Ajuru",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1504059",
+    "municipio": "Mãe do Rio",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1504109",
+    "municipio": "Magalhães Barata",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1504208",
+    "municipio": "Marabá",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1504307",
+    "municipio": "Maracanã",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1504406",
+    "municipio": "Marapanim",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1504422",
+    "municipio": "Marituba",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1504455",
+    "municipio": "Medicilândia",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1504505",
+    "municipio": "Melgaço",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1504604",
+    "municipio": "Mocajuba",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1504703",
+    "municipio": "Moju",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1504752",
+    "municipio": "Mojuí dos Campos",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1504802",
+    "municipio": "Monte Alegre",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1504901",
+    "municipio": "Muaná",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1504950",
+    "municipio": "Nova Esperança do Piriá",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1504976",
+    "municipio": "Nova Ipixuna",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505007",
+    "municipio": "Nova Timboteua",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505031",
+    "municipio": "Novo Progresso",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505064",
+    "municipio": "Novo Repartimento",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505106",
+    "municipio": "Óbidos",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505205",
+    "municipio": "Oeiras do Pará",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505304",
+    "municipio": "Oriximiná",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505403",
+    "municipio": "Ourém",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505437",
+    "municipio": "Ourilândia do Norte",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505486",
+    "municipio": "Pacajá",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505494",
+    "municipio": "Palestina do Pará",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505502",
+    "municipio": "Paragominas",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505536",
+    "municipio": "Parauapebas",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505551",
+    "municipio": "Pau D'Arco",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505601",
+    "municipio": "Peixe-Boi",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505635",
+    "municipio": "Piçarra",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505650",
+    "municipio": "Placas",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505700",
+    "municipio": "Ponta de Pedras",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505809",
+    "municipio": "Portel",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1505908",
+    "municipio": "Porto de Moz",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506005",
+    "municipio": "Prainha",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506104",
+    "municipio": "Primavera",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506112",
+    "municipio": "Quatipuru",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506138",
+    "municipio": "Redenção",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506161",
+    "municipio": "Rio Maria",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506187",
+    "municipio": "Rondon do Pará",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506195",
+    "municipio": "Rurópolis",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506203",
+    "municipio": "Salinópolis",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506302",
+    "municipio": "Salvaterra",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506351",
+    "municipio": "Santa Bárbara do Pará",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506401",
+    "municipio": "Santa Cruz do Arari",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506500",
+    "municipio": "Santa Izabel do Pará",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506559",
+    "municipio": "Santa Luzia do Pará",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506583",
+    "municipio": "Santa Maria das Barreiras",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506609",
+    "municipio": "Santa Maria do Pará",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506708",
+    "municipio": "Santana do Araguaia",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506807",
+    "municipio": "Santarém",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1506906",
+    "municipio": "Santarém Novo",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507003",
+    "municipio": "Santo Antônio do Tauá",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507102",
+    "municipio": "São Caetano de Odivelas",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507151",
+    "municipio": "São Domingos do Araguaia",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507201",
+    "municipio": "São Domingos do Capim",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507300",
+    "municipio": "São Félix do Xingu",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507409",
+    "municipio": "São Francisco do Pará",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507458",
+    "municipio": "São Geraldo do Araguaia",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507466",
+    "municipio": "São João da Ponta",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507474",
+    "municipio": "São João de Pirabas",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507508",
+    "municipio": "São João do Araguaia",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507607",
+    "municipio": "São Miguel do Guamá",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507706",
+    "municipio": "São Sebastião da Boa Vista",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507755",
+    "municipio": "Sapucaia",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507805",
+    "municipio": "Senador José Porfírio",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507904",
+    "municipio": "Soure",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507953",
+    "municipio": "Tailândia",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507961",
+    "municipio": "Terra Alta",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1507979",
+    "municipio": "Terra Santa",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1508001",
+    "municipio": "Tomé-Açu",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1508035",
+    "municipio": "Tracuateua",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1508050",
+    "municipio": "Trairão",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1508084",
+    "municipio": "Tucumã",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1508100",
+    "municipio": "Tucuruí",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1508126",
+    "municipio": "Ulianópolis",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1508159",
+    "municipio": "Uruará",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1508209",
+    "municipio": "Vigia",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1508308",
+    "municipio": "Viseu",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1508357",
+    "municipio": "Vitória do Xingu",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1508407",
+    "municipio": "Xinguara",
+    "uf": "PA"
+  },
+  {
+    "codigo": "1600055",
+    "municipio": "Serra do Navio",
+    "uf": "AP"
+  },
+  {
+    "codigo": "1600105",
+    "municipio": "Amapá",
+    "uf": "AP"
+  },
+  {
+    "codigo": "1600154",
+    "municipio": "Pedra Branca do Amapari",
+    "uf": "AP"
+  },
+  {
+    "codigo": "1600204",
+    "municipio": "Calçoene",
+    "uf": "AP"
+  },
+  {
+    "codigo": "1600212",
+    "municipio": "Cutias",
+    "uf": "AP"
+  },
+  {
+    "codigo": "1600238",
+    "municipio": "Ferreira Gomes",
+    "uf": "AP"
+  },
+  {
+    "codigo": "1600253",
+    "municipio": "Itaubal",
+    "uf": "AP"
+  },
+  {
+    "codigo": "1600279",
+    "municipio": "Laranjal do Jari",
+    "uf": "AP"
+  },
+  {
+    "codigo": "1600303",
+    "municipio": "Macapá",
+    "uf": "AP"
+  },
+  {
+    "codigo": "1600402",
+    "municipio": "Mazagão",
+    "uf": "AP"
+  },
+  {
+    "codigo": "1600501",
+    "municipio": "Oiapoque",
+    "uf": "AP"
+  },
+  {
+    "codigo": "1600535",
+    "municipio": "Porto Grande",
+    "uf": "AP"
+  },
+  {
+    "codigo": "1600550",
+    "municipio": "Pracuúba",
+    "uf": "AP"
+  },
+  {
+    "codigo": "1600600",
+    "municipio": "Santana",
+    "uf": "AP"
+  },
+  {
+    "codigo": "1600709",
+    "municipio": "Tartarugalzinho",
+    "uf": "AP"
+  },
+  {
+    "codigo": "1600808",
+    "municipio": "Vitória do Jari",
+    "uf": "AP"
+  },
+  {
+    "codigo": "1700251",
+    "municipio": "Abreulândia",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1700301",
+    "municipio": "Aguiarnópolis",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1700350",
+    "municipio": "Aliança do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1700400",
+    "municipio": "Almas",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1700707",
+    "municipio": "Alvorada",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1701002",
+    "municipio": "Ananás",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1701051",
+    "municipio": "Angico",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1701101",
+    "municipio": "Aparecida do Rio Negro",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1701309",
+    "municipio": "Aragominas",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1701903",
+    "municipio": "Araguacema",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1702000",
+    "municipio": "Araguaçu",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1702109",
+    "municipio": "Araguaína",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1702158",
+    "municipio": "Araguanã",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1702208",
+    "municipio": "Araguatins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1702307",
+    "municipio": "Arapoema",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1702406",
+    "municipio": "Arraias",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1702554",
+    "municipio": "Augustinópolis",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1702703",
+    "municipio": "Aurora do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1702901",
+    "municipio": "Axixá do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1703008",
+    "municipio": "Babaçulândia",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1703057",
+    "municipio": "Bandeirantes do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1703073",
+    "municipio": "Barra do Ouro",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1703107",
+    "municipio": "Barrolândia",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1703206",
+    "municipio": "Bernardo Sayão",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1703305",
+    "municipio": "Bom Jesus do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1703602",
+    "municipio": "Brasilândia do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1703701",
+    "municipio": "Brejinho de Nazaré",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1703800",
+    "municipio": "Buriti do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1703826",
+    "municipio": "Cachoeirinha",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1703842",
+    "municipio": "Campos Lindos",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1703867",
+    "municipio": "Cariri do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1703883",
+    "municipio": "Carmolândia",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1703891",
+    "municipio": "Carrasco Bonito",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1703909",
+    "municipio": "Caseara",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1704105",
+    "municipio": "Centenário",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1704600",
+    "municipio": "Chapada de Areia",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1705102",
+    "municipio": "Chapada da Natividade",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1705508",
+    "municipio": "Colinas do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1705557",
+    "municipio": "Combinado",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1705607",
+    "municipio": "Conceição do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1706001",
+    "municipio": "Couto Magalhães",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1706100",
+    "municipio": "Cristalândia",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1706258",
+    "municipio": "Crixás do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1706506",
+    "municipio": "Darcinópolis",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1707009",
+    "municipio": "Dianópolis",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1707108",
+    "municipio": "Divinópolis do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1707207",
+    "municipio": "Dois Irmãos do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1707306",
+    "municipio": "Dueré",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1707405",
+    "municipio": "Esperantina",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1707553",
+    "municipio": "Fátima",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1707652",
+    "municipio": "Figueirópolis",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1707702",
+    "municipio": "Filadélfia",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1708205",
+    "municipio": "Formoso do Araguaia",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1708254",
+    "municipio": "Tabocão",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1708304",
+    "municipio": "Goianorte",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1709005",
+    "municipio": "Goiatins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1709302",
+    "municipio": "Guaraí",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1709500",
+    "municipio": "Gurupi",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1709807",
+    "municipio": "Ipueiras",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1710508",
+    "municipio": "Itacajá",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1710706",
+    "municipio": "Itaguatins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1710904",
+    "municipio": "Itapiratins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1711100",
+    "municipio": "Itaporã do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1711506",
+    "municipio": "Jaú do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1711803",
+    "municipio": "Juarina",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1711902",
+    "municipio": "Lagoa da Confusão",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1711951",
+    "municipio": "Lagoa do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1712009",
+    "municipio": "Lajeado",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1712157",
+    "municipio": "Lavandeira",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1712405",
+    "municipio": "Lizarda",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1712454",
+    "municipio": "Luzinópolis",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1712504",
+    "municipio": "Marianópolis do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1712702",
+    "municipio": "Mateiros",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1712801",
+    "municipio": "Maurilândia do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1713205",
+    "municipio": "Miracema do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1713304",
+    "municipio": "Miranorte",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1713601",
+    "municipio": "Monte do Carmo",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1713700",
+    "municipio": "Monte Santo do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1713809",
+    "municipio": "Palmeiras do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1713957",
+    "municipio": "Muricilândia",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1714203",
+    "municipio": "Natividade",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1714302",
+    "municipio": "Nazaré",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1714880",
+    "municipio": "Nova Olinda",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1715002",
+    "municipio": "Nova Rosalândia",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1715101",
+    "municipio": "Novo Acordo",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1715150",
+    "municipio": "Novo Alegre",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1715259",
+    "municipio": "Novo Jardim",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1715507",
+    "municipio": "Oliveira de Fátima",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1715705",
+    "municipio": "Palmeirante",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1715754",
+    "municipio": "Palmeirópolis",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1716109",
+    "municipio": "Paraíso do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1716208",
+    "municipio": "Paranã",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1716307",
+    "municipio": "Pau D'Arco",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1716505",
+    "municipio": "Pedro Afonso",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1716604",
+    "municipio": "Peixe",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1716653",
+    "municipio": "Pequizeiro",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1716703",
+    "municipio": "Colméia",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1717008",
+    "municipio": "Pindorama do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1717206",
+    "municipio": "Piraquê",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1717503",
+    "municipio": "Pium",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1717800",
+    "municipio": "Ponte Alta do Bom Jesus",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1717909",
+    "municipio": "Ponte Alta do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1718006",
+    "municipio": "Porto Alegre do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1718204",
+    "municipio": "Porto Nacional",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1718303",
+    "municipio": "Praia Norte",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1718402",
+    "municipio": "Presidente Kennedy",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1718451",
+    "municipio": "Pugmil",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1718501",
+    "municipio": "Recursolândia",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1718550",
+    "municipio": "Riachinho",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1718659",
+    "municipio": "Rio da Conceição",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1718709",
+    "municipio": "Rio dos Bois",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1718758",
+    "municipio": "Rio Sono",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1718808",
+    "municipio": "Sampaio",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1718840",
+    "municipio": "Sandolândia",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1718865",
+    "municipio": "Santa Fé do Araguaia",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1718881",
+    "municipio": "Santa Maria do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1718899",
+    "municipio": "Santa Rita do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1718907",
+    "municipio": "Santa Rosa do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1719004",
+    "municipio": "Santa Tereza do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1720002",
+    "municipio": "Santa Terezinha do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1720101",
+    "municipio": "São Bento do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1720150",
+    "municipio": "São Félix do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1720200",
+    "municipio": "São Miguel do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1720259",
+    "municipio": "São Salvador do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1720309",
+    "municipio": "São Sebastião do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1720499",
+    "municipio": "São Valério",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1720655",
+    "municipio": "Silvanópolis",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1720804",
+    "municipio": "Sítio Novo do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1720853",
+    "municipio": "Sucupira",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1720903",
+    "municipio": "Taguatinga",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1720937",
+    "municipio": "Taipas do Tocantins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1720978",
+    "municipio": "Talismã",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1721000",
+    "municipio": "Palmas",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1721109",
+    "municipio": "Tocantínia",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1721208",
+    "municipio": "Tocantinópolis",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1721257",
+    "municipio": "Tupirama",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1721307",
+    "municipio": "Tupiratins",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1722081",
+    "municipio": "Wanderlândia",
+    "uf": "TO"
+  },
+  {
+    "codigo": "1722107",
+    "municipio": "Xambioá",
+    "uf": "TO"
+  },
+  {
+    "codigo": "2100055",
+    "municipio": "Açailândia",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2100105",
+    "municipio": "Afonso Cunha",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2100154",
+    "municipio": "Água Doce do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2100204",
+    "municipio": "Alcântara",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2100303",
+    "municipio": "Aldeias Altas",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2100402",
+    "municipio": "Altamira do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2100436",
+    "municipio": "Alto Alegre do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2100477",
+    "municipio": "Alto Alegre do Pindaré",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2100501",
+    "municipio": "Alto Parnaíba",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2100550",
+    "municipio": "Amapá do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2100600",
+    "municipio": "Amarante do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2100709",
+    "municipio": "Anajatuba",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2100808",
+    "municipio": "Anapurus",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2100832",
+    "municipio": "Apicum-Açu",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2100873",
+    "municipio": "Araguanã",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2100907",
+    "municipio": "Araioses",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2100956",
+    "municipio": "Arame",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2101004",
+    "municipio": "Arari",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2101103",
+    "municipio": "Axixá",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2101202",
+    "municipio": "Bacabal",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2101251",
+    "municipio": "Bacabeira",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2101301",
+    "municipio": "Bacuri",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2101350",
+    "municipio": "Bacurituba",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2101400",
+    "municipio": "Balsas",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2101509",
+    "municipio": "Barão de Grajaú",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2101608",
+    "municipio": "Barra do Corda",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2101707",
+    "municipio": "Barreirinhas",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2101731",
+    "municipio": "Belágua",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2101772",
+    "municipio": "Bela Vista do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2101806",
+    "municipio": "Benedito Leite",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2101905",
+    "municipio": "Bequimão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2101939",
+    "municipio": "Bernardo do Mearim",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2101970",
+    "municipio": "Boa Vista do Gurupi",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102002",
+    "municipio": "Bom Jardim",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102036",
+    "municipio": "Bom Jesus das Selvas",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102077",
+    "municipio": "Bom Lugar",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102101",
+    "municipio": "Brejo",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102150",
+    "municipio": "Brejo de Areia",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102200",
+    "municipio": "Buriti",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102309",
+    "municipio": "Buriti Bravo",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102325",
+    "municipio": "Buriticupu",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102358",
+    "municipio": "Buritirana",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102374",
+    "municipio": "Cachoeira Grande",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102408",
+    "municipio": "Cajapió",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102507",
+    "municipio": "Cajari",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102556",
+    "municipio": "Campestre do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102606",
+    "municipio": "Cândido Mendes",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102705",
+    "municipio": "Cantanhede",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102754",
+    "municipio": "Capinzal do Norte",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102804",
+    "municipio": "Carolina",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2102903",
+    "municipio": "Carutapera",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2103000",
+    "municipio": "Caxias",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2103109",
+    "municipio": "Cedral",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2103125",
+    "municipio": "Central do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2103158",
+    "municipio": "Centro do Guilherme",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2103174",
+    "municipio": "Centro Novo do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2103208",
+    "municipio": "Chapadinha",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2103257",
+    "municipio": "Cidelândia",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2103307",
+    "municipio": "Codó",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2103406",
+    "municipio": "Coelho Neto",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2103505",
+    "municipio": "Colinas",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2103554",
+    "municipio": "Conceição do Lago-Açu",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2103604",
+    "municipio": "Coroatá",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2103703",
+    "municipio": "Cururupu",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2103752",
+    "municipio": "Davinópolis",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2103802",
+    "municipio": "Dom Pedro",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2103901",
+    "municipio": "Duque Bacelar",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104008",
+    "municipio": "Esperantinópolis",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104057",
+    "municipio": "Estreito",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104073",
+    "municipio": "Feira Nova do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104081",
+    "municipio": "Fernando Falcão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104099",
+    "municipio": "Formosa da Serra Negra",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104107",
+    "municipio": "Fortaleza dos Nogueiras",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104206",
+    "municipio": "Fortuna",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104305",
+    "municipio": "Godofredo Viana",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104404",
+    "municipio": "Gonçalves Dias",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104503",
+    "municipio": "Governador Archer",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104552",
+    "municipio": "Governador Edison Lobão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104602",
+    "municipio": "Governador Eugênio Barros",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104628",
+    "municipio": "Governador Luiz Rocha",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104651",
+    "municipio": "Governador Newton Bello",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104677",
+    "municipio": "Governador Nunes Freire",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104701",
+    "municipio": "Graça Aranha",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104800",
+    "municipio": "Grajaú",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2104909",
+    "municipio": "Guimarães",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105005",
+    "municipio": "Humberto de Campos",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105104",
+    "municipio": "Icatu",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105153",
+    "municipio": "Igarapé do Meio",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105203",
+    "municipio": "Igarapé Grande",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105302",
+    "municipio": "Imperatriz",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105351",
+    "municipio": "Itaipava do Grajaú",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105401",
+    "municipio": "Itapecuru Mirim",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105427",
+    "municipio": "Itinga do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105450",
+    "municipio": "Jatobá",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105476",
+    "municipio": "Jenipapo dos Vieiras",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105500",
+    "municipio": "João Lisboa",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105609",
+    "municipio": "Joselândia",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105658",
+    "municipio": "Junco do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105708",
+    "municipio": "Lago da Pedra",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105807",
+    "municipio": "Lago do Junco",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105906",
+    "municipio": "Lago Verde",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105922",
+    "municipio": "Lagoa do Mato",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105948",
+    "municipio": "Lago dos Rodrigues",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105963",
+    "municipio": "Lagoa Grande do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2105989",
+    "municipio": "Lajeado Novo",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2106003",
+    "municipio": "Lima Campos",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2106102",
+    "municipio": "Loreto",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2106201",
+    "municipio": "Luís Domingues",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2106300",
+    "municipio": "Magalhães de Almeida",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2106326",
+    "municipio": "Maracaçumé",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2106359",
+    "municipio": "Marajá do Sena",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2106375",
+    "municipio": "Maranhãozinho",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2106409",
+    "municipio": "Mata Roma",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2106508",
+    "municipio": "Matinha",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2106607",
+    "municipio": "Matões",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2106631",
+    "municipio": "Matões do Norte",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2106672",
+    "municipio": "Milagres do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2106706",
+    "municipio": "Mirador",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2106755",
+    "municipio": "Miranda do Norte",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2106805",
+    "municipio": "Mirinzal",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2106904",
+    "municipio": "Monção",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2107001",
+    "municipio": "Montes Altos",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2107100",
+    "municipio": "Morros",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2107209",
+    "municipio": "Nina Rodrigues",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2107258",
+    "municipio": "Nova Colinas",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2107308",
+    "municipio": "Nova Iorque",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2107357",
+    "municipio": "Nova Olinda do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2107407",
+    "municipio": "Olho d'Água das Cunhãs",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2107456",
+    "municipio": "Olinda Nova do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2107506",
+    "municipio": "Paço do Lumiar",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2107605",
+    "municipio": "Palmeirândia",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2107704",
+    "municipio": "Paraibano",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2107803",
+    "municipio": "Parnarama",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2107902",
+    "municipio": "Passagem Franca",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2108009",
+    "municipio": "Pastos Bons",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2108058",
+    "municipio": "Paulino Neves",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2108108",
+    "municipio": "Paulo Ramos",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2108207",
+    "municipio": "Pedreiras",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2108256",
+    "municipio": "Pedro do Rosário",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2108306",
+    "municipio": "Penalva",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2108405",
+    "municipio": "Peri Mirim",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2108454",
+    "municipio": "Peritoró",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2108504",
+    "municipio": "Pindaré-Mirim",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2108603",
+    "municipio": "Pinheiro",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2108702",
+    "municipio": "Pio XII",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2108801",
+    "municipio": "Pirapemas",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2108900",
+    "municipio": "Poção de Pedras",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2109007",
+    "municipio": "Porto Franco",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2109056",
+    "municipio": "Porto Rico do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2109106",
+    "municipio": "Presidente Dutra",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2109205",
+    "municipio": "Presidente Juscelino",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2109239",
+    "municipio": "Presidente Médici",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2109270",
+    "municipio": "Presidente Sarney",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2109304",
+    "municipio": "Presidente Vargas",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2109403",
+    "municipio": "Primeira Cruz",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2109452",
+    "municipio": "Raposa",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2109502",
+    "municipio": "Riachão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2109551",
+    "municipio": "Ribamar Fiquene",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2109601",
+    "municipio": "Rosário",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2109700",
+    "municipio": "Sambaíba",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2109759",
+    "municipio": "Santa Filomena do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2109809",
+    "municipio": "Santa Helena",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2109908",
+    "municipio": "Santa Inês",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2110005",
+    "municipio": "Santa Luzia",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2110039",
+    "municipio": "Santa Luzia do Paruá",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2110104",
+    "municipio": "Santa Quitéria do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2110203",
+    "municipio": "Santa Rita",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2110237",
+    "municipio": "Santana do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2110278",
+    "municipio": "Santo Amaro do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2110302",
+    "municipio": "Santo Antônio dos Lopes",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2110401",
+    "municipio": "São Benedito do Rio Preto",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2110500",
+    "municipio": "São Bento",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2110609",
+    "municipio": "São Bernardo",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2110658",
+    "municipio": "São Domingos do Azeitão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2110708",
+    "municipio": "São Domingos do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2110807",
+    "municipio": "São Félix de Balsas",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2110856",
+    "municipio": "São Francisco do Brejão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2110906",
+    "municipio": "São Francisco do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111003",
+    "municipio": "São João Batista",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111029",
+    "municipio": "São João do Carú",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111052",
+    "municipio": "São João do Paraíso",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111078",
+    "municipio": "São João do Soter",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111102",
+    "municipio": "São João dos Patos",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111201",
+    "municipio": "São José de Ribamar",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111250",
+    "municipio": "São José dos Basílios",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111300",
+    "municipio": "São Luís",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111409",
+    "municipio": "São Luís Gonzaga do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111508",
+    "municipio": "São Mateus do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111532",
+    "municipio": "São Pedro da Água Branca",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111573",
+    "municipio": "São Pedro dos Crentes",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111607",
+    "municipio": "São Raimundo das Mangabeiras",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111631",
+    "municipio": "São Raimundo do Doca Bezerra",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111672",
+    "municipio": "São Roberto",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111706",
+    "municipio": "São Vicente Ferrer",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111722",
+    "municipio": "Satubinha",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111748",
+    "municipio": "Senador Alexandre Costa",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111763",
+    "municipio": "Senador La Rocque",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111789",
+    "municipio": "Serrano do Maranhão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111805",
+    "municipio": "Sítio Novo",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111904",
+    "municipio": "Sucupira do Norte",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2111953",
+    "municipio": "Sucupira do Riachão",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2112001",
+    "municipio": "Tasso Fragoso",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2112100",
+    "municipio": "Timbiras",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2112209",
+    "municipio": "Timon",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2112233",
+    "municipio": "Trizidela do Vale",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2112274",
+    "municipio": "Tufilândia",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2112308",
+    "municipio": "Tuntum",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2112407",
+    "municipio": "Turiaçu",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2112456",
+    "municipio": "Turilândia",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2112506",
+    "municipio": "Tutóia",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2112605",
+    "municipio": "Urbano Santos",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2112704",
+    "municipio": "Vargem Grande",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2112803",
+    "municipio": "Viana",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2112852",
+    "municipio": "Vila Nova dos Martírios",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2112902",
+    "municipio": "Vitória do Mearim",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2113009",
+    "municipio": "Vitorino Freire",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2114007",
+    "municipio": "Zé Doca",
+    "uf": "MA"
+  },
+  {
+    "codigo": "2200053",
+    "municipio": "Acauã",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2200103",
+    "municipio": "Agricolândia",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2200202",
+    "municipio": "Água Branca",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2200251",
+    "municipio": "Alagoinha do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2200277",
+    "municipio": "Alegrete do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2200301",
+    "municipio": "Alto Longá",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2200400",
+    "municipio": "Altos",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2200459",
+    "municipio": "Alvorada do Gurguéia",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2200509",
+    "municipio": "Amarante",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2200608",
+    "municipio": "Angical do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2200707",
+    "municipio": "Anísio de Abreu",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2200806",
+    "municipio": "Antônio Almeida",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2200905",
+    "municipio": "Aroazes",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2200954",
+    "municipio": "Aroeiras do Itaim",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201002",
+    "municipio": "Arraial",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201051",
+    "municipio": "Assunção do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201101",
+    "municipio": "Avelino Lopes",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201150",
+    "municipio": "Baixa Grande do Ribeiro",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201176",
+    "municipio": "Barra D'Alcântara",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201200",
+    "municipio": "Barras",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201309",
+    "municipio": "Barreiras do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201408",
+    "municipio": "Barro Duro",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201507",
+    "municipio": "Batalha",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201556",
+    "municipio": "Bela Vista do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201572",
+    "municipio": "Belém do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201606",
+    "municipio": "Beneditinos",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201705",
+    "municipio": "Bertolínia",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201739",
+    "municipio": "Betânia do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201770",
+    "municipio": "Boa Hora",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201804",
+    "municipio": "Bocaina",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201903",
+    "municipio": "Bom Jesus",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201919",
+    "municipio": "Bom Princípio do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201929",
+    "municipio": "Bonfim do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201945",
+    "municipio": "Boqueirão do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201960",
+    "municipio": "Brasileira",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2201988",
+    "municipio": "Brejo do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202000",
+    "municipio": "Buriti dos Lopes",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202026",
+    "municipio": "Buriti dos Montes",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202059",
+    "municipio": "Cabeceiras do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202075",
+    "municipio": "Cajazeiras do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202083",
+    "municipio": "Cajueiro da Praia",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202091",
+    "municipio": "Caldeirão Grande do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202109",
+    "municipio": "Campinas do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202117",
+    "municipio": "Campo Alegre do Fidalgo",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202133",
+    "municipio": "Campo Grande do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202174",
+    "municipio": "Campo Largo do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202208",
+    "municipio": "Campo Maior",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202251",
+    "municipio": "Canavieira",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202307",
+    "municipio": "Canto do Buriti",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202406",
+    "municipio": "Capitão de Campos",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202455",
+    "municipio": "Capitão Gervásio Oliveira",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202505",
+    "municipio": "Caracol",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202539",
+    "municipio": "Caraúbas do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202554",
+    "municipio": "Caridade do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202604",
+    "municipio": "Castelo do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202653",
+    "municipio": "Caxingó",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202703",
+    "municipio": "Cocal",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202711",
+    "municipio": "Cocal de Telha",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202729",
+    "municipio": "Cocal dos Alves",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202737",
+    "municipio": "Coivaras",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202752",
+    "municipio": "Colônia do Gurguéia",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202778",
+    "municipio": "Colônia do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202802",
+    "municipio": "Conceição do Canindé",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202851",
+    "municipio": "Coronel José Dias",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2202901",
+    "municipio": "Corrente",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203008",
+    "municipio": "Cristalândia do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203107",
+    "municipio": "Cristino Castro",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203206",
+    "municipio": "Curimatá",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203230",
+    "municipio": "Currais",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203255",
+    "municipio": "Curralinhos",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203271",
+    "municipio": "Curral Novo do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203305",
+    "municipio": "Demerval Lobão",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203354",
+    "municipio": "Dirceu Arcoverde",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203404",
+    "municipio": "Dom Expedito Lopes",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203420",
+    "municipio": "Domingos Mourão",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203453",
+    "municipio": "Dom Inocêncio",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203503",
+    "municipio": "Elesbão Veloso",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203602",
+    "municipio": "Eliseu Martins",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203701",
+    "municipio": "Esperantina",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203750",
+    "municipio": "Fartura do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203800",
+    "municipio": "Flores do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203859",
+    "municipio": "Floresta do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2203909",
+    "municipio": "Floriano",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2204006",
+    "municipio": "Francinópolis",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2204105",
+    "municipio": "Francisco Ayres",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2204154",
+    "municipio": "Francisco Macedo",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2204204",
+    "municipio": "Francisco Santos",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2204303",
+    "municipio": "Fronteiras",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2204352",
+    "municipio": "Geminiano",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2204402",
+    "municipio": "Gilbués",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2204501",
+    "municipio": "Guadalupe",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2204550",
+    "municipio": "Guaribas",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2204600",
+    "municipio": "Hugo Napoleão",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2204659",
+    "municipio": "Ilha Grande",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2204709",
+    "municipio": "Inhuma",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2204808",
+    "municipio": "Ipiranga do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2204907",
+    "municipio": "Isaías Coelho",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205003",
+    "municipio": "Itainópolis",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205102",
+    "municipio": "Itaueira",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205151",
+    "municipio": "Jacobina do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205201",
+    "municipio": "Jaicós",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205250",
+    "municipio": "Jardim do Mulato",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205276",
+    "municipio": "Jatobá do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205300",
+    "municipio": "Jerumenha",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205359",
+    "municipio": "João Costa",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205409",
+    "municipio": "Joaquim Pires",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205458",
+    "municipio": "Joca Marques",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205508",
+    "municipio": "José de Freitas",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205516",
+    "municipio": "Juazeiro do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205524",
+    "municipio": "Júlio Borges",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205532",
+    "municipio": "Jurema",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205540",
+    "municipio": "Lagoinha do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205557",
+    "municipio": "Lagoa Alegre",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205565",
+    "municipio": "Lagoa do Barro do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205573",
+    "municipio": "Lagoa de São Francisco",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205581",
+    "municipio": "Lagoa do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205599",
+    "municipio": "Lagoa do Sítio",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205607",
+    "municipio": "Landri Sales",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205706",
+    "municipio": "Luís Correia",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205805",
+    "municipio": "Luzilândia",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205854",
+    "municipio": "Madeiro",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205904",
+    "municipio": "Manoel Emídio",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2205953",
+    "municipio": "Marcolândia",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206001",
+    "municipio": "Marcos Parente",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206050",
+    "municipio": "Massapê do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206100",
+    "municipio": "Matias Olímpio",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206209",
+    "municipio": "Miguel Alves",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206308",
+    "municipio": "Miguel Leão",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206357",
+    "municipio": "Milton Brandão",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206407",
+    "municipio": "Monsenhor Gil",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206506",
+    "municipio": "Monsenhor Hipólito",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206605",
+    "municipio": "Monte Alegre do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206654",
+    "municipio": "Morro Cabeça no Tempo",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206670",
+    "municipio": "Morro do Chapéu do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206696",
+    "municipio": "Murici dos Portelas",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206704",
+    "municipio": "Nazaré do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206720",
+    "municipio": "Nazária",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206753",
+    "municipio": "Nossa Senhora de Nazaré",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206803",
+    "municipio": "Nossa Senhora dos Remédios",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206902",
+    "municipio": "Novo Oriente do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2206951",
+    "municipio": "Novo Santo Antônio",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207009",
+    "municipio": "Oeiras",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207108",
+    "municipio": "Olho D'Água do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207207",
+    "municipio": "Padre Marcos",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207306",
+    "municipio": "Paes Landim",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207355",
+    "municipio": "Pajeú do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207405",
+    "municipio": "Palmeira do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207504",
+    "municipio": "Palmeirais",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207553",
+    "municipio": "Paquetá",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207603",
+    "municipio": "Parnaguá",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207702",
+    "municipio": "Parnaíba",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207751",
+    "municipio": "Passagem Franca do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207777",
+    "municipio": "Patos do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207793",
+    "municipio": "Pau D'Arco do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207801",
+    "municipio": "Paulistana",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207850",
+    "municipio": "Pavussu",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207900",
+    "municipio": "Pedro II",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207934",
+    "municipio": "Pedro Laurentino",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2207959",
+    "municipio": "Nova Santa Rita",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2208007",
+    "municipio": "Picos",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2208106",
+    "municipio": "Pimenteiras",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2208205",
+    "municipio": "Pio IX",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2208304",
+    "municipio": "Piracuruca",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2208403",
+    "municipio": "Piripiri",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2208502",
+    "municipio": "Porto",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2208551",
+    "municipio": "Porto Alegre do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2208601",
+    "municipio": "Prata do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2208650",
+    "municipio": "Queimada Nova",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2208700",
+    "municipio": "Redenção do Gurguéia",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2208809",
+    "municipio": "Regeneração",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2208858",
+    "municipio": "Riacho Frio",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2208874",
+    "municipio": "Ribeira do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2208908",
+    "municipio": "Ribeiro Gonçalves",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209005",
+    "municipio": "Rio Grande do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209104",
+    "municipio": "Santa Cruz do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209153",
+    "municipio": "Santa Cruz dos Milagres",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209203",
+    "municipio": "Santa Filomena",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209302",
+    "municipio": "Santa Luz",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209351",
+    "municipio": "Santana do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209377",
+    "municipio": "Santa Rosa do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209401",
+    "municipio": "Santo Antônio de Lisboa",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209450",
+    "municipio": "Santo Antônio dos Milagres",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209500",
+    "municipio": "Santo Inácio do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209559",
+    "municipio": "São Braz do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209609",
+    "municipio": "São Félix do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209658",
+    "municipio": "São Francisco de Assis do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209708",
+    "municipio": "São Francisco do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209757",
+    "municipio": "São Gonçalo do Gurguéia",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209807",
+    "municipio": "São Gonçalo do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209856",
+    "municipio": "São João da Canabrava",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209872",
+    "municipio": "São João da Fronteira",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209906",
+    "municipio": "São João da Serra",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209955",
+    "municipio": "São João da Varjota",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2209971",
+    "municipio": "São João do Arraial",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210003",
+    "municipio": "São João do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210052",
+    "municipio": "São José do Divino",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210102",
+    "municipio": "São José do Peixe",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210201",
+    "municipio": "São José do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210300",
+    "municipio": "São Julião",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210359",
+    "municipio": "São Lourenço do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210375",
+    "municipio": "São Luis do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210383",
+    "municipio": "São Miguel da Baixa Grande",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210391",
+    "municipio": "São Miguel do Fidalgo",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210409",
+    "municipio": "São Miguel do Tapuio",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210508",
+    "municipio": "São Pedro do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210607",
+    "municipio": "São Raimundo Nonato",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210623",
+    "municipio": "Sebastião Barros",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210631",
+    "municipio": "Sebastião Leal",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210656",
+    "municipio": "Sigefredo Pacheco",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210706",
+    "municipio": "Simões",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210805",
+    "municipio": "Simplício Mendes",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210904",
+    "municipio": "Socorro do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210938",
+    "municipio": "Sussuapara",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210953",
+    "municipio": "Tamboril do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2210979",
+    "municipio": "Tanque do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2211001",
+    "municipio": "Teresina",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2211100",
+    "municipio": "União",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2211209",
+    "municipio": "Uruçuí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2211308",
+    "municipio": "Valença do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2211357",
+    "municipio": "Várzea Branca",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2211407",
+    "municipio": "Várzea Grande",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2211506",
+    "municipio": "Vera Mendes",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2211605",
+    "municipio": "Vila Nova do Piauí",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2211704",
+    "municipio": "Wall Ferraz",
+    "uf": "PI"
+  },
+  {
+    "codigo": "2300101",
+    "municipio": "Abaiara",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2300150",
+    "municipio": "Acarape",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2300200",
+    "municipio": "Acaraú",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2300309",
+    "municipio": "Acopiara",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2300408",
+    "municipio": "Aiuaba",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2300507",
+    "municipio": "Alcântaras",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2300606",
+    "municipio": "Altaneira",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2300705",
+    "municipio": "Alto Santo",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2300754",
+    "municipio": "Amontada",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2300804",
+    "municipio": "Antonina do Norte",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2300903",
+    "municipio": "Apuiarés",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2301000",
+    "municipio": "Aquiraz",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2301109",
+    "municipio": "Aracati",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2301208",
+    "municipio": "Aracoiaba",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2301257",
+    "municipio": "Ararendá",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2301307",
+    "municipio": "Araripe",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2301406",
+    "municipio": "Aratuba",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2301505",
+    "municipio": "Arneiroz",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2301604",
+    "municipio": "Assaré",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2301703",
+    "municipio": "Aurora",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2301802",
+    "municipio": "Baixio",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2301851",
+    "municipio": "Banabuiú",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2301901",
+    "municipio": "Barbalha",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2301950",
+    "municipio": "Barreira",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2302008",
+    "municipio": "Barro",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2302057",
+    "municipio": "Barroquinha",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2302107",
+    "municipio": "Baturité",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2302206",
+    "municipio": "Beberibe",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2302305",
+    "municipio": "Bela Cruz",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2302404",
+    "municipio": "Boa Viagem",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2302503",
+    "municipio": "Brejo Santo",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2302602",
+    "municipio": "Camocim",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2302701",
+    "municipio": "Campos Sales",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2302800",
+    "municipio": "Canindé",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2302909",
+    "municipio": "Capistrano",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2303006",
+    "municipio": "Caridade",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2303105",
+    "municipio": "Cariré",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2303204",
+    "municipio": "Caririaçu",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2303303",
+    "municipio": "Cariús",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2303402",
+    "municipio": "Carnaubal",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2303501",
+    "municipio": "Cascavel",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2303600",
+    "municipio": "Catarina",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2303659",
+    "municipio": "Catunda",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2303709",
+    "municipio": "Caucaia",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2303808",
+    "municipio": "Cedro",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2303907",
+    "municipio": "Chaval",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2303931",
+    "municipio": "Choró",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2303956",
+    "municipio": "Chorozinho",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304004",
+    "municipio": "Coreaú",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304103",
+    "municipio": "Crateús",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304202",
+    "municipio": "Crato",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304236",
+    "municipio": "Croatá",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304251",
+    "municipio": "Cruz",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304269",
+    "municipio": "Deputado Irapuan Pinheiro",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304277",
+    "municipio": "Ereré",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304285",
+    "municipio": "Eusébio",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304301",
+    "municipio": "Farias Brito",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304350",
+    "municipio": "Forquilha",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304400",
+    "municipio": "Fortaleza",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304459",
+    "municipio": "Fortim",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304509",
+    "municipio": "Frecheirinha",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304608",
+    "municipio": "General Sampaio",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304657",
+    "municipio": "Graça",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304707",
+    "municipio": "Granja",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304806",
+    "municipio": "Granjeiro",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304905",
+    "municipio": "Groaíras",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2304954",
+    "municipio": "Guaiúba",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2305001",
+    "municipio": "Guaraciaba do Norte",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2305100",
+    "municipio": "Guaramiranga",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2305209",
+    "municipio": "Hidrolândia",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2305233",
+    "municipio": "Horizonte",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2305266",
+    "municipio": "Ibaretama",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2305308",
+    "municipio": "Ibiapina",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2305332",
+    "municipio": "Ibicuitinga",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2305357",
+    "municipio": "Icapuí",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2305407",
+    "municipio": "Icó",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2305506",
+    "municipio": "Iguatu",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2305605",
+    "municipio": "Independência",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2305654",
+    "municipio": "Ipaporanga",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2305704",
+    "municipio": "Ipaumirim",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2305803",
+    "municipio": "Ipu",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2305902",
+    "municipio": "Ipueiras",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2306009",
+    "municipio": "Iracema",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2306108",
+    "municipio": "Irauçuba",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2306207",
+    "municipio": "Itaiçaba",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2306256",
+    "municipio": "Itaitinga",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2306306",
+    "municipio": "Itapajé",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2306405",
+    "municipio": "Itapipoca",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2306504",
+    "municipio": "Itapiúna",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2306553",
+    "municipio": "Itarema",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2306603",
+    "municipio": "Itatira",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2306702",
+    "municipio": "Jaguaretama",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2306801",
+    "municipio": "Jaguaribara",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2306900",
+    "municipio": "Jaguaribe",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2307007",
+    "municipio": "Jaguaruana",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2307106",
+    "municipio": "Jardim",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2307205",
+    "municipio": "Jati",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2307254",
+    "municipio": "Jijoca de Jericoacoara",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2307304",
+    "municipio": "Juazeiro do Norte",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2307403",
+    "municipio": "Jucás",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2307502",
+    "municipio": "Lavras da Mangabeira",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2307601",
+    "municipio": "Limoeiro do Norte",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2307635",
+    "municipio": "Madalena",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2307650",
+    "municipio": "Maracanaú",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2307700",
+    "municipio": "Maranguape",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2307809",
+    "municipio": "Marco",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2307908",
+    "municipio": "Martinópole",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2308005",
+    "municipio": "Massapê",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2308104",
+    "municipio": "Mauriti",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2308203",
+    "municipio": "Meruoca",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2308302",
+    "municipio": "Milagres",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2308351",
+    "municipio": "Milhã",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2308377",
+    "municipio": "Miraíma",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2308401",
+    "municipio": "Missão Velha",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2308500",
+    "municipio": "Mombaça",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2308609",
+    "municipio": "Monsenhor Tabosa",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2308708",
+    "municipio": "Morada Nova",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2308807",
+    "municipio": "Moraújo",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2308906",
+    "municipio": "Morrinhos",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2309003",
+    "municipio": "Mucambo",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2309102",
+    "municipio": "Mulungu",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2309201",
+    "municipio": "Nova Olinda",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2309300",
+    "municipio": "Nova Russas",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2309409",
+    "municipio": "Novo Oriente",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2309458",
+    "municipio": "Ocara",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2309508",
+    "municipio": "Orós",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2309607",
+    "municipio": "Pacajus",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2309706",
+    "municipio": "Pacatuba",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2309805",
+    "municipio": "Pacoti",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2309904",
+    "municipio": "Pacujá",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2310001",
+    "municipio": "Palhano",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2310100",
+    "municipio": "Palmácia",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2310209",
+    "municipio": "Paracuru",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2310258",
+    "municipio": "Paraipaba",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2310308",
+    "municipio": "Parambu",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2310407",
+    "municipio": "Paramoti",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2310506",
+    "municipio": "Pedra Branca",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2310605",
+    "municipio": "Penaforte",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2310704",
+    "municipio": "Pentecoste",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2310803",
+    "municipio": "Pereiro",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2310852",
+    "municipio": "Pindoretama",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2310902",
+    "municipio": "Piquet Carneiro",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2310951",
+    "municipio": "Pires Ferreira",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2311009",
+    "municipio": "Poranga",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2311108",
+    "municipio": "Porteiras",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2311207",
+    "municipio": "Potengi",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2311231",
+    "municipio": "Potiretama",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2311264",
+    "municipio": "Quiterianópolis",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2311306",
+    "municipio": "Quixadá",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2311355",
+    "municipio": "Quixelô",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2311405",
+    "municipio": "Quixeramobim",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2311504",
+    "municipio": "Quixeré",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2311603",
+    "municipio": "Redenção",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2311702",
+    "municipio": "Reriutaba",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2311801",
+    "municipio": "Russas",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2311900",
+    "municipio": "Saboeiro",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2311959",
+    "municipio": "Salitre",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2312007",
+    "municipio": "Santana do Acaraú",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2312106",
+    "municipio": "Santana do Cariri",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2312205",
+    "municipio": "Santa Quitéria",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2312304",
+    "municipio": "São Benedito",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2312403",
+    "municipio": "São Gonçalo do Amarante",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2312502",
+    "municipio": "São João do Jaguaribe",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2312601",
+    "municipio": "São Luís do Curu",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2312700",
+    "municipio": "Senador Pompeu",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2312809",
+    "municipio": "Senador Sá",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2312908",
+    "municipio": "Sobral",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2313005",
+    "municipio": "Solonópole",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2313104",
+    "municipio": "Tabuleiro do Norte",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2313203",
+    "municipio": "Tamboril",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2313252",
+    "municipio": "Tarrafas",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2313302",
+    "municipio": "Tauá",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2313351",
+    "municipio": "Tejuçuoca",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2313401",
+    "municipio": "Tianguá",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2313500",
+    "municipio": "Trairi",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2313559",
+    "municipio": "Tururu",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2313609",
+    "municipio": "Ubajara",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2313708",
+    "municipio": "Umari",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2313757",
+    "municipio": "Umirim",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2313807",
+    "municipio": "Uruburetama",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2313906",
+    "municipio": "Uruoca",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2313955",
+    "municipio": "Varjota",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2314003",
+    "municipio": "Várzea Alegre",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2314102",
+    "municipio": "Viçosa do Ceará",
+    "uf": "CE"
+  },
+  {
+    "codigo": "2400109",
+    "municipio": "Acari",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2400208",
+    "municipio": "Açu",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2400307",
+    "municipio": "Afonso Bezerra",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2400406",
+    "municipio": "Água Nova",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2400505",
+    "municipio": "Alexandria",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2400604",
+    "municipio": "Almino Afonso",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2400703",
+    "municipio": "Alto do Rodrigues",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2400802",
+    "municipio": "Angicos",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2400901",
+    "municipio": "Antônio Martins",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2401008",
+    "municipio": "Apodi",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2401107",
+    "municipio": "Areia Branca",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2401206",
+    "municipio": "Arês",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2401305",
+    "municipio": "Campo Grande",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2401404",
+    "municipio": "Baía Formosa",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2401453",
+    "municipio": "Baraúna",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2401503",
+    "municipio": "Barcelona",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2401602",
+    "municipio": "Bento Fernandes",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2401651",
+    "municipio": "Bodó",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2401701",
+    "municipio": "Bom Jesus",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2401800",
+    "municipio": "Brejinho",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2401859",
+    "municipio": "Caiçara do Norte",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2401909",
+    "municipio": "Caiçara do Rio do Vento",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2402006",
+    "municipio": "Caicó",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2402105",
+    "municipio": "Campo Redondo",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2402204",
+    "municipio": "Canguaretama",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2402303",
+    "municipio": "Caraúbas",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2402402",
+    "municipio": "Carnaúba dos Dantas",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2402501",
+    "municipio": "Carnaubais",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2402600",
+    "municipio": "Ceará-Mirim",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2402709",
+    "municipio": "Cerro Corá",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2402808",
+    "municipio": "Coronel Ezequiel",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2402907",
+    "municipio": "Coronel João Pessoa",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2403004",
+    "municipio": "Cruzeta",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2403103",
+    "municipio": "Currais Novos",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2403202",
+    "municipio": "Doutor Severiano",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2403251",
+    "municipio": "Parnamirim",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2403301",
+    "municipio": "Encanto",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2403400",
+    "municipio": "Equador",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2403509",
+    "municipio": "Espírito Santo",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2403608",
+    "municipio": "Extremoz",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2403707",
+    "municipio": "Felipe Guerra",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2403756",
+    "municipio": "Fernando Pedroza",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2403806",
+    "municipio": "Florânia",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2403905",
+    "municipio": "Francisco Dantas",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2404002",
+    "municipio": "Frutuoso Gomes",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2404101",
+    "municipio": "Galinhos",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2404200",
+    "municipio": "Goianinha",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2404309",
+    "municipio": "Governador Dix-Sept Rosado",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2404408",
+    "municipio": "Grossos",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2404507",
+    "municipio": "Guamaré",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2404606",
+    "municipio": "Ielmo Marinho",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2404705",
+    "municipio": "Ipanguaçu",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2404804",
+    "municipio": "Ipueira",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2404853",
+    "municipio": "Itajá",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2404903",
+    "municipio": "Itaú",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2405009",
+    "municipio": "Jaçanã",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2405108",
+    "municipio": "Jandaíra",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2405207",
+    "municipio": "Janduís",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2405306",
+    "municipio": "Januário Cicco",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2405405",
+    "municipio": "Japi",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2405504",
+    "municipio": "Jardim de Angicos",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2405603",
+    "municipio": "Jardim de Piranhas",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2405702",
+    "municipio": "Jardim do Seridó",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2405801",
+    "municipio": "João Câmara",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2405900",
+    "municipio": "João Dias",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2406007",
+    "municipio": "José da Penha",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2406106",
+    "municipio": "Jucurutu",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2406155",
+    "municipio": "Jundiá",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2406205",
+    "municipio": "Lagoa d'Anta",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2406304",
+    "municipio": "Lagoa de Pedras",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2406403",
+    "municipio": "Lagoa de Velhos",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2406502",
+    "municipio": "Lagoa Nova",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2406601",
+    "municipio": "Lagoa Salgada",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2406700",
+    "municipio": "Lajes",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2406809",
+    "municipio": "Lajes Pintadas",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2406908",
+    "municipio": "Lucrécia",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2407005",
+    "municipio": "Luís Gomes",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2407104",
+    "municipio": "Macaíba",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2407203",
+    "municipio": "Macau",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2407252",
+    "municipio": "Major Sales",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2407302",
+    "municipio": "Marcelino Vieira",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2407401",
+    "municipio": "Martins",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2407500",
+    "municipio": "Maxaranguape",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2407609",
+    "municipio": "Messias Targino",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2407708",
+    "municipio": "Montanhas",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2407807",
+    "municipio": "Monte Alegre",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2407906",
+    "municipio": "Monte das Gameleiras",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2408003",
+    "municipio": "Mossoró",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2408102",
+    "municipio": "Natal",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2408201",
+    "municipio": "Nísia Floresta",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2408300",
+    "municipio": "Nova Cruz",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2408409",
+    "municipio": "Olho d'Água do Borges",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2408508",
+    "municipio": "Ouro Branco",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2408607",
+    "municipio": "Paraná",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2408706",
+    "municipio": "Paraú",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2408805",
+    "municipio": "Parazinho",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2408904",
+    "municipio": "Parelhas",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2408953",
+    "municipio": "Rio do Fogo",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2409100",
+    "municipio": "Passa e Fica",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2409209",
+    "municipio": "Passagem",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2409308",
+    "municipio": "Patu",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2409332",
+    "municipio": "Santa Maria",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2409407",
+    "municipio": "Pau dos Ferros",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2409506",
+    "municipio": "Pedra Grande",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2409605",
+    "municipio": "Pedra Preta",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2409704",
+    "municipio": "Pedro Avelino",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2409803",
+    "municipio": "Pedro Velho",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2409902",
+    "municipio": "Pendências",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2410009",
+    "municipio": "Pilões",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2410108",
+    "municipio": "Poço Branco",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2410207",
+    "municipio": "Portalegre",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2410256",
+    "municipio": "Porto do Mangue",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2410306",
+    "municipio": "Serra Caiada",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2410405",
+    "municipio": "Pureza",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2410504",
+    "municipio": "Rafael Fernandes",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2410603",
+    "municipio": "Rafael Godeiro",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2410702",
+    "municipio": "Riacho da Cruz",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2410801",
+    "municipio": "Riacho de Santana",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2410900",
+    "municipio": "Riachuelo",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2411007",
+    "municipio": "Rodolfo Fernandes",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2411056",
+    "municipio": "Tibau",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2411106",
+    "municipio": "Ruy Barbosa",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2411205",
+    "municipio": "Santa Cruz",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2411403",
+    "municipio": "Santana do Matos",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2411429",
+    "municipio": "Santana do Seridó",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2411502",
+    "municipio": "Santo Antônio",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2411601",
+    "municipio": "São Bento do Norte",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2411700",
+    "municipio": "São Bento do Trairí",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2411809",
+    "municipio": "São Fernando",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2411908",
+    "municipio": "São Francisco do Oeste",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2412005",
+    "municipio": "São Gonçalo do Amarante",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2412104",
+    "municipio": "São João do Sabugi",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2412203",
+    "municipio": "São José de Mipibu",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2412302",
+    "municipio": "São José do Campestre",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2412401",
+    "municipio": "São José do Seridó",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2412500",
+    "municipio": "São Miguel",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2412559",
+    "municipio": "São Miguel do Gostoso",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2412609",
+    "municipio": "São Paulo do Potengi",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2412708",
+    "municipio": "São Pedro",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2412807",
+    "municipio": "São Rafael",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2412906",
+    "municipio": "São Tomé",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2413003",
+    "municipio": "São Vicente",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2413102",
+    "municipio": "Senador Elói de Souza",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2413201",
+    "municipio": "Senador Georgino Avelino",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2413300",
+    "municipio": "Serra de São Bento",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2413359",
+    "municipio": "Serra do Mel",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2413409",
+    "municipio": "Serra Negra do Norte",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2413508",
+    "municipio": "Serrinha",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2413557",
+    "municipio": "Serrinha dos Pintos",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2413607",
+    "municipio": "Severiano Melo",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2413706",
+    "municipio": "Sítio Novo",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2413805",
+    "municipio": "Taboleiro Grande",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2413904",
+    "municipio": "Taipu",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2414001",
+    "municipio": "Tangará",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2414100",
+    "municipio": "Tenente Ananias",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2414159",
+    "municipio": "Tenente Laurentino Cruz",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2414209",
+    "municipio": "Tibau do Sul",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2414308",
+    "municipio": "Timbaúba dos Batistas",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2414407",
+    "municipio": "Touros",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2414456",
+    "municipio": "Triunfo Potiguar",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2414506",
+    "municipio": "Umarizal",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2414605",
+    "municipio": "Upanema",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2414704",
+    "municipio": "Várzea",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2414753",
+    "municipio": "Venha-Ver",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2414803",
+    "municipio": "Vera Cruz",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2414902",
+    "municipio": "Viçosa",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2415008",
+    "municipio": "Vila Flor",
+    "uf": "RN"
+  },
+  {
+    "codigo": "2500106",
+    "municipio": "Água Branca",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2500205",
+    "municipio": "Aguiar",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2500304",
+    "municipio": "Alagoa Grande",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2500403",
+    "municipio": "Alagoa Nova",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2500502",
+    "municipio": "Alagoinha",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2500536",
+    "municipio": "Alcantil",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2500577",
+    "municipio": "Algodão de Jandaíra",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2500601",
+    "municipio": "Alhandra",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2500700",
+    "municipio": "São João do Rio do Peixe",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2500734",
+    "municipio": "Amparo",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2500775",
+    "municipio": "Aparecida",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2500809",
+    "municipio": "Araçagi",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2500908",
+    "municipio": "Arara",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2501005",
+    "municipio": "Araruna",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2501104",
+    "municipio": "Areia",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2501153",
+    "municipio": "Areia de Baraúnas",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2501203",
+    "municipio": "Areial",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2501302",
+    "municipio": "Aroeiras",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2501351",
+    "municipio": "Assunção",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2501401",
+    "municipio": "Baía da Traição",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2501500",
+    "municipio": "Bananeiras",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2501534",
+    "municipio": "Baraúna",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2501575",
+    "municipio": "Barra de Santana",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2501609",
+    "municipio": "Barra de Santa Rosa",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2501708",
+    "municipio": "Barra de São Miguel",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2501807",
+    "municipio": "Bayeux",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2501906",
+    "municipio": "Belém",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2502003",
+    "municipio": "Belém do Brejo do Cruz",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2502052",
+    "municipio": "Bernardino Batista",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2502102",
+    "municipio": "Boa Ventura",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2502151",
+    "municipio": "Boa Vista",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2502201",
+    "municipio": "Bom Jesus",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2502300",
+    "municipio": "Bom Sucesso",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2502409",
+    "municipio": "Bonito de Santa Fé",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2502508",
+    "municipio": "Boqueirão",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2502607",
+    "municipio": "Igaracy",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2502706",
+    "municipio": "Borborema",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2502805",
+    "municipio": "Brejo do Cruz",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2502904",
+    "municipio": "Brejo dos Santos",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2503001",
+    "municipio": "Caaporã",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2503100",
+    "municipio": "Cabaceiras",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2503209",
+    "municipio": "Cabedelo",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2503308",
+    "municipio": "Cachoeira dos Índios",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2503407",
+    "municipio": "Cacimba de Areia",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2503506",
+    "municipio": "Cacimba de Dentro",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2503555",
+    "municipio": "Cacimbas",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2503605",
+    "municipio": "Caiçara",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2503704",
+    "municipio": "Cajazeiras",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2503753",
+    "municipio": "Cajazeirinhas",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2503803",
+    "municipio": "Caldas Brandão",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2503902",
+    "municipio": "Camalaú",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2504009",
+    "municipio": "Campina Grande",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2504033",
+    "municipio": "Capim",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2504074",
+    "municipio": "Caraúbas",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2504108",
+    "municipio": "Carrapateira",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2504157",
+    "municipio": "Casserengue",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2504207",
+    "municipio": "Catingueira",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2504306",
+    "municipio": "Catolé do Rocha",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2504355",
+    "municipio": "Caturité",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2504405",
+    "municipio": "Conceição",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2504504",
+    "municipio": "Condado",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2504603",
+    "municipio": "Conde",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2504702",
+    "municipio": "Congo",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2504801",
+    "municipio": "Coremas",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2504850",
+    "municipio": "Coxixola",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2504900",
+    "municipio": "Cruz do Espírito Santo",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2505006",
+    "municipio": "Cubati",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2505105",
+    "municipio": "Cuité",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2505204",
+    "municipio": "Cuitegi",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2505238",
+    "municipio": "Cuité de Mamanguape",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2505279",
+    "municipio": "Curral de Cima",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2505303",
+    "municipio": "Curral Velho",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2505352",
+    "municipio": "Damião",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2505402",
+    "municipio": "Desterro",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2505501",
+    "municipio": "Vista Serrana",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2505600",
+    "municipio": "Diamante",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2505709",
+    "municipio": "Dona Inês",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2505808",
+    "municipio": "Duas Estradas",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2505907",
+    "municipio": "Emas",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2506004",
+    "municipio": "Esperança",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2506103",
+    "municipio": "Fagundes",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2506202",
+    "municipio": "Frei Martinho",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2506251",
+    "municipio": "Gado Bravo",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2506301",
+    "municipio": "Guarabira",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2506400",
+    "municipio": "Gurinhém",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2506509",
+    "municipio": "Gurjão",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2506608",
+    "municipio": "Ibiara",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2506707",
+    "municipio": "Imaculada",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2506806",
+    "municipio": "Ingá",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2506905",
+    "municipio": "Itabaiana",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2507002",
+    "municipio": "Itaporanga",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2507101",
+    "municipio": "Itapororoca",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2507200",
+    "municipio": "Itatuba",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2507309",
+    "municipio": "Jacaraú",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2507408",
+    "municipio": "Jericó",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2507507",
+    "municipio": "João Pessoa",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2507606",
+    "municipio": "Juarez Távora",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2507705",
+    "municipio": "Juazeirinho",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2507804",
+    "municipio": "Junco do Seridó",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2507903",
+    "municipio": "Juripiranga",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2508000",
+    "municipio": "Juru",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2508109",
+    "municipio": "Lagoa",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2508208",
+    "municipio": "Lagoa de Dentro",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2508307",
+    "municipio": "Lagoa Seca",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2508406",
+    "municipio": "Lastro",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2508505",
+    "municipio": "Livramento",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2508554",
+    "municipio": "Logradouro",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2508604",
+    "municipio": "Lucena",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2508703",
+    "municipio": "Mãe d'Água",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2508802",
+    "municipio": "Malta",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2508901",
+    "municipio": "Mamanguape",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2509008",
+    "municipio": "Manaíra",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2509057",
+    "municipio": "Marcação",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2509107",
+    "municipio": "Mari",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2509156",
+    "municipio": "Marizópolis",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2509206",
+    "municipio": "Massaranduba",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2509305",
+    "municipio": "Mataraca",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2509339",
+    "municipio": "Matinhas",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2509370",
+    "municipio": "Mato Grosso",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2509396",
+    "municipio": "Maturéia",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2509404",
+    "municipio": "Mogeiro",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2509503",
+    "municipio": "Montadas",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2509602",
+    "municipio": "Monte Horebe",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2509701",
+    "municipio": "Monteiro",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2509800",
+    "municipio": "Mulungu",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2509909",
+    "municipio": "Natuba",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2510006",
+    "municipio": "Nazarezinho",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2510105",
+    "municipio": "Nova Floresta",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2510204",
+    "municipio": "Nova Olinda",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2510303",
+    "municipio": "Nova Palmeira",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2510402",
+    "municipio": "Olho d'Água",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2510501",
+    "municipio": "Olivedos",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2510600",
+    "municipio": "Ouro Velho",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2510659",
+    "municipio": "Parari",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2510709",
+    "municipio": "Passagem",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2510808",
+    "municipio": "Patos",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2510907",
+    "municipio": "Paulista",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2511004",
+    "municipio": "Pedra Branca",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2511103",
+    "municipio": "Pedra Lavrada",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2511202",
+    "municipio": "Pedras de Fogo",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2511301",
+    "municipio": "Piancó",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2511400",
+    "municipio": "Picuí",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2511509",
+    "municipio": "Pilar",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2511608",
+    "municipio": "Pilões",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2511707",
+    "municipio": "Pilõezinhos",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2511806",
+    "municipio": "Pirpirituba",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2511905",
+    "municipio": "Pitimbu",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2512002",
+    "municipio": "Pocinhos",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2512036",
+    "municipio": "Poço Dantas",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2512077",
+    "municipio": "Poço de José de Moura",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2512101",
+    "municipio": "Pombal",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2512200",
+    "municipio": "Prata",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2512309",
+    "municipio": "Princesa Isabel",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2512408",
+    "municipio": "Puxinanã",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2512507",
+    "municipio": "Queimadas",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2512606",
+    "municipio": "Quixaba",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2512705",
+    "municipio": "Remígio",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2512721",
+    "municipio": "Pedro Régis",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2512747",
+    "municipio": "Riachão",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2512754",
+    "municipio": "Riachão do Bacamarte",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2512762",
+    "municipio": "Riachão do Poço",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2512788",
+    "municipio": "Riacho de Santo Antônio",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2512804",
+    "municipio": "Riacho dos Cavalos",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2512903",
+    "municipio": "Rio Tinto",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513000",
+    "municipio": "Salgadinho",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513109",
+    "municipio": "Salgado de São Félix",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513158",
+    "municipio": "Santa Cecília",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513208",
+    "municipio": "Santa Cruz",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513307",
+    "municipio": "Santa Helena",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513356",
+    "municipio": "Santa Inês",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513406",
+    "municipio": "Santa Luzia",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513505",
+    "municipio": "Santana de Mangueira",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513604",
+    "municipio": "Santana dos Garrotes",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513653",
+    "municipio": "Joca Claudino",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513703",
+    "municipio": "Santa Rita",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513802",
+    "municipio": "Santa Teresinha",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513851",
+    "municipio": "Santo André",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513901",
+    "municipio": "São Bento",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513927",
+    "municipio": "São Bentinho",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513943",
+    "municipio": "São Domingos do Cariri",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513968",
+    "municipio": "São Domingos",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2513984",
+    "municipio": "São Francisco",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2514008",
+    "municipio": "São João do Cariri",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2514107",
+    "municipio": "São João do Tigre",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2514206",
+    "municipio": "São José da Lagoa Tapada",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2514305",
+    "municipio": "São José de Caiana",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2514404",
+    "municipio": "São José de Espinharas",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2514453",
+    "municipio": "São José dos Ramos",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2514503",
+    "municipio": "São José de Piranhas",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2514552",
+    "municipio": "São José de Princesa",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2514602",
+    "municipio": "São José do Bonfim",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2514651",
+    "municipio": "São José do Brejo do Cruz",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2514701",
+    "municipio": "São José do Sabugi",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2514800",
+    "municipio": "São José dos Cordeiros",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2514909",
+    "municipio": "São Mamede",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2515005",
+    "municipio": "São Miguel de Taipu",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2515104",
+    "municipio": "São Sebastião de Lagoa de Roça",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2515203",
+    "municipio": "São Sebastião do Umbuzeiro",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2515302",
+    "municipio": "Sapé",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2515401",
+    "municipio": "São Vicente do Seridó",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2515500",
+    "municipio": "Serra Branca",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2515609",
+    "municipio": "Serra da Raiz",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2515708",
+    "municipio": "Serra Grande",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2515807",
+    "municipio": "Serra Redonda",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2515906",
+    "municipio": "Serraria",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2515930",
+    "municipio": "Sertãozinho",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2515971",
+    "municipio": "Sobrado",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2516003",
+    "municipio": "Solânea",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2516102",
+    "municipio": "Soledade",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2516151",
+    "municipio": "Sossêgo",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2516201",
+    "municipio": "Sousa",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2516300",
+    "municipio": "Sumé",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2516409",
+    "municipio": "Tacima",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2516508",
+    "municipio": "Taperoá",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2516607",
+    "municipio": "Tavares",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2516706",
+    "municipio": "Teixeira",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2516755",
+    "municipio": "Tenório",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2516805",
+    "municipio": "Triunfo",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2516904",
+    "municipio": "Uiraúna",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2517001",
+    "municipio": "Umbuzeiro",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2517100",
+    "municipio": "Várzea",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2517209",
+    "municipio": "Vieirópolis",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2517407",
+    "municipio": "Zabelê",
+    "uf": "PB"
+  },
+  {
+    "codigo": "2600054",
+    "municipio": "Abreu e Lima",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2600104",
+    "municipio": "Afogados da Ingazeira",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2600203",
+    "municipio": "Afrânio",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2600302",
+    "municipio": "Agrestina",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2600401",
+    "municipio": "Água Preta",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2600500",
+    "municipio": "Águas Belas",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2600609",
+    "municipio": "Alagoinha",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2600708",
+    "municipio": "Aliança",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2600807",
+    "municipio": "Altinho",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2600906",
+    "municipio": "Amaraji",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2601003",
+    "municipio": "Angelim",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2601052",
+    "municipio": "Araçoiaba",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2601102",
+    "municipio": "Araripina",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2601201",
+    "municipio": "Arcoverde",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2601300",
+    "municipio": "Barra de Guabiraba",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2601409",
+    "municipio": "Barreiros",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2601508",
+    "municipio": "Belém de Maria",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2601607",
+    "municipio": "Belém do São Francisco",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2601706",
+    "municipio": "Belo Jardim",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2601805",
+    "municipio": "Betânia",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2601904",
+    "municipio": "Bezerros",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2602001",
+    "municipio": "Bodocó",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2602100",
+    "municipio": "Bom Conselho",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2602209",
+    "municipio": "Bom Jardim",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2602308",
+    "municipio": "Bonito",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2602407",
+    "municipio": "Brejão",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2602506",
+    "municipio": "Brejinho",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2602605",
+    "municipio": "Brejo da Madre de Deus",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2602704",
+    "municipio": "Buenos Aires",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2602803",
+    "municipio": "Buíque",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2602902",
+    "municipio": "Cabo de Santo Agostinho",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2603009",
+    "municipio": "Cabrobó",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2603108",
+    "municipio": "Cachoeirinha",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2603207",
+    "municipio": "Caetés",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2603306",
+    "municipio": "Calçado",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2603405",
+    "municipio": "Calumbi",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2603454",
+    "municipio": "Camaragibe",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2603504",
+    "municipio": "Camocim de São Félix",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2603603",
+    "municipio": "Camutanga",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2603702",
+    "municipio": "Canhotinho",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2603801",
+    "municipio": "Capoeiras",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2603900",
+    "municipio": "Carnaíba",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2603926",
+    "municipio": "Carnaubeira da Penha",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2604007",
+    "municipio": "Carpina",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2604106",
+    "municipio": "Caruaru",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2604155",
+    "municipio": "Casinhas",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2604205",
+    "municipio": "Catende",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2604304",
+    "municipio": "Cedro",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2604403",
+    "municipio": "Chã de Alegria",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2604502",
+    "municipio": "Chã Grande",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2604601",
+    "municipio": "Condado",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2604700",
+    "municipio": "Correntes",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2604809",
+    "municipio": "Cortês",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2604908",
+    "municipio": "Cumaru",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2605004",
+    "municipio": "Cupira",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2605103",
+    "municipio": "Custódia",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2605152",
+    "municipio": "Dormentes",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2605202",
+    "municipio": "Escada",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2605301",
+    "municipio": "Exu",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2605400",
+    "municipio": "Feira Nova",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2605459",
+    "municipio": "Fernando de Noronha",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2605509",
+    "municipio": "Ferreiros",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2605608",
+    "municipio": "Flores",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2605707",
+    "municipio": "Floresta",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2605806",
+    "municipio": "Frei Miguelinho",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2605905",
+    "municipio": "Gameleira",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2606002",
+    "municipio": "Garanhuns",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2606101",
+    "municipio": "Glória do Goitá",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2606200",
+    "municipio": "Goiana",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2606309",
+    "municipio": "Granito",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2606408",
+    "municipio": "Gravatá",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2606507",
+    "municipio": "Iati",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2606606",
+    "municipio": "Ibimirim",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2606705",
+    "municipio": "Ibirajuba",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2606804",
+    "municipio": "Igarassu",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2606903",
+    "municipio": "Iguaracy",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2607000",
+    "municipio": "Inajá",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2607109",
+    "municipio": "Ingazeira",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2607208",
+    "municipio": "Ipojuca",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2607307",
+    "municipio": "Ipubi",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2607406",
+    "municipio": "Itacuruba",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2607505",
+    "municipio": "Itaíba",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2607604",
+    "municipio": "Ilha de Itamaracá",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2607653",
+    "municipio": "Itambé",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2607703",
+    "municipio": "Itapetim",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2607752",
+    "municipio": "Itapissuma",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2607802",
+    "municipio": "Itaquitinga",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2607901",
+    "municipio": "Jaboatão dos Guararapes",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2607950",
+    "municipio": "Jaqueira",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2608008",
+    "municipio": "Jataúba",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2608057",
+    "municipio": "Jatobá",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2608107",
+    "municipio": "João Alfredo",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2608206",
+    "municipio": "Joaquim Nabuco",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2608255",
+    "municipio": "Jucati",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2608305",
+    "municipio": "Jupi",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2608404",
+    "municipio": "Jurema",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2608453",
+    "municipio": "Lagoa do Carro",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2608503",
+    "municipio": "Lagoa de Itaenga",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2608602",
+    "municipio": "Lagoa do Ouro",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2608701",
+    "municipio": "Lagoa dos Gatos",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2608750",
+    "municipio": "Lagoa Grande",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2608800",
+    "municipio": "Lajedo",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2608909",
+    "municipio": "Limoeiro",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2609006",
+    "municipio": "Macaparana",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2609105",
+    "municipio": "Machados",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2609154",
+    "municipio": "Manari",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2609204",
+    "municipio": "Maraial",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2609303",
+    "municipio": "Mirandiba",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2609402",
+    "municipio": "Moreno",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2609501",
+    "municipio": "Nazaré da Mata",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2609600",
+    "municipio": "Olinda",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2609709",
+    "municipio": "Orobó",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2609808",
+    "municipio": "Orocó",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2609907",
+    "municipio": "Ouricuri",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2610004",
+    "municipio": "Palmares",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2610103",
+    "municipio": "Palmeirina",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2610202",
+    "municipio": "Panelas",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2610301",
+    "municipio": "Paranatama",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2610400",
+    "municipio": "Parnamirim",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2610509",
+    "municipio": "Passira",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2610608",
+    "municipio": "Paudalho",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2610707",
+    "municipio": "Paulista",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2610806",
+    "municipio": "Pedra",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2610905",
+    "municipio": "Pesqueira",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2611002",
+    "municipio": "Petrolândia",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2611101",
+    "municipio": "Petrolina",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2611200",
+    "municipio": "Poção",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2611309",
+    "municipio": "Pombos",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2611408",
+    "municipio": "Primavera",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2611507",
+    "municipio": "Quipapá",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2611533",
+    "municipio": "Quixaba",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2611606",
+    "municipio": "Recife",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2611705",
+    "municipio": "Riacho das Almas",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2611804",
+    "municipio": "Ribeirão",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2611903",
+    "municipio": "Rio Formoso",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2612000",
+    "municipio": "Sairé",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2612109",
+    "municipio": "Salgadinho",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2612208",
+    "municipio": "Salgueiro",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2612307",
+    "municipio": "Saloá",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2612406",
+    "municipio": "Sanharó",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2612455",
+    "municipio": "Santa Cruz",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2612471",
+    "municipio": "Santa Cruz da Baixa Verde",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2612505",
+    "municipio": "Santa Cruz do Capibaribe",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2612554",
+    "municipio": "Santa Filomena",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2612604",
+    "municipio": "Santa Maria da Boa Vista",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2612703",
+    "municipio": "Santa Maria do Cambucá",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2612802",
+    "municipio": "Santa Terezinha",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2612901",
+    "municipio": "São Benedito do Sul",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2613008",
+    "municipio": "São Bento do Una",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2613107",
+    "municipio": "São Caitano",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2613206",
+    "municipio": "São João",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2613305",
+    "municipio": "São Joaquim do Monte",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2613404",
+    "municipio": "São José da Coroa Grande",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2613503",
+    "municipio": "São José do Belmonte",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2613602",
+    "municipio": "São José do Egito",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2613701",
+    "municipio": "São Lourenço da Mata",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2613800",
+    "municipio": "São Vicente Férrer",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2613909",
+    "municipio": "Serra Talhada",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2614006",
+    "municipio": "Serrita",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2614105",
+    "municipio": "Sertânia",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2614204",
+    "municipio": "Sirinhaém",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2614303",
+    "municipio": "Moreilândia",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2614402",
+    "municipio": "Solidão",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2614501",
+    "municipio": "Surubim",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2614600",
+    "municipio": "Tabira",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2614709",
+    "municipio": "Tacaimbó",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2614808",
+    "municipio": "Tacaratu",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2614857",
+    "municipio": "Tamandaré",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2615003",
+    "municipio": "Taquaritinga do Norte",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2615102",
+    "municipio": "Terezinha",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2615201",
+    "municipio": "Terra Nova",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2615300",
+    "municipio": "Timbaúba",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2615409",
+    "municipio": "Toritama",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2615508",
+    "municipio": "Tracunhaém",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2615607",
+    "municipio": "Trindade",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2615706",
+    "municipio": "Triunfo",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2615805",
+    "municipio": "Tupanatinga",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2615904",
+    "municipio": "Tuparetama",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2616001",
+    "municipio": "Venturosa",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2616100",
+    "municipio": "Verdejante",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2616183",
+    "municipio": "Vertente do Lério",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2616209",
+    "municipio": "Vertentes",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2616308",
+    "municipio": "Vicência",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2616407",
+    "municipio": "Vitória de Santo Antão",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2616506",
+    "municipio": "Xexéu",
+    "uf": "PE"
+  },
+  {
+    "codigo": "2700102",
+    "municipio": "Água Branca",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2700201",
+    "municipio": "Anadia",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2700300",
+    "municipio": "Arapiraca",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2700409",
+    "municipio": "Atalaia",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2700508",
+    "municipio": "Barra de Santo Antônio",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2700607",
+    "municipio": "Barra de São Miguel",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2700706",
+    "municipio": "Batalha",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2700805",
+    "municipio": "Belém",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2700904",
+    "municipio": "Belo Monte",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2701001",
+    "municipio": "Boca da Mata",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2701100",
+    "municipio": "Branquinha",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2701209",
+    "municipio": "Cacimbinhas",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2701308",
+    "municipio": "Cajueiro",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2701357",
+    "municipio": "Campestre",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2701407",
+    "municipio": "Campo Alegre",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2701506",
+    "municipio": "Campo Grande",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2701605",
+    "municipio": "Canapi",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2701704",
+    "municipio": "Capela",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2701803",
+    "municipio": "Carneiros",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2701902",
+    "municipio": "Chã Preta",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2702009",
+    "municipio": "Coité do Nóia",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2702108",
+    "municipio": "Colônia Leopoldina",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2702207",
+    "municipio": "Coqueiro Seco",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2702306",
+    "municipio": "Coruripe",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2702355",
+    "municipio": "Craíbas",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2702405",
+    "municipio": "Delmiro Gouveia",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2702504",
+    "municipio": "Dois Riachos",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2702553",
+    "municipio": "Estrela de Alagoas",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2702603",
+    "municipio": "Feira Grande",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2702702",
+    "municipio": "Feliz Deserto",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2702801",
+    "municipio": "Flexeiras",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2702900",
+    "municipio": "Girau do Ponciano",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2703007",
+    "municipio": "Ibateguara",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2703106",
+    "municipio": "Igaci",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2703205",
+    "municipio": "Igreja Nova",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2703304",
+    "municipio": "Inhapi",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2703403",
+    "municipio": "Jacaré dos Homens",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2703502",
+    "municipio": "Jacuípe",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2703601",
+    "municipio": "Japaratinga",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2703700",
+    "municipio": "Jaramataia",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2703759",
+    "municipio": "Jequiá da Praia",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2703809",
+    "municipio": "Joaquim Gomes",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2703908",
+    "municipio": "Jundiá",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2704005",
+    "municipio": "Junqueiro",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2704104",
+    "municipio": "Lagoa da Canoa",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2704203",
+    "municipio": "Limoeiro de Anadia",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2704302",
+    "municipio": "Maceió",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2704401",
+    "municipio": "Major Isidoro",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2704500",
+    "municipio": "Maragogi",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2704609",
+    "municipio": "Maravilha",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2704708",
+    "municipio": "Marechal Deodoro",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2704807",
+    "municipio": "Maribondo",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2704906",
+    "municipio": "Mar Vermelho",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2705002",
+    "municipio": "Mata Grande",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2705101",
+    "municipio": "Matriz de Camaragibe",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2705200",
+    "municipio": "Messias",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2705309",
+    "municipio": "Minador do Negrão",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2705408",
+    "municipio": "Monteirópolis",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2705507",
+    "municipio": "Murici",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2705606",
+    "municipio": "Novo Lino",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2705705",
+    "municipio": "Olho d'Água das Flores",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2705804",
+    "municipio": "Olho d'Água do Casado",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2705903",
+    "municipio": "Olho d'Água Grande",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2706000",
+    "municipio": "Olivença",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2706109",
+    "municipio": "Ouro Branco",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2706208",
+    "municipio": "Palestina",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2706307",
+    "municipio": "Palmeira dos Índios",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2706406",
+    "municipio": "Pão de Açúcar",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2706422",
+    "municipio": "Pariconha",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2706448",
+    "municipio": "Paripueira",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2706505",
+    "municipio": "Passo de Camaragibe",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2706604",
+    "municipio": "Paulo Jacinto",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2706703",
+    "municipio": "Penedo",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2706802",
+    "municipio": "Piaçabuçu",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2706901",
+    "municipio": "Pilar",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2707008",
+    "municipio": "Pindoba",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2707107",
+    "municipio": "Piranhas",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2707206",
+    "municipio": "Poço das Trincheiras",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2707305",
+    "municipio": "Porto Calvo",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2707404",
+    "municipio": "Porto de Pedras",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2707503",
+    "municipio": "Porto Real do Colégio",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2707602",
+    "municipio": "Quebrangulo",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2707701",
+    "municipio": "Rio Largo",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2707800",
+    "municipio": "Roteiro",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2707909",
+    "municipio": "Santa Luzia do Norte",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2708006",
+    "municipio": "Santana do Ipanema",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2708105",
+    "municipio": "Santana do Mundaú",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2708204",
+    "municipio": "São Brás",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2708303",
+    "municipio": "São José da Laje",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2708402",
+    "municipio": "São José da Tapera",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2708501",
+    "municipio": "São Luís do Quitunde",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2708600",
+    "municipio": "São Miguel dos Campos",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2708709",
+    "municipio": "São Miguel dos Milagres",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2708808",
+    "municipio": "São Sebastião",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2708907",
+    "municipio": "Satuba",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2708956",
+    "municipio": "Senador Rui Palmeira",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2709004",
+    "municipio": "Tanque d'Arca",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2709103",
+    "municipio": "Taquarana",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2709152",
+    "municipio": "Teotônio Vilela",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2709202",
+    "municipio": "Traipu",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2709301",
+    "municipio": "União dos Palmares",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2709400",
+    "municipio": "Viçosa",
+    "uf": "AL"
+  },
+  {
+    "codigo": "2800100",
+    "municipio": "Amparo do São Francisco",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2800209",
+    "municipio": "Aquidabã",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2800308",
+    "municipio": "Aracaju",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2800407",
+    "municipio": "Arauá",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2800506",
+    "municipio": "Areia Branca",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2800605",
+    "municipio": "Barra dos Coqueiros",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2800670",
+    "municipio": "Boquim",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2800704",
+    "municipio": "Brejo Grande",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2801009",
+    "municipio": "Campo do Brito",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2801108",
+    "municipio": "Canhoba",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2801207",
+    "municipio": "Canindé de São Francisco",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2801306",
+    "municipio": "Capela",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2801405",
+    "municipio": "Carira",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2801504",
+    "municipio": "Carmópolis",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2801603",
+    "municipio": "Cedro de São João",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2801702",
+    "municipio": "Cristinápolis",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2801900",
+    "municipio": "Cumbe",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2802007",
+    "municipio": "Divina Pastora",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2802106",
+    "municipio": "Estância",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2802205",
+    "municipio": "Feira Nova",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2802304",
+    "municipio": "Frei Paulo",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2802403",
+    "municipio": "Gararu",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2802502",
+    "municipio": "General Maynard",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2802601",
+    "municipio": "Graccho Cardoso",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2802700",
+    "municipio": "Ilha das Flores",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2802809",
+    "municipio": "Indiaroba",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2802908",
+    "municipio": "Itabaiana",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2803005",
+    "municipio": "Itabaianinha",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2803104",
+    "municipio": "Itabi",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2803203",
+    "municipio": "Itaporanga d'Ajuda",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2803302",
+    "municipio": "Japaratuba",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2803401",
+    "municipio": "Japoatã",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2803500",
+    "municipio": "Lagarto",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2803609",
+    "municipio": "Laranjeiras",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2803708",
+    "municipio": "Macambira",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2803807",
+    "municipio": "Malhada dos Bois",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2803906",
+    "municipio": "Malhador",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2804003",
+    "municipio": "Maruim",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2804102",
+    "municipio": "Moita Bonita",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2804201",
+    "municipio": "Monte Alegre de Sergipe",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2804300",
+    "municipio": "Muribeca",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2804409",
+    "municipio": "Neópolis",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2804458",
+    "municipio": "Nossa Senhora Aparecida",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2804508",
+    "municipio": "Nossa Senhora da Glória",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2804607",
+    "municipio": "Nossa Senhora das Dores",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2804706",
+    "municipio": "Nossa Senhora de Lourdes",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2804805",
+    "municipio": "Nossa Senhora do Socorro",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2804904",
+    "municipio": "Pacatuba",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2805000",
+    "municipio": "Pedra Mole",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2805109",
+    "municipio": "Pedrinhas",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2805208",
+    "municipio": "Pinhão",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2805307",
+    "municipio": "Pirambu",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2805406",
+    "municipio": "Poço Redondo",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2805505",
+    "municipio": "Poço Verde",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2805604",
+    "municipio": "Porto da Folha",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2805703",
+    "municipio": "Propriá",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2805802",
+    "municipio": "Riachão do Dantas",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2805901",
+    "municipio": "Riachuelo",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2806008",
+    "municipio": "Ribeirópolis",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2806107",
+    "municipio": "Rosário do Catete",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2806206",
+    "municipio": "Salgado",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2806305",
+    "municipio": "Santa Luzia do Itanhy",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2806404",
+    "municipio": "Santana do São Francisco",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2806503",
+    "municipio": "Santa Rosa de Lima",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2806602",
+    "municipio": "Santo Amaro das Brotas",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2806701",
+    "municipio": "São Cristóvão",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2806800",
+    "municipio": "São Domingos",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2806909",
+    "municipio": "São Francisco",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2807006",
+    "municipio": "São Miguel do Aleixo",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2807105",
+    "municipio": "Simão Dias",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2807204",
+    "municipio": "Siriri",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2807303",
+    "municipio": "Telha",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2807402",
+    "municipio": "Tobias Barreto",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2807501",
+    "municipio": "Tomar do Geru",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2807600",
+    "municipio": "Umbaúba",
+    "uf": "SE"
+  },
+  {
+    "codigo": "2900108",
+    "municipio": "Abaíra",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2900207",
+    "municipio": "Abaré",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2900306",
+    "municipio": "Acajutiba",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2900355",
+    "municipio": "Adustina",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2900405",
+    "municipio": "Água Fria",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2900504",
+    "municipio": "Érico Cardoso",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2900603",
+    "municipio": "Aiquara",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2900702",
+    "municipio": "Alagoinhas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2900801",
+    "municipio": "Alcobaça",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2900900",
+    "municipio": "Almadina",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2901007",
+    "municipio": "Amargosa",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2901106",
+    "municipio": "Amélia Rodrigues",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2901155",
+    "municipio": "América Dourada",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2901205",
+    "municipio": "Anagé",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2901304",
+    "municipio": "Andaraí",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2901353",
+    "municipio": "Andorinha",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2901403",
+    "municipio": "Angical",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2901502",
+    "municipio": "Anguera",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2901601",
+    "municipio": "Antas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2901700",
+    "municipio": "Antônio Cardoso",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2901809",
+    "municipio": "Antônio Gonçalves",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2901908",
+    "municipio": "Aporá",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2901957",
+    "municipio": "Apuarema",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2902005",
+    "municipio": "Aracatu",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2902054",
+    "municipio": "Araçás",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2902104",
+    "municipio": "Araci",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2902203",
+    "municipio": "Aramari",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2902252",
+    "municipio": "Arataca",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2902302",
+    "municipio": "Aratuípe",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2902401",
+    "municipio": "Aurelino Leal",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2902500",
+    "municipio": "Baianópolis",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2902609",
+    "municipio": "Baixa Grande",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2902658",
+    "municipio": "Banzaê",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2902708",
+    "municipio": "Barra",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2902807",
+    "municipio": "Barra da Estiva",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2902906",
+    "municipio": "Barra do Choça",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2903003",
+    "municipio": "Barra do Mendes",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2903102",
+    "municipio": "Barra do Rocha",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2903201",
+    "municipio": "Barreiras",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2903235",
+    "municipio": "Barro Alto",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2903276",
+    "municipio": "Barrocas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2903300",
+    "municipio": "Barro Preto",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2903409",
+    "municipio": "Belmonte",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2903508",
+    "municipio": "Belo Campo",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2903607",
+    "municipio": "Biritinga",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2903706",
+    "municipio": "Boa Nova",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2903805",
+    "municipio": "Boa Vista do Tupim",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2903904",
+    "municipio": "Bom Jesus da Lapa",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2903953",
+    "municipio": "Bom Jesus da Serra",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2904001",
+    "municipio": "Boninal",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2904050",
+    "municipio": "Bonito",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2904100",
+    "municipio": "Boquira",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2904209",
+    "municipio": "Botuporã",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2904308",
+    "municipio": "Brejões",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2904407",
+    "municipio": "Brejolândia",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2904506",
+    "municipio": "Brotas de Macaúbas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2904605",
+    "municipio": "Brumado",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2904704",
+    "municipio": "Buerarema",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2904753",
+    "municipio": "Buritirama",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2904803",
+    "municipio": "Caatiba",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2904852",
+    "municipio": "Cabaceiras do Paraguaçu",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2904902",
+    "municipio": "Cachoeira",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2905008",
+    "municipio": "Caculé",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2905107",
+    "municipio": "Caém",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2905156",
+    "municipio": "Caetanos",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2905206",
+    "municipio": "Caetité",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2905305",
+    "municipio": "Cafarnaum",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2905404",
+    "municipio": "Cairu",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2905503",
+    "municipio": "Caldeirão Grande",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2905602",
+    "municipio": "Camacan",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2905701",
+    "municipio": "Camaçari",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2905800",
+    "municipio": "Camamu",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2905909",
+    "municipio": "Campo Alegre de Lourdes",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2906006",
+    "municipio": "Campo Formoso",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2906105",
+    "municipio": "Canápolis",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2906204",
+    "municipio": "Canarana",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2906303",
+    "municipio": "Canavieiras",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2906402",
+    "municipio": "Candeal",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2906501",
+    "municipio": "Candeias",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2906600",
+    "municipio": "Candiba",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2906709",
+    "municipio": "Cândido Sales",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2906808",
+    "municipio": "Cansanção",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2906824",
+    "municipio": "Canudos",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2906857",
+    "municipio": "Capela do Alto Alegre",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2906873",
+    "municipio": "Capim Grosso",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2906899",
+    "municipio": "Caraíbas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2906907",
+    "municipio": "Caravelas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2907004",
+    "municipio": "Cardeal da Silva",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2907103",
+    "municipio": "Carinhanha",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2907202",
+    "municipio": "Casa Nova",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2907301",
+    "municipio": "Castro Alves",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2907400",
+    "municipio": "Catolândia",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2907509",
+    "municipio": "Catu",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2907558",
+    "municipio": "Caturama",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2907608",
+    "municipio": "Central",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2907707",
+    "municipio": "Chorrochó",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2907806",
+    "municipio": "Cícero Dantas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2907905",
+    "municipio": "Cipó",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2908002",
+    "municipio": "Coaraci",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2908101",
+    "municipio": "Cocos",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2908200",
+    "municipio": "Conceição da Feira",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2908309",
+    "municipio": "Conceição do Almeida",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2908408",
+    "municipio": "Conceição do Coité",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2908507",
+    "municipio": "Conceição do Jacuípe",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2908606",
+    "municipio": "Conde",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2908705",
+    "municipio": "Condeúba",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2908804",
+    "municipio": "Contendas do Sincorá",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2908903",
+    "municipio": "Coração de Maria",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2909000",
+    "municipio": "Cordeiros",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2909109",
+    "municipio": "Coribe",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2909208",
+    "municipio": "Coronel João Sá",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2909307",
+    "municipio": "Correntina",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2909406",
+    "municipio": "Cotegipe",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2909505",
+    "municipio": "Cravolândia",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2909604",
+    "municipio": "Crisópolis",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2909703",
+    "municipio": "Cristópolis",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2909802",
+    "municipio": "Cruz das Almas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2909901",
+    "municipio": "Curaçá",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2910008",
+    "municipio": "Dário Meira",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2910057",
+    "municipio": "Dias d'Ávila",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2910107",
+    "municipio": "Dom Basílio",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2910206",
+    "municipio": "Dom Macedo Costa",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2910305",
+    "municipio": "Elísio Medrado",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2910404",
+    "municipio": "Encruzilhada",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2910503",
+    "municipio": "Entre Rios",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2910602",
+    "municipio": "Esplanada",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2910701",
+    "municipio": "Euclides da Cunha",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2910727",
+    "municipio": "Eunápolis",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2910750",
+    "municipio": "Fátima",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2910776",
+    "municipio": "Feira da Mata",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2910800",
+    "municipio": "Feira de Santana",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2910859",
+    "municipio": "Filadélfia",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2910909",
+    "municipio": "Firmino Alves",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2911006",
+    "municipio": "Floresta Azul",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2911105",
+    "municipio": "Formosa do Rio Preto",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2911204",
+    "municipio": "Gandu",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2911253",
+    "municipio": "Gavião",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2911303",
+    "municipio": "Gentio do Ouro",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2911402",
+    "municipio": "Glória",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2911501",
+    "municipio": "Gongogi",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2911600",
+    "municipio": "Governador Mangabeira",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2911659",
+    "municipio": "Guajeru",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2911709",
+    "municipio": "Guanambi",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2911808",
+    "municipio": "Guaratinga",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2911857",
+    "municipio": "Heliópolis",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2911907",
+    "municipio": "Iaçu",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2912004",
+    "municipio": "Ibiassucê",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2912103",
+    "municipio": "Ibicaraí",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2912202",
+    "municipio": "Ibicoara",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2912301",
+    "municipio": "Ibicuí",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2912400",
+    "municipio": "Ibipeba",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2912509",
+    "municipio": "Ibipitanga",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2912608",
+    "municipio": "Ibiquera",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2912707",
+    "municipio": "Ibirapitanga",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2912806",
+    "municipio": "Ibirapuã",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2912905",
+    "municipio": "Ibirataia",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2913002",
+    "municipio": "Ibitiara",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2913101",
+    "municipio": "Ibititá",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2913200",
+    "municipio": "Ibotirama",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2913309",
+    "municipio": "Ichu",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2913408",
+    "municipio": "Igaporã",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2913457",
+    "municipio": "Igrapiúna",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2913507",
+    "municipio": "Iguaí",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2913606",
+    "municipio": "Ilhéus",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2913705",
+    "municipio": "Inhambupe",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2913804",
+    "municipio": "Ipecaetá",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2913903",
+    "municipio": "Ipiaú",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2914000",
+    "municipio": "Ipirá",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2914109",
+    "municipio": "Ipupiara",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2914208",
+    "municipio": "Irajuba",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2914307",
+    "municipio": "Iramaia",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2914406",
+    "municipio": "Iraquara",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2914505",
+    "municipio": "Irará",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2914604",
+    "municipio": "Irecê",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2914653",
+    "municipio": "Itabela",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2914703",
+    "municipio": "Itaberaba",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2914802",
+    "municipio": "Itabuna",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2914901",
+    "municipio": "Itacaré",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2915007",
+    "municipio": "Itaeté",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2915106",
+    "municipio": "Itagi",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2915205",
+    "municipio": "Itagibá",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2915304",
+    "municipio": "Itagimirim",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2915353",
+    "municipio": "Itaguaçu da Bahia",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2915403",
+    "municipio": "Itaju do Colônia",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2915502",
+    "municipio": "Itajuípe",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2915601",
+    "municipio": "Itamaraju",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2915700",
+    "municipio": "Itamari",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2915809",
+    "municipio": "Itambé",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2915908",
+    "municipio": "Itanagra",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2916005",
+    "municipio": "Itanhém",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2916104",
+    "municipio": "Itaparica",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2916203",
+    "municipio": "Itapé",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2916302",
+    "municipio": "Itapebi",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2916401",
+    "municipio": "Itapetinga",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2916500",
+    "municipio": "Itapicuru",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2916609",
+    "municipio": "Itapitanga",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2916708",
+    "municipio": "Itaquara",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2916807",
+    "municipio": "Itarantim",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2916856",
+    "municipio": "Itatim",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2916906",
+    "municipio": "Itiruçu",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2917003",
+    "municipio": "Itiúba",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2917102",
+    "municipio": "Itororó",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2917201",
+    "municipio": "Ituaçu",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2917300",
+    "municipio": "Ituberá",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2917334",
+    "municipio": "Iuiu",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2917359",
+    "municipio": "Jaborandi",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2917409",
+    "municipio": "Jacaraci",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2917508",
+    "municipio": "Jacobina",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2917607",
+    "municipio": "Jaguaquara",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2917706",
+    "municipio": "Jaguarari",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2917805",
+    "municipio": "Jaguaripe",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2917904",
+    "municipio": "Jandaíra",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2918001",
+    "municipio": "Jequié",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2918100",
+    "municipio": "Jeremoabo",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2918209",
+    "municipio": "Jiquiriçá",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2918308",
+    "municipio": "Jitaúna",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2918357",
+    "municipio": "João Dourado",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2918407",
+    "municipio": "Juazeiro",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2918456",
+    "municipio": "Jucuruçu",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2918506",
+    "municipio": "Jussara",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2918555",
+    "municipio": "Jussari",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2918605",
+    "municipio": "Jussiape",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2918704",
+    "municipio": "Lafaiete Coutinho",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2918753",
+    "municipio": "Lagoa Real",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2918803",
+    "municipio": "Laje",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2918902",
+    "municipio": "Lajedão",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2919009",
+    "municipio": "Lajedinho",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2919058",
+    "municipio": "Lajedo do Tabocal",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2919108",
+    "municipio": "Lamarão",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2919157",
+    "municipio": "Lapão",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2919207",
+    "municipio": "Lauro de Freitas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2919306",
+    "municipio": "Lençóis",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2919405",
+    "municipio": "Licínio de Almeida",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2919504",
+    "municipio": "Livramento de Nossa Senhora",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2919553",
+    "municipio": "Luís Eduardo Magalhães",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2919603",
+    "municipio": "Macajuba",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2919702",
+    "municipio": "Macarani",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2919801",
+    "municipio": "Macaúbas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2919900",
+    "municipio": "Macururé",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2919926",
+    "municipio": "Madre de Deus",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2919959",
+    "municipio": "Maetinga",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2920007",
+    "municipio": "Maiquinique",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2920106",
+    "municipio": "Mairi",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2920205",
+    "municipio": "Malhada",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2920304",
+    "municipio": "Malhada de Pedras",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2920403",
+    "municipio": "Manoel Vitorino",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2920452",
+    "municipio": "Mansidão",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2920502",
+    "municipio": "Maracás",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2920601",
+    "municipio": "Maragogipe",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2920700",
+    "municipio": "Maraú",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2920809",
+    "municipio": "Marcionílio Souza",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2920908",
+    "municipio": "Mascote",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2921005",
+    "municipio": "Mata de São João",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2921054",
+    "municipio": "Matina",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2921104",
+    "municipio": "Medeiros Neto",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2921203",
+    "municipio": "Miguel Calmon",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2921302",
+    "municipio": "Milagres",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2921401",
+    "municipio": "Mirangaba",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2921450",
+    "municipio": "Mirante",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2921500",
+    "municipio": "Monte Santo",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2921609",
+    "municipio": "Morpará",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2921708",
+    "municipio": "Morro do Chapéu",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2921807",
+    "municipio": "Mortugaba",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2921906",
+    "municipio": "Mucugê",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2922003",
+    "municipio": "Mucuri",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2922052",
+    "municipio": "Mulungu do Morro",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2922102",
+    "municipio": "Mundo Novo",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2922201",
+    "municipio": "Muniz Ferreira",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2922250",
+    "municipio": "Muquém do São Francisco",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2922300",
+    "municipio": "Muritiba",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2922409",
+    "municipio": "Mutuípe",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2922508",
+    "municipio": "Nazaré",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2922607",
+    "municipio": "Nilo Peçanha",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2922656",
+    "municipio": "Nordestina",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2922706",
+    "municipio": "Nova Canaã",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2922730",
+    "municipio": "Nova Fátima",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2922755",
+    "municipio": "Nova Ibiá",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2922805",
+    "municipio": "Nova Itarana",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2922854",
+    "municipio": "Nova Redenção",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2922904",
+    "municipio": "Nova Soure",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2923001",
+    "municipio": "Nova Viçosa",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2923035",
+    "municipio": "Novo Horizonte",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2923050",
+    "municipio": "Novo Triunfo",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2923100",
+    "municipio": "Olindina",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2923209",
+    "municipio": "Oliveira dos Brejinhos",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2923308",
+    "municipio": "Ouriçangas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2923357",
+    "municipio": "Ourolândia",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2923407",
+    "municipio": "Palmas de Monte Alto",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2923506",
+    "municipio": "Palmeiras",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2923605",
+    "municipio": "Paramirim",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2923704",
+    "municipio": "Paratinga",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2923803",
+    "municipio": "Paripiranga",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2923902",
+    "municipio": "Pau Brasil",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2924009",
+    "municipio": "Paulo Afonso",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2924058",
+    "municipio": "Pé de Serra",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2924108",
+    "municipio": "Pedrão",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2924207",
+    "municipio": "Pedro Alexandre",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2924306",
+    "municipio": "Piatã",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2924405",
+    "municipio": "Pilão Arcado",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2924504",
+    "municipio": "Pindaí",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2924603",
+    "municipio": "Pindobaçu",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2924652",
+    "municipio": "Pintadas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2924678",
+    "municipio": "Piraí do Norte",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2924702",
+    "municipio": "Piripá",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2924801",
+    "municipio": "Piritiba",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2924900",
+    "municipio": "Planaltino",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2925006",
+    "municipio": "Planalto",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2925105",
+    "municipio": "Poções",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2925204",
+    "municipio": "Pojuca",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2925253",
+    "municipio": "Ponto Novo",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2925303",
+    "municipio": "Porto Seguro",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2925402",
+    "municipio": "Potiraguá",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2925501",
+    "municipio": "Prado",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2925600",
+    "municipio": "Presidente Dutra",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2925709",
+    "municipio": "Presidente Jânio Quadros",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2925758",
+    "municipio": "Presidente Tancredo Neves",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2925808",
+    "municipio": "Queimadas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2925907",
+    "municipio": "Quijingue",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2925931",
+    "municipio": "Quixabeira",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2925956",
+    "municipio": "Rafael Jambeiro",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2926004",
+    "municipio": "Remanso",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2926103",
+    "municipio": "Retirolândia",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2926202",
+    "municipio": "Riachão das Neves",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2926301",
+    "municipio": "Riachão do Jacuípe",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2926400",
+    "municipio": "Riacho de Santana",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2926509",
+    "municipio": "Ribeira do Amparo",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2926608",
+    "municipio": "Ribeira do Pombal",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2926657",
+    "municipio": "Ribeirão do Largo",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2926707",
+    "municipio": "Rio de Contas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2926806",
+    "municipio": "Rio do Antônio",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2926905",
+    "municipio": "Rio do Pires",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2927002",
+    "municipio": "Rio Real",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2927101",
+    "municipio": "Rodelas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2927200",
+    "municipio": "Ruy Barbosa",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2927309",
+    "municipio": "Salinas da Margarida",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2927408",
+    "municipio": "Salvador",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2927507",
+    "municipio": "Santa Bárbara",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2927606",
+    "municipio": "Santa Brígida",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2927705",
+    "municipio": "Santa Cruz Cabrália",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2927804",
+    "municipio": "Santa Cruz da Vitória",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2927903",
+    "municipio": "Santa Inês",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2928000",
+    "municipio": "Santaluz",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2928059",
+    "municipio": "Santa Luzia",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2928109",
+    "municipio": "Santa Maria da Vitória",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2928208",
+    "municipio": "Santana",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2928307",
+    "municipio": "Santanópolis",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2928406",
+    "municipio": "Santa Rita de Cássia",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2928505",
+    "municipio": "Santa Terezinha",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2928604",
+    "municipio": "Santo Amaro",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2928703",
+    "municipio": "Santo Antônio de Jesus",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2928802",
+    "municipio": "Santo Estêvão",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2928901",
+    "municipio": "São Desidério",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2928950",
+    "municipio": "São Domingos",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2929008",
+    "municipio": "São Félix",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2929057",
+    "municipio": "São Félix do Coribe",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2929107",
+    "municipio": "São Felipe",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2929206",
+    "municipio": "São Francisco do Conde",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2929255",
+    "municipio": "São Gabriel",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2929305",
+    "municipio": "São Gonçalo dos Campos",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2929354",
+    "municipio": "São José da Vitória",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2929370",
+    "municipio": "São José do Jacuípe",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2929404",
+    "municipio": "São Miguel das Matas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2929503",
+    "municipio": "São Sebastião do Passé",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2929602",
+    "municipio": "Sapeaçu",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2929701",
+    "municipio": "Sátiro Dias",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2929750",
+    "municipio": "Saubara",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2929800",
+    "municipio": "Saúde",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2929909",
+    "municipio": "Seabra",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2930006",
+    "municipio": "Sebastião Laranjeiras",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2930105",
+    "municipio": "Senhor do Bonfim",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2930154",
+    "municipio": "Serra do Ramalho",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2930204",
+    "municipio": "Sento Sé",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2930303",
+    "municipio": "Serra Dourada",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2930402",
+    "municipio": "Serra Preta",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2930501",
+    "municipio": "Serrinha",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2930600",
+    "municipio": "Serrolândia",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2930709",
+    "municipio": "Simões Filho",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2930758",
+    "municipio": "Sítio do Mato",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2930766",
+    "municipio": "Sítio do Quinto",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2930774",
+    "municipio": "Sobradinho",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2930808",
+    "municipio": "Souto Soares",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2930907",
+    "municipio": "Tabocas do Brejo Velho",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2931004",
+    "municipio": "Tanhaçu",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2931053",
+    "municipio": "Tanque Novo",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2931103",
+    "municipio": "Tanquinho",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2931202",
+    "municipio": "Taperoá",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2931301",
+    "municipio": "Tapiramutá",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2931350",
+    "municipio": "Teixeira de Freitas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2931400",
+    "municipio": "Teodoro Sampaio",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2931509",
+    "municipio": "Teofilândia",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2931608",
+    "municipio": "Teolândia",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2931707",
+    "municipio": "Terra Nova",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2931806",
+    "municipio": "Tremedal",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2931905",
+    "municipio": "Tucano",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2932002",
+    "municipio": "Uauá",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2932101",
+    "municipio": "Ubaíra",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2932200",
+    "municipio": "Ubaitaba",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2932309",
+    "municipio": "Ubatã",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2932408",
+    "municipio": "Uibaí",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2932457",
+    "municipio": "Umburanas",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2932507",
+    "municipio": "Una",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2932606",
+    "municipio": "Urandi",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2932705",
+    "municipio": "Uruçuca",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2932804",
+    "municipio": "Utinga",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2932903",
+    "municipio": "Valença",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2933000",
+    "municipio": "Valente",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2933059",
+    "municipio": "Várzea da Roça",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2933109",
+    "municipio": "Várzea do Poço",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2933158",
+    "municipio": "Várzea Nova",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2933174",
+    "municipio": "Varzedo",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2933208",
+    "municipio": "Vera Cruz",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2933257",
+    "municipio": "Vereda",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2933307",
+    "municipio": "Vitória da Conquista",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2933406",
+    "municipio": "Wagner",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2933455",
+    "municipio": "Wanderley",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2933505",
+    "municipio": "Wenceslau Guimarães",
+    "uf": "BA"
+  },
+  {
+    "codigo": "2933604",
+    "municipio": "Xique-Xique",
+    "uf": "BA"
+  },
+  {
+    "codigo": "3100104",
+    "municipio": "Abadia dos Dourados",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3100203",
+    "municipio": "Abaeté",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3100302",
+    "municipio": "Abre Campo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3100401",
+    "municipio": "Acaiaca",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3100500",
+    "municipio": "Açucena",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3100609",
+    "municipio": "Água Boa",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3100708",
+    "municipio": "Água Comprida",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3100807",
+    "municipio": "Aguanil",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3100906",
+    "municipio": "Águas Formosas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3101003",
+    "municipio": "Águas Vermelhas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3101102",
+    "municipio": "Aimorés",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3101201",
+    "municipio": "Aiuruoca",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3101300",
+    "municipio": "Alagoa",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3101409",
+    "municipio": "Albertina",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3101508",
+    "municipio": "Além Paraíba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3101607",
+    "municipio": "Alfenas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3101631",
+    "municipio": "Alfredo Vasconcelos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3101706",
+    "municipio": "Almenara",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3101805",
+    "municipio": "Alpercata",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3101904",
+    "municipio": "Alpinópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3102001",
+    "municipio": "Alterosa",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3102050",
+    "municipio": "Alto Caparaó",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3102100",
+    "municipio": "Alto Rio Doce",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3102209",
+    "municipio": "Alvarenga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3102308",
+    "municipio": "Alvinópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3102407",
+    "municipio": "Alvorada de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3102506",
+    "municipio": "Amparo do Serra",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3102605",
+    "municipio": "Andradas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3102704",
+    "municipio": "Cachoeira de Pajeú",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3102803",
+    "municipio": "Andrelândia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3102852",
+    "municipio": "Angelândia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3102902",
+    "municipio": "Antônio Carlos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3103009",
+    "municipio": "Antônio Dias",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3103108",
+    "municipio": "Antônio Prado de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3103207",
+    "municipio": "Araçaí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3103306",
+    "municipio": "Aracitaba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3103405",
+    "municipio": "Araçuaí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3103504",
+    "municipio": "Araguari",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3103603",
+    "municipio": "Arantina",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3103702",
+    "municipio": "Araponga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3103751",
+    "municipio": "Araporã",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3103801",
+    "municipio": "Arapuá",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3103900",
+    "municipio": "Araújos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3104007",
+    "municipio": "Araxá",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3104106",
+    "municipio": "Arceburgo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3104205",
+    "municipio": "Arcos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3104304",
+    "municipio": "Areado",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3104403",
+    "municipio": "Argirita",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3104452",
+    "municipio": "Aricanduva",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3104502",
+    "municipio": "Arinos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3104601",
+    "municipio": "Astolfo Dutra",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3104700",
+    "municipio": "Ataléia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3104809",
+    "municipio": "Augusto de Lima",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3104908",
+    "municipio": "Baependi",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3105004",
+    "municipio": "Baldim",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3105103",
+    "municipio": "Bambuí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3105202",
+    "municipio": "Bandeira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3105301",
+    "municipio": "Bandeira do Sul",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3105400",
+    "municipio": "Barão de Cocais",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3105509",
+    "municipio": "Barão do Monte Alto",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3105608",
+    "municipio": "Barbacena",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3105707",
+    "municipio": "Barra Longa",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3105905",
+    "municipio": "Barroso",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3106002",
+    "municipio": "Bela Vista de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3106101",
+    "municipio": "Belmiro Braga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3106200",
+    "municipio": "Belo Horizonte",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3106309",
+    "municipio": "Belo Oriente",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3106408",
+    "municipio": "Belo Vale",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3106507",
+    "municipio": "Berilo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3106606",
+    "municipio": "Bertópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3106655",
+    "municipio": "Berizal",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3106705",
+    "municipio": "Betim",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3106804",
+    "municipio": "Bias Fortes",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3106903",
+    "municipio": "Bicas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3107000",
+    "municipio": "Biquinhas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3107109",
+    "municipio": "Boa Esperança",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3107208",
+    "municipio": "Bocaina de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3107307",
+    "municipio": "Bocaiúva",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3107406",
+    "municipio": "Bom Despacho",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3107505",
+    "municipio": "Bom Jardim de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3107604",
+    "municipio": "Bom Jesus da Penha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3107703",
+    "municipio": "Bom Jesus do Amparo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3107802",
+    "municipio": "Bom Jesus do Galho",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3107901",
+    "municipio": "Bom Repouso",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3108008",
+    "municipio": "Bom Sucesso",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3108107",
+    "municipio": "Bonfim",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3108206",
+    "municipio": "Bonfinópolis de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3108255",
+    "municipio": "Bonito de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3108305",
+    "municipio": "Borda da Mata",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3108404",
+    "municipio": "Botelhos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3108503",
+    "municipio": "Botumirim",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3108552",
+    "municipio": "Brasilândia de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3108602",
+    "municipio": "Brasília de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3108701",
+    "municipio": "Brás Pires",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3108800",
+    "municipio": "Braúnas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3108909",
+    "municipio": "Brazópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3109006",
+    "municipio": "Brumadinho",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3109105",
+    "municipio": "Bueno Brandão",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3109204",
+    "municipio": "Buenópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3109253",
+    "municipio": "Bugre",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3109303",
+    "municipio": "Buritis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3109402",
+    "municipio": "Buritizeiro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3109451",
+    "municipio": "Cabeceira Grande",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3109501",
+    "municipio": "Cabo Verde",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3109600",
+    "municipio": "Cachoeira da Prata",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3109709",
+    "municipio": "Cachoeira de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3109808",
+    "municipio": "Cachoeira Dourada",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3109907",
+    "municipio": "Caetanópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3110004",
+    "municipio": "Caeté",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3110103",
+    "municipio": "Caiana",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3110202",
+    "municipio": "Cajuri",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3110301",
+    "municipio": "Caldas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3110400",
+    "municipio": "Camacho",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3110509",
+    "municipio": "Camanducaia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3110608",
+    "municipio": "Cambuí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3110707",
+    "municipio": "Cambuquira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3110806",
+    "municipio": "Campanário",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3110905",
+    "municipio": "Campanha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3111002",
+    "municipio": "Campestre",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3111101",
+    "municipio": "Campina Verde",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3111150",
+    "municipio": "Campo Azul",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3111200",
+    "municipio": "Campo Belo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3111309",
+    "municipio": "Campo do Meio",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3111408",
+    "municipio": "Campo Florido",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3111507",
+    "municipio": "Campos Altos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3111606",
+    "municipio": "Campos Gerais",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3111705",
+    "municipio": "Canaã",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3111804",
+    "municipio": "Canápolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3111903",
+    "municipio": "Cana Verde",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3112000",
+    "municipio": "Candeias",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3112059",
+    "municipio": "Cantagalo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3112109",
+    "municipio": "Caparaó",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3112208",
+    "municipio": "Capela Nova",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3112307",
+    "municipio": "Capelinha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3112406",
+    "municipio": "Capetinga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3112505",
+    "municipio": "Capim Branco",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3112604",
+    "municipio": "Capinópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3112653",
+    "municipio": "Capitão Andrade",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3112703",
+    "municipio": "Capitão Enéas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3112802",
+    "municipio": "Capitólio",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3112901",
+    "municipio": "Caputira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3113008",
+    "municipio": "Caraí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3113107",
+    "municipio": "Caranaíba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3113206",
+    "municipio": "Carandaí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3113305",
+    "municipio": "Carangola",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3113404",
+    "municipio": "Caratinga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3113503",
+    "municipio": "Carbonita",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3113602",
+    "municipio": "Careaçu",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3113701",
+    "municipio": "Carlos Chagas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3113800",
+    "municipio": "Carmésia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3113909",
+    "municipio": "Carmo da Cachoeira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3114006",
+    "municipio": "Carmo da Mata",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3114105",
+    "municipio": "Carmo de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3114204",
+    "municipio": "Carmo do Cajuru",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3114303",
+    "municipio": "Carmo do Paranaíba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3114402",
+    "municipio": "Carmo do Rio Claro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3114501",
+    "municipio": "Carmópolis de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3114550",
+    "municipio": "Carneirinho",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3114600",
+    "municipio": "Carrancas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3114709",
+    "municipio": "Carvalhópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3114808",
+    "municipio": "Carvalhos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3114907",
+    "municipio": "Casa Grande",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3115003",
+    "municipio": "Cascalho Rico",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3115102",
+    "municipio": "Cássia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3115201",
+    "municipio": "Conceição da Barra de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3115300",
+    "municipio": "Cataguases",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3115359",
+    "municipio": "Catas Altas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3115409",
+    "municipio": "Catas Altas da Noruega",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3115458",
+    "municipio": "Catuji",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3115474",
+    "municipio": "Catuti",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3115508",
+    "municipio": "Caxambu",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3115607",
+    "municipio": "Cedro do Abaeté",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3115706",
+    "municipio": "Central de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3115805",
+    "municipio": "Centralina",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3115904",
+    "municipio": "Chácara",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3116001",
+    "municipio": "Chalé",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3116100",
+    "municipio": "Chapada do Norte",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3116159",
+    "municipio": "Chapada Gaúcha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3116209",
+    "municipio": "Chiador",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3116308",
+    "municipio": "Cipotânea",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3116407",
+    "municipio": "Claraval",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3116506",
+    "municipio": "Claro dos Poções",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3116605",
+    "municipio": "Cláudio",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3116704",
+    "municipio": "Coimbra",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3116803",
+    "municipio": "Coluna",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3116902",
+    "municipio": "Comendador Gomes",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3117009",
+    "municipio": "Comercinho",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3117108",
+    "municipio": "Conceição da Aparecida",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3117207",
+    "municipio": "Conceição das Pedras",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3117306",
+    "municipio": "Conceição das Alagoas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3117405",
+    "municipio": "Conceição de Ipanema",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3117504",
+    "municipio": "Conceição do Mato Dentro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3117603",
+    "municipio": "Conceição do Pará",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3117702",
+    "municipio": "Conceição do Rio Verde",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3117801",
+    "municipio": "Conceição dos Ouros",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3117836",
+    "municipio": "Cônego Marinho",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3117876",
+    "municipio": "Confins",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3117900",
+    "municipio": "Congonhal",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3118007",
+    "municipio": "Congonhas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3118106",
+    "municipio": "Congonhas do Norte",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3118205",
+    "municipio": "Conquista",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3118304",
+    "municipio": "Conselheiro Lafaiete",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3118403",
+    "municipio": "Conselheiro Pena",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3118502",
+    "municipio": "Consolação",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3118601",
+    "municipio": "Contagem",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3118700",
+    "municipio": "Coqueiral",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3118809",
+    "municipio": "Coração de Jesus",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3118908",
+    "municipio": "Cordisburgo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3119005",
+    "municipio": "Cordislândia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3119104",
+    "municipio": "Corinto",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3119203",
+    "municipio": "Coroaci",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3119302",
+    "municipio": "Coromandel",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3119401",
+    "municipio": "Coronel Fabriciano",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3119500",
+    "municipio": "Coronel Murta",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3119609",
+    "municipio": "Coronel Pacheco",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3119708",
+    "municipio": "Coronel Xavier Chaves",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3119807",
+    "municipio": "Córrego Danta",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3119906",
+    "municipio": "Córrego do Bom Jesus",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3119955",
+    "municipio": "Córrego Fundo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3120003",
+    "municipio": "Córrego Novo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3120102",
+    "municipio": "Couto de Magalhães de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3120151",
+    "municipio": "Crisólita",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3120201",
+    "municipio": "Cristais",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3120300",
+    "municipio": "Cristália",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3120409",
+    "municipio": "Cristiano Otoni",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3120508",
+    "municipio": "Cristina",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3120607",
+    "municipio": "Crucilândia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3120706",
+    "municipio": "Cruzeiro da Fortaleza",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3120805",
+    "municipio": "Cruzília",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3120839",
+    "municipio": "Cuparaque",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3120870",
+    "municipio": "Curral de Dentro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3120904",
+    "municipio": "Curvelo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3121001",
+    "municipio": "Datas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3121100",
+    "municipio": "Delfim Moreira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3121209",
+    "municipio": "Delfinópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3121258",
+    "municipio": "Delta",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3121308",
+    "municipio": "Descoberto",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3121407",
+    "municipio": "Desterro de Entre Rios",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3121506",
+    "municipio": "Desterro do Melo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3121605",
+    "municipio": "Diamantina",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3121704",
+    "municipio": "Diogo de Vasconcelos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3121803",
+    "municipio": "Dionísio",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3121902",
+    "municipio": "Divinésia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3122009",
+    "municipio": "Divino",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3122108",
+    "municipio": "Divino das Laranjeiras",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3122207",
+    "municipio": "Divinolândia de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3122306",
+    "municipio": "Divinópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3122355",
+    "municipio": "Divisa Alegre",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3122405",
+    "municipio": "Divisa Nova",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3122454",
+    "municipio": "Divisópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3122470",
+    "municipio": "Dom Bosco",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3122504",
+    "municipio": "Dom Cavati",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3122603",
+    "municipio": "Dom Joaquim",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3122702",
+    "municipio": "Dom Silvério",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3122801",
+    "municipio": "Dom Viçoso",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3122900",
+    "municipio": "Dona Euzébia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3123007",
+    "municipio": "Dores de Campos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3123106",
+    "municipio": "Dores de Guanhães",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3123205",
+    "municipio": "Dores do Indaiá",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3123304",
+    "municipio": "Dores do Turvo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3123403",
+    "municipio": "Doresópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3123502",
+    "municipio": "Douradoquara",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3123528",
+    "municipio": "Durandé",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3123601",
+    "municipio": "Elói Mendes",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3123700",
+    "municipio": "Engenheiro Caldas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3123809",
+    "municipio": "Engenheiro Navarro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3123858",
+    "municipio": "Entre Folhas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3123908",
+    "municipio": "Entre Rios de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3124005",
+    "municipio": "Ervália",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3124104",
+    "municipio": "Esmeraldas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3124203",
+    "municipio": "Espera Feliz",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3124302",
+    "municipio": "Espinosa",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3124401",
+    "municipio": "Espírito Santo do Dourado",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3124500",
+    "municipio": "Estiva",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3124609",
+    "municipio": "Estrela Dalva",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3124708",
+    "municipio": "Estrela do Indaiá",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3124807",
+    "municipio": "Estrela do Sul",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3124906",
+    "municipio": "Eugenópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3125002",
+    "municipio": "Ewbank da Câmara",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3125101",
+    "municipio": "Extrema",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3125200",
+    "municipio": "Fama",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3125309",
+    "municipio": "Faria Lemos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3125408",
+    "municipio": "Felício dos Santos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3125507",
+    "municipio": "São Gonçalo do Rio Preto",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3125606",
+    "municipio": "Felisburgo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3125705",
+    "municipio": "Felixlândia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3125804",
+    "municipio": "Fernandes Tourinho",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3125903",
+    "municipio": "Ferros",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3125952",
+    "municipio": "Fervedouro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3126000",
+    "municipio": "Florestal",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3126109",
+    "municipio": "Formiga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3126208",
+    "municipio": "Formoso",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3126307",
+    "municipio": "Fortaleza de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3126406",
+    "municipio": "Fortuna de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3126505",
+    "municipio": "Francisco Badaró",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3126604",
+    "municipio": "Francisco Dumont",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3126703",
+    "municipio": "Francisco Sá",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3126752",
+    "municipio": "Franciscópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3126802",
+    "municipio": "Frei Gaspar",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3126901",
+    "municipio": "Frei Inocêncio",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3126950",
+    "municipio": "Frei Lagonegro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3127008",
+    "municipio": "Fronteira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3127057",
+    "municipio": "Fronteira dos Vales",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3127073",
+    "municipio": "Fruta de Leite",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3127107",
+    "municipio": "Frutal",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3127206",
+    "municipio": "Funilândia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3127305",
+    "municipio": "Galiléia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3127339",
+    "municipio": "Gameleiras",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3127354",
+    "municipio": "Glaucilândia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3127370",
+    "municipio": "Goiabeira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3127388",
+    "municipio": "Goianá",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3127404",
+    "municipio": "Gonçalves",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3127503",
+    "municipio": "Gonzaga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3127602",
+    "municipio": "Gouveia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3127701",
+    "municipio": "Governador Valadares",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3127800",
+    "municipio": "Grão Mogol",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3127909",
+    "municipio": "Grupiara",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3128006",
+    "municipio": "Guanhães",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3128105",
+    "municipio": "Guapé",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3128204",
+    "municipio": "Guaraciaba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3128253",
+    "municipio": "Guaraciama",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3128303",
+    "municipio": "Guaranésia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3128402",
+    "municipio": "Guarani",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3128501",
+    "municipio": "Guarará",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3128600",
+    "municipio": "Guarda-Mor",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3128709",
+    "municipio": "Guaxupé",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3128808",
+    "municipio": "Guidoval",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3128907",
+    "municipio": "Guimarânia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3129004",
+    "municipio": "Guiricema",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3129103",
+    "municipio": "Gurinhatã",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3129202",
+    "municipio": "Heliodora",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3129301",
+    "municipio": "Iapu",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3129400",
+    "municipio": "Ibertioga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3129509",
+    "municipio": "Ibiá",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3129608",
+    "municipio": "Ibiaí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3129657",
+    "municipio": "Ibiracatu",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3129707",
+    "municipio": "Ibiraci",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3129806",
+    "municipio": "Ibirité",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3129905",
+    "municipio": "Ibitiúra de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3130002",
+    "municipio": "Ibituruna",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3130051",
+    "municipio": "Icaraí de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3130101",
+    "municipio": "Igarapé",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3130200",
+    "municipio": "Igaratinga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3130309",
+    "municipio": "Iguatama",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3130408",
+    "municipio": "Ijaci",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3130507",
+    "municipio": "Ilicínea",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3130556",
+    "municipio": "Imbé de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3130606",
+    "municipio": "Inconfidentes",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3130655",
+    "municipio": "Indaiabira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3130705",
+    "municipio": "Indianópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3130804",
+    "municipio": "Ingaí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3130903",
+    "municipio": "Inhapim",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3131000",
+    "municipio": "Inhaúma",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3131109",
+    "municipio": "Inimutaba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3131158",
+    "municipio": "Ipaba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3131208",
+    "municipio": "Ipanema",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3131307",
+    "municipio": "Ipatinga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3131406",
+    "municipio": "Ipiaçu",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3131505",
+    "municipio": "Ipuiúna",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3131604",
+    "municipio": "Iraí de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3131703",
+    "municipio": "Itabira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3131802",
+    "municipio": "Itabirinha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3131901",
+    "municipio": "Itabirito",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3132008",
+    "municipio": "Itacambira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3132107",
+    "municipio": "Itacarambi",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3132206",
+    "municipio": "Itaguara",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3132305",
+    "municipio": "Itaipé",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3132404",
+    "municipio": "Itajubá",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3132503",
+    "municipio": "Itamarandiba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3132602",
+    "municipio": "Itamarati de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3132701",
+    "municipio": "Itambacuri",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3132800",
+    "municipio": "Itambé do Mato Dentro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3132909",
+    "municipio": "Itamogi",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3133006",
+    "municipio": "Itamonte",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3133105",
+    "municipio": "Itanhandu",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3133204",
+    "municipio": "Itanhomi",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3133303",
+    "municipio": "Itaobim",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3133402",
+    "municipio": "Itapagipe",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3133501",
+    "municipio": "Itapecerica",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3133600",
+    "municipio": "Itapeva",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3133709",
+    "municipio": "Itatiaiuçu",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3133758",
+    "municipio": "Itaú de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3133808",
+    "municipio": "Itaúna",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3133907",
+    "municipio": "Itaverava",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3134004",
+    "municipio": "Itinga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3134103",
+    "municipio": "Itueta",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3134202",
+    "municipio": "Ituiutaba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3134301",
+    "municipio": "Itumirim",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3134400",
+    "municipio": "Iturama",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3134509",
+    "municipio": "Itutinga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3134608",
+    "municipio": "Jaboticatubas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3134707",
+    "municipio": "Jacinto",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3134806",
+    "municipio": "Jacuí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3134905",
+    "municipio": "Jacutinga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3135001",
+    "municipio": "Jaguaraçu",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3135050",
+    "municipio": "Jaíba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3135076",
+    "municipio": "Jampruca",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3135100",
+    "municipio": "Janaúba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3135209",
+    "municipio": "Januária",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3135308",
+    "municipio": "Japaraíba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3135357",
+    "municipio": "Japonvar",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3135407",
+    "municipio": "Jeceaba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3135456",
+    "municipio": "Jenipapo de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3135506",
+    "municipio": "Jequeri",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3135605",
+    "municipio": "Jequitaí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3135704",
+    "municipio": "Jequitibá",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3135803",
+    "municipio": "Jequitinhonha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3135902",
+    "municipio": "Jesuânia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3136009",
+    "municipio": "Joaíma",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3136108",
+    "municipio": "Joanésia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3136207",
+    "municipio": "João Monlevade",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3136306",
+    "municipio": "João Pinheiro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3136405",
+    "municipio": "Joaquim Felício",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3136504",
+    "municipio": "Jordânia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3136520",
+    "municipio": "José Gonçalves de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3136553",
+    "municipio": "José Raydan",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3136579",
+    "municipio": "Josenópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3136603",
+    "municipio": "Nova União",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3136652",
+    "municipio": "Juatuba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3136702",
+    "municipio": "Juiz de Fora",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3136801",
+    "municipio": "Juramento",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3136900",
+    "municipio": "Juruaia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3136959",
+    "municipio": "Juvenília",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3137007",
+    "municipio": "Ladainha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3137106",
+    "municipio": "Lagamar",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3137205",
+    "municipio": "Lagoa da Prata",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3137304",
+    "municipio": "Lagoa dos Patos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3137403",
+    "municipio": "Lagoa Dourada",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3137502",
+    "municipio": "Lagoa Formosa",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3137536",
+    "municipio": "Lagoa Grande",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3137601",
+    "municipio": "Lagoa Santa",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3137700",
+    "municipio": "Lajinha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3137809",
+    "municipio": "Lambari",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3137908",
+    "municipio": "Lamim",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3138005",
+    "municipio": "Laranjal",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3138104",
+    "municipio": "Lassance",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3138203",
+    "municipio": "Lavras",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3138302",
+    "municipio": "Leandro Ferreira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3138351",
+    "municipio": "Leme do Prado",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3138401",
+    "municipio": "Leopoldina",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3138500",
+    "municipio": "Liberdade",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3138609",
+    "municipio": "Lima Duarte",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3138625",
+    "municipio": "Limeira do Oeste",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3138658",
+    "municipio": "Lontra",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3138674",
+    "municipio": "Luisburgo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3138682",
+    "municipio": "Luislândia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3138708",
+    "municipio": "Luminárias",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3138807",
+    "municipio": "Luz",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3138906",
+    "municipio": "Machacalis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3139003",
+    "municipio": "Machado",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3139102",
+    "municipio": "Madre de Deus de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3139201",
+    "municipio": "Malacacheta",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3139250",
+    "municipio": "Mamonas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3139300",
+    "municipio": "Manga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3139409",
+    "municipio": "Manhuaçu",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3139508",
+    "municipio": "Manhumirim",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3139607",
+    "municipio": "Mantena",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3139706",
+    "municipio": "Maravilhas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3139805",
+    "municipio": "Mar de Espanha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3139904",
+    "municipio": "Maria da Fé",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3140001",
+    "municipio": "Mariana",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3140100",
+    "municipio": "Marilac",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3140159",
+    "municipio": "Mário Campos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3140209",
+    "municipio": "Maripá de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3140308",
+    "municipio": "Marliéria",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3140407",
+    "municipio": "Marmelópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3140506",
+    "municipio": "Martinho Campos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3140530",
+    "municipio": "Martins Soares",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3140555",
+    "municipio": "Mata Verde",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3140605",
+    "municipio": "Materlândia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3140704",
+    "municipio": "Mateus Leme",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3140803",
+    "municipio": "Matias Barbosa",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3140852",
+    "municipio": "Matias Cardoso",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3140902",
+    "municipio": "Matipó",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3141009",
+    "municipio": "Mato Verde",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3141108",
+    "municipio": "Matozinhos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3141207",
+    "municipio": "Matutina",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3141306",
+    "municipio": "Medeiros",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3141405",
+    "municipio": "Medina",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3141504",
+    "municipio": "Mendes Pimentel",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3141603",
+    "municipio": "Mercês",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3141702",
+    "municipio": "Mesquita",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3141801",
+    "municipio": "Minas Novas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3141900",
+    "municipio": "Minduri",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3142007",
+    "municipio": "Mirabela",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3142106",
+    "municipio": "Miradouro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3142205",
+    "municipio": "Miraí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3142254",
+    "municipio": "Miravânia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3142304",
+    "municipio": "Moeda",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3142403",
+    "municipio": "Moema",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3142502",
+    "municipio": "Monjolos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3142601",
+    "municipio": "Monsenhor Paulo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3142700",
+    "municipio": "Montalvânia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3142809",
+    "municipio": "Monte Alegre de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3142908",
+    "municipio": "Monte Azul",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3143005",
+    "municipio": "Monte Belo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3143104",
+    "municipio": "Monte Carmelo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3143153",
+    "municipio": "Monte Formoso",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3143203",
+    "municipio": "Monte Santo de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3143302",
+    "municipio": "Montes Claros",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3143401",
+    "municipio": "Monte Sião",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3143450",
+    "municipio": "Montezuma",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3143500",
+    "municipio": "Morada Nova de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3143609",
+    "municipio": "Morro da Garça",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3143708",
+    "municipio": "Morro do Pilar",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3143807",
+    "municipio": "Munhoz",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3143906",
+    "municipio": "Muriaé",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3144003",
+    "municipio": "Mutum",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3144102",
+    "municipio": "Muzambinho",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3144201",
+    "municipio": "Nacip Raydan",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3144300",
+    "municipio": "Nanuque",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3144359",
+    "municipio": "Naque",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3144375",
+    "municipio": "Natalândia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3144409",
+    "municipio": "Natércia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3144508",
+    "municipio": "Nazareno",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3144607",
+    "municipio": "Nepomuceno",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3144656",
+    "municipio": "Ninheira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3144672",
+    "municipio": "Nova Belém",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3144706",
+    "municipio": "Nova Era",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3144805",
+    "municipio": "Nova Lima",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3144904",
+    "municipio": "Nova Módica",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3145000",
+    "municipio": "Nova Ponte",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3145059",
+    "municipio": "Nova Porteirinha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3145109",
+    "municipio": "Nova Resende",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3145208",
+    "municipio": "Nova Serrana",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3145307",
+    "municipio": "Novo Cruzeiro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3145356",
+    "municipio": "Novo Oriente de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3145372",
+    "municipio": "Novorizonte",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3145406",
+    "municipio": "Olaria",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3145455",
+    "municipio": "Olhos-d'Água",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3145505",
+    "municipio": "Olímpio Noronha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3145604",
+    "municipio": "Oliveira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3145703",
+    "municipio": "Oliveira Fortes",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3145802",
+    "municipio": "Onça de Pitangui",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3145851",
+    "municipio": "Oratórios",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3145877",
+    "municipio": "Orizânia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3145901",
+    "municipio": "Ouro Branco",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3146008",
+    "municipio": "Ouro Fino",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3146107",
+    "municipio": "Ouro Preto",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3146206",
+    "municipio": "Ouro Verde de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3146255",
+    "municipio": "Padre Carvalho",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3146305",
+    "municipio": "Padre Paraíso",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3146404",
+    "municipio": "Paineiras",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3146503",
+    "municipio": "Pains",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3146552",
+    "municipio": "Pai Pedro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3146602",
+    "municipio": "Paiva",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3146701",
+    "municipio": "Palma",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3146750",
+    "municipio": "Palmópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3146909",
+    "municipio": "Papagaios",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3147006",
+    "municipio": "Paracatu",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3147105",
+    "municipio": "Pará de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3147204",
+    "municipio": "Paraguaçu",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3147303",
+    "municipio": "Paraisópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3147402",
+    "municipio": "Paraopeba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3147501",
+    "municipio": "Passabém",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3147600",
+    "municipio": "Passa Quatro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3147709",
+    "municipio": "Passa Tempo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3147808",
+    "municipio": "Passa Vinte",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3147907",
+    "municipio": "Passos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3147956",
+    "municipio": "Patis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3148004",
+    "municipio": "Patos de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3148103",
+    "municipio": "Patrocínio",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3148202",
+    "municipio": "Patrocínio do Muriaé",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3148301",
+    "municipio": "Paula Cândido",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3148400",
+    "municipio": "Paulistas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3148509",
+    "municipio": "Pavão",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3148608",
+    "municipio": "Peçanha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3148707",
+    "municipio": "Pedra Azul",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3148756",
+    "municipio": "Pedra Bonita",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3148806",
+    "municipio": "Pedra do Anta",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3148905",
+    "municipio": "Pedra do Indaiá",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3149002",
+    "municipio": "Pedra Dourada",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3149101",
+    "municipio": "Pedralva",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3149150",
+    "municipio": "Pedras de Maria da Cruz",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3149200",
+    "municipio": "Pedrinópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3149309",
+    "municipio": "Pedro Leopoldo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3149408",
+    "municipio": "Pedro Teixeira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3149507",
+    "municipio": "Pequeri",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3149606",
+    "municipio": "Pequi",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3149705",
+    "municipio": "Perdigão",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3149804",
+    "municipio": "Perdizes",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3149903",
+    "municipio": "Perdões",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3149952",
+    "municipio": "Periquito",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3150000",
+    "municipio": "Pescador",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3150109",
+    "municipio": "Piau",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3150158",
+    "municipio": "Piedade de Caratinga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3150208",
+    "municipio": "Piedade de Ponte Nova",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3150307",
+    "municipio": "Piedade do Rio Grande",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3150406",
+    "municipio": "Piedade dos Gerais",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3150505",
+    "municipio": "Pimenta",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3150539",
+    "municipio": "Pingo-d'Água",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3150570",
+    "municipio": "Pintópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3150604",
+    "municipio": "Piracema",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3150703",
+    "municipio": "Pirajuba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3150802",
+    "municipio": "Piranga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3150901",
+    "municipio": "Piranguçu",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3151008",
+    "municipio": "Piranguinho",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3151107",
+    "municipio": "Pirapetinga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3151206",
+    "municipio": "Pirapora",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3151305",
+    "municipio": "Piraúba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3151404",
+    "municipio": "Pitangui",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3151503",
+    "municipio": "Piumhi",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3151602",
+    "municipio": "Planura",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3151701",
+    "municipio": "Poço Fundo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3151800",
+    "municipio": "Poços de Caldas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3151909",
+    "municipio": "Pocrane",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3152006",
+    "municipio": "Pompéu",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3152105",
+    "municipio": "Ponte Nova",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3152131",
+    "municipio": "Ponto Chique",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3152170",
+    "municipio": "Ponto dos Volantes",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3152204",
+    "municipio": "Porteirinha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3152303",
+    "municipio": "Porto Firme",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3152402",
+    "municipio": "Poté",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3152501",
+    "municipio": "Pouso Alegre",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3152600",
+    "municipio": "Pouso Alto",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3152709",
+    "municipio": "Prados",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3152808",
+    "municipio": "Prata",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3152907",
+    "municipio": "Pratápolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3153004",
+    "municipio": "Pratinha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3153103",
+    "municipio": "Presidente Bernardes",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3153202",
+    "municipio": "Presidente Juscelino",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3153301",
+    "municipio": "Presidente Kubitschek",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3153400",
+    "municipio": "Presidente Olegário",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3153509",
+    "municipio": "Alto Jequitibá",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3153608",
+    "municipio": "Prudente de Morais",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3153707",
+    "municipio": "Quartel Geral",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3153806",
+    "municipio": "Queluzito",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3153905",
+    "municipio": "Raposos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3154002",
+    "municipio": "Raul Soares",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3154101",
+    "municipio": "Recreio",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3154150",
+    "municipio": "Reduto",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3154200",
+    "municipio": "Resende Costa",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3154309",
+    "municipio": "Resplendor",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3154408",
+    "municipio": "Ressaquinha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3154457",
+    "municipio": "Riachinho",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3154507",
+    "municipio": "Riacho dos Machados",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3154606",
+    "municipio": "Ribeirão das Neves",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3154705",
+    "municipio": "Ribeirão Vermelho",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3154804",
+    "municipio": "Rio Acima",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3154903",
+    "municipio": "Rio Casca",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3155009",
+    "municipio": "Rio Doce",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3155108",
+    "municipio": "Rio do Prado",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3155207",
+    "municipio": "Rio Espera",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3155306",
+    "municipio": "Rio Manso",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3155405",
+    "municipio": "Rio Novo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3155504",
+    "municipio": "Rio Paranaíba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3155603",
+    "municipio": "Rio Pardo de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3155702",
+    "municipio": "Rio Piracicaba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3155801",
+    "municipio": "Rio Pomba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3155900",
+    "municipio": "Rio Preto",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3156007",
+    "municipio": "Rio Vermelho",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3156106",
+    "municipio": "Ritápolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3156205",
+    "municipio": "Rochedo de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3156304",
+    "municipio": "Rodeiro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3156403",
+    "municipio": "Romaria",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3156452",
+    "municipio": "Rosário da Limeira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3156502",
+    "municipio": "Rubelita",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3156601",
+    "municipio": "Rubim",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3156700",
+    "municipio": "Sabará",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3156809",
+    "municipio": "Sabinópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3156908",
+    "municipio": "Sacramento",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3157005",
+    "municipio": "Salinas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3157104",
+    "municipio": "Salto da Divisa",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3157203",
+    "municipio": "Santa Bárbara",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3157252",
+    "municipio": "Santa Bárbara do Leste",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3157278",
+    "municipio": "Santa Bárbara do Monte Verde",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3157302",
+    "municipio": "Santa Bárbara do Tugúrio",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3157336",
+    "municipio": "Santa Cruz de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3157377",
+    "municipio": "Santa Cruz de Salinas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3157401",
+    "municipio": "Santa Cruz do Escalvado",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3157500",
+    "municipio": "Santa Efigênia de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3157609",
+    "municipio": "Santa Fé de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3157658",
+    "municipio": "Santa Helena de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3157708",
+    "municipio": "Santa Juliana",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3157807",
+    "municipio": "Santa Luzia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3157906",
+    "municipio": "Santa Margarida",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3158003",
+    "municipio": "Santa Maria de Itabira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3158102",
+    "municipio": "Santa Maria do Salto",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3158201",
+    "municipio": "Santa Maria do Suaçuí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3158300",
+    "municipio": "Santana da Vargem",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3158409",
+    "municipio": "Santana de Cataguases",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3158508",
+    "municipio": "Santana de Pirapama",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3158607",
+    "municipio": "Santana do Deserto",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3158706",
+    "municipio": "Santana do Garambéu",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3158805",
+    "municipio": "Santana do Jacaré",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3158904",
+    "municipio": "Santana do Manhuaçu",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3158953",
+    "municipio": "Santana do Paraíso",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3159001",
+    "municipio": "Santana do Riacho",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3159100",
+    "municipio": "Santana dos Montes",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3159209",
+    "municipio": "Santa Rita de Caldas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3159308",
+    "municipio": "Santa Rita de Jacutinga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3159357",
+    "municipio": "Santa Rita de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3159407",
+    "municipio": "Santa Rita de Ibitipoca",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3159506",
+    "municipio": "Santa Rita do Itueto",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3159605",
+    "municipio": "Santa Rita do Sapucaí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3159704",
+    "municipio": "Santa Rosa da Serra",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3159803",
+    "municipio": "Santa Vitória",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3159902",
+    "municipio": "Santo Antônio do Amparo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3160009",
+    "municipio": "Santo Antônio do Aventureiro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3160108",
+    "municipio": "Santo Antônio do Grama",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3160207",
+    "municipio": "Santo Antônio do Itambé",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3160306",
+    "municipio": "Santo Antônio do Jacinto",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3160405",
+    "municipio": "Santo Antônio do Monte",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3160454",
+    "municipio": "Santo Antônio do Retiro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3160504",
+    "municipio": "Santo Antônio do Rio Abaixo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3160603",
+    "municipio": "Santo Hipólito",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3160702",
+    "municipio": "Santos Dumont",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3160801",
+    "municipio": "São Bento Abade",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3160900",
+    "municipio": "São Brás do Suaçuí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3160959",
+    "municipio": "São Domingos das Dores",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3161007",
+    "municipio": "São Domingos do Prata",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3161056",
+    "municipio": "São Félix de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3161106",
+    "municipio": "São Francisco",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3161205",
+    "municipio": "São Francisco de Paula",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3161304",
+    "municipio": "São Francisco de Sales",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3161403",
+    "municipio": "São Francisco do Glória",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3161502",
+    "municipio": "São Geraldo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3161601",
+    "municipio": "São Geraldo da Piedade",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3161650",
+    "municipio": "São Geraldo do Baixio",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3161700",
+    "municipio": "São Gonçalo do Abaeté",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3161809",
+    "municipio": "São Gonçalo do Pará",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3161908",
+    "municipio": "São Gonçalo do Rio Abaixo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162005",
+    "municipio": "São Gonçalo do Sapucaí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162104",
+    "municipio": "São Gotardo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162203",
+    "municipio": "São João Batista do Glória",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162252",
+    "municipio": "São João da Lagoa",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162302",
+    "municipio": "São João da Mata",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162401",
+    "municipio": "São João da Ponte",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162450",
+    "municipio": "São João das Missões",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162500",
+    "municipio": "São João del Rei",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162559",
+    "municipio": "São João do Manhuaçu",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162575",
+    "municipio": "São João do Manteninha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162609",
+    "municipio": "São João do Oriente",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162658",
+    "municipio": "São João do Pacuí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162708",
+    "municipio": "São João do Paraíso",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162807",
+    "municipio": "São João Evangelista",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162906",
+    "municipio": "São João Nepomuceno",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162922",
+    "municipio": "São Joaquim de Bicas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162948",
+    "municipio": "São José da Barra",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3162955",
+    "municipio": "São José da Lapa",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3163003",
+    "municipio": "São José da Safira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3163102",
+    "municipio": "São José da Varginha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3163201",
+    "municipio": "São José do Alegre",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3163300",
+    "municipio": "São José do Divino",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3163409",
+    "municipio": "São José do Goiabal",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3163508",
+    "municipio": "São José do Jacuri",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3163607",
+    "municipio": "São José do Mantimento",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3163706",
+    "municipio": "São Lourenço",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3163805",
+    "municipio": "São Miguel do Anta",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3163904",
+    "municipio": "São Pedro da União",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3164001",
+    "municipio": "São Pedro dos Ferros",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3164100",
+    "municipio": "São Pedro do Suaçuí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3164209",
+    "municipio": "São Romão",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3164308",
+    "municipio": "São Roque de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3164407",
+    "municipio": "São Sebastião da Bela Vista",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3164431",
+    "municipio": "São Sebastião da Vargem Alegre",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3164472",
+    "municipio": "São Sebastião do Anta",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3164506",
+    "municipio": "São Sebastião do Maranhão",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3164605",
+    "municipio": "São Sebastião do Oeste",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3164704",
+    "municipio": "São Sebastião do Paraíso",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3164803",
+    "municipio": "São Sebastião do Rio Preto",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3164902",
+    "municipio": "São Sebastião do Rio Verde",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3165008",
+    "municipio": "São Tiago",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3165107",
+    "municipio": "São Tomás de Aquino",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3165206",
+    "municipio": "São Tomé das Letras",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3165305",
+    "municipio": "São Vicente de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3165404",
+    "municipio": "Sapucaí-Mirim",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3165503",
+    "municipio": "Sardoá",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3165537",
+    "municipio": "Sarzedo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3165552",
+    "municipio": "Setubinha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3165560",
+    "municipio": "Sem-Peixe",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3165578",
+    "municipio": "Senador Amaral",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3165602",
+    "municipio": "Senador Cortes",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3165701",
+    "municipio": "Senador Firmino",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3165800",
+    "municipio": "Senador José Bento",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3165909",
+    "municipio": "Senador Modestino Gonçalves",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3166006",
+    "municipio": "Senhora de Oliveira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3166105",
+    "municipio": "Senhora do Porto",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3166204",
+    "municipio": "Senhora dos Remédios",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3166303",
+    "municipio": "Sericita",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3166402",
+    "municipio": "Seritinga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3166501",
+    "municipio": "Serra Azul de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3166600",
+    "municipio": "Serra da Saudade",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3166709",
+    "municipio": "Serra dos Aimorés",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3166808",
+    "municipio": "Serra do Salitre",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3166907",
+    "municipio": "Serrania",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3166956",
+    "municipio": "Serranópolis de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3167004",
+    "municipio": "Serranos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3167103",
+    "municipio": "Serro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3167202",
+    "municipio": "Sete Lagoas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3167301",
+    "municipio": "Silveirânia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3167400",
+    "municipio": "Silvianópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3167509",
+    "municipio": "Simão Pereira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3167608",
+    "municipio": "Simonésia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3167707",
+    "municipio": "Sobrália",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3167806",
+    "municipio": "Soledade de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3167905",
+    "municipio": "Tabuleiro",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3168002",
+    "municipio": "Taiobeiras",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3168051",
+    "municipio": "Taparuba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3168101",
+    "municipio": "Tapira",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3168200",
+    "municipio": "Tapiraí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3168309",
+    "municipio": "Taquaraçu de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3168408",
+    "municipio": "Tarumirim",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3168507",
+    "municipio": "Teixeiras",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3168606",
+    "municipio": "Teófilo Otoni",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3168705",
+    "municipio": "Timóteo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3168804",
+    "municipio": "Tiradentes",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3168903",
+    "municipio": "Tiros",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3169000",
+    "municipio": "Tocantins",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3169059",
+    "municipio": "Tocos do Moji",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3169109",
+    "municipio": "Toledo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3169208",
+    "municipio": "Tombos",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3169307",
+    "municipio": "Três Corações",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3169356",
+    "municipio": "Três Marias",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3169406",
+    "municipio": "Três Pontas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3169505",
+    "municipio": "Tumiritinga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3169604",
+    "municipio": "Tupaciguara",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3169703",
+    "municipio": "Turmalina",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3169802",
+    "municipio": "Turvolândia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3169901",
+    "municipio": "Ubá",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3170008",
+    "municipio": "Ubaí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3170057",
+    "municipio": "Ubaporanga",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3170107",
+    "municipio": "Uberaba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3170206",
+    "municipio": "Uberlândia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3170305",
+    "municipio": "Umburatiba",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3170404",
+    "municipio": "Unaí",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3170438",
+    "municipio": "União de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3170479",
+    "municipio": "Uruana de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3170503",
+    "municipio": "Urucânia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3170529",
+    "municipio": "Urucuia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3170578",
+    "municipio": "Vargem Alegre",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3170602",
+    "municipio": "Vargem Bonita",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3170651",
+    "municipio": "Vargem Grande do Rio Pardo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3170701",
+    "municipio": "Varginha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3170750",
+    "municipio": "Varjão de Minas",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3170800",
+    "municipio": "Várzea da Palma",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3170909",
+    "municipio": "Varzelândia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3171006",
+    "municipio": "Vazante",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3171030",
+    "municipio": "Verdelândia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3171071",
+    "municipio": "Veredinha",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3171105",
+    "municipio": "Veríssimo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3171154",
+    "municipio": "Vermelho Novo",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3171204",
+    "municipio": "Vespasiano",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3171303",
+    "municipio": "Viçosa",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3171402",
+    "municipio": "Vieiras",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3171501",
+    "municipio": "Mathias Lobato",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3171600",
+    "municipio": "Virgem da Lapa",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3171709",
+    "municipio": "Virgínia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3171808",
+    "municipio": "Virginópolis",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3171907",
+    "municipio": "Virgolândia",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3172004",
+    "municipio": "Visconde do Rio Branco",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3172103",
+    "municipio": "Volta Grande",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3172202",
+    "municipio": "Wenceslau Braz",
+    "uf": "MG"
+  },
+  {
+    "codigo": "3200102",
+    "municipio": "Afonso Cláudio",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3200136",
+    "municipio": "Águia Branca",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3200169",
+    "municipio": "Água Doce do Norte",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3200201",
+    "municipio": "Alegre",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3200300",
+    "municipio": "Alfredo Chaves",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3200359",
+    "municipio": "Alto Rio Novo",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3200409",
+    "municipio": "Anchieta",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3200508",
+    "municipio": "Apiacá",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3200607",
+    "municipio": "Aracruz",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3200706",
+    "municipio": "Atílio Vivácqua",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3200805",
+    "municipio": "Baixo Guandu",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3200904",
+    "municipio": "Barra de São Francisco",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3201001",
+    "municipio": "Boa Esperança",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3201100",
+    "municipio": "Bom Jesus do Norte",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3201159",
+    "municipio": "Brejetuba",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3201209",
+    "municipio": "Cachoeiro de Itapemirim",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3201308",
+    "municipio": "Cariacica",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3201407",
+    "municipio": "Castelo",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3201506",
+    "municipio": "Colatina",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3201605",
+    "municipio": "Conceição da Barra",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3201704",
+    "municipio": "Conceição do Castelo",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3201803",
+    "municipio": "Divino de São Lourenço",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3201902",
+    "municipio": "Domingos Martins",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3202009",
+    "municipio": "Dores do Rio Preto",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3202108",
+    "municipio": "Ecoporanga",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3202207",
+    "municipio": "Fundão",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3202256",
+    "municipio": "Governador Lindenberg",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3202306",
+    "municipio": "Guaçuí",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3202405",
+    "municipio": "Guarapari",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3202454",
+    "municipio": "Ibatiba",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3202504",
+    "municipio": "Ibiraçu",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3202553",
+    "municipio": "Ibitirama",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3202603",
+    "municipio": "Iconha",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3202652",
+    "municipio": "Irupi",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3202702",
+    "municipio": "Itaguaçu",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3202801",
+    "municipio": "Itapemirim",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3202900",
+    "municipio": "Itarana",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3203007",
+    "municipio": "Iúna",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3203056",
+    "municipio": "Jaguaré",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3203106",
+    "municipio": "Jerônimo Monteiro",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3203130",
+    "municipio": "João Neiva",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3203163",
+    "municipio": "Laranja da Terra",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3203205",
+    "municipio": "Linhares",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3203304",
+    "municipio": "Mantenópolis",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3203320",
+    "municipio": "Marataízes",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3203346",
+    "municipio": "Marechal Floriano",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3203353",
+    "municipio": "Marilândia",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3203403",
+    "municipio": "Mimoso do Sul",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3203502",
+    "municipio": "Montanha",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3203601",
+    "municipio": "Mucurici",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3203700",
+    "municipio": "Muniz Freire",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3203809",
+    "municipio": "Muqui",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3203908",
+    "municipio": "Nova Venécia",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3204005",
+    "municipio": "Pancas",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3204054",
+    "municipio": "Pedro Canário",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3204104",
+    "municipio": "Pinheiros",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3204203",
+    "municipio": "Piúma",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3204252",
+    "municipio": "Ponto Belo",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3204302",
+    "municipio": "Presidente Kennedy",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3204351",
+    "municipio": "Rio Bananal",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3204401",
+    "municipio": "Rio Novo do Sul",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3204500",
+    "municipio": "Santa Leopoldina",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3204559",
+    "municipio": "Santa Maria de Jetibá",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3204609",
+    "municipio": "Santa Teresa",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3204658",
+    "municipio": "São Domingos do Norte",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3204708",
+    "municipio": "São Gabriel da Palha",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3204807",
+    "municipio": "São José do Calçado",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3204906",
+    "municipio": "São Mateus",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3204955",
+    "municipio": "São Roque do Canaã",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3205002",
+    "municipio": "Serra",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3205010",
+    "municipio": "Sooretama",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3205036",
+    "municipio": "Vargem Alta",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3205069",
+    "municipio": "Venda Nova do Imigrante",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3205101",
+    "municipio": "Viana",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3205150",
+    "municipio": "Vila Pavão",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3205176",
+    "municipio": "Vila Valério",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3205200",
+    "municipio": "Vila Velha",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3205309",
+    "municipio": "Vitória",
+    "uf": "ES"
+  },
+  {
+    "codigo": "3300100",
+    "municipio": "Angra dos Reis",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3300159",
+    "municipio": "Aperibé",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3300209",
+    "municipio": "Araruama",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3300225",
+    "municipio": "Areal",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3300233",
+    "municipio": "Armação dos Búzios",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3300258",
+    "municipio": "Arraial do Cabo",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3300308",
+    "municipio": "Barra do Piraí",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3300407",
+    "municipio": "Barra Mansa",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3300456",
+    "municipio": "Belford Roxo",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3300506",
+    "municipio": "Bom Jardim",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3300605",
+    "municipio": "Bom Jesus do Itabapoana",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3300704",
+    "municipio": "Cabo Frio",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3300803",
+    "municipio": "Cachoeiras de Macacu",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3300902",
+    "municipio": "Cambuci",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3300936",
+    "municipio": "Carapebus",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3300951",
+    "municipio": "Comendador Levy Gasparian",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3301009",
+    "municipio": "Campos dos Goytacazes",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3301108",
+    "municipio": "Cantagalo",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3301157",
+    "municipio": "Cardoso Moreira",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3301207",
+    "municipio": "Carmo",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3301306",
+    "municipio": "Casimiro de Abreu",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3301405",
+    "municipio": "Conceição de Macabu",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3301504",
+    "municipio": "Cordeiro",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3301603",
+    "municipio": "Duas Barras",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3301702",
+    "municipio": "Duque de Caxias",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3301801",
+    "municipio": "Engenheiro Paulo de Frontin",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3301850",
+    "municipio": "Guapimirim",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3301876",
+    "municipio": "Iguaba Grande",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3301900",
+    "municipio": "Itaboraí",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3302007",
+    "municipio": "Itaguaí",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3302056",
+    "municipio": "Italva",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3302106",
+    "municipio": "Itaocara",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3302205",
+    "municipio": "Itaperuna",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3302254",
+    "municipio": "Itatiaia",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3302270",
+    "municipio": "Japeri",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3302304",
+    "municipio": "Laje do Muriaé",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3302403",
+    "municipio": "Macaé",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3302452",
+    "municipio": "Macuco",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3302502",
+    "municipio": "Magé",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3302601",
+    "municipio": "Mangaratiba",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3302700",
+    "municipio": "Maricá",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3302809",
+    "municipio": "Mendes",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3302858",
+    "municipio": "Mesquita",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3302908",
+    "municipio": "Miguel Pereira",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3303005",
+    "municipio": "Miracema",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3303104",
+    "municipio": "Natividade",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3303203",
+    "municipio": "Nilópolis",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3303302",
+    "municipio": "Niterói",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3303401",
+    "municipio": "Nova Friburgo",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3303500",
+    "municipio": "Nova Iguaçu",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3303609",
+    "municipio": "Paracambi",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3303708",
+    "municipio": "Paraíba do Sul",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3303807",
+    "municipio": "Paraty",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3303856",
+    "municipio": "Paty do Alferes",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3303906",
+    "municipio": "Petrópolis",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3303955",
+    "municipio": "Pinheiral",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3304003",
+    "municipio": "Piraí",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3304102",
+    "municipio": "Porciúncula",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3304110",
+    "municipio": "Porto Real",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3304128",
+    "municipio": "Quatis",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3304144",
+    "municipio": "Queimados",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3304151",
+    "municipio": "Quissamã",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3304201",
+    "municipio": "Resende",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3304300",
+    "municipio": "Rio Bonito",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3304409",
+    "municipio": "Rio Claro",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3304508",
+    "municipio": "Rio das Flores",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3304524",
+    "municipio": "Rio das Ostras",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3304557",
+    "municipio": "Rio de Janeiro",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3304607",
+    "municipio": "Santa Maria Madalena",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3304706",
+    "municipio": "Santo Antônio de Pádua",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3304755",
+    "municipio": "São Francisco de Itabapoana",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3304805",
+    "municipio": "São Fidélis",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3304904",
+    "municipio": "São Gonçalo",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3305000",
+    "municipio": "São João da Barra",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3305109",
+    "municipio": "São João de Meriti",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3305133",
+    "municipio": "São José de Ubá",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3305158",
+    "municipio": "São José do Vale do Rio Preto",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3305208",
+    "municipio": "São Pedro da Aldeia",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3305307",
+    "municipio": "São Sebastião do Alto",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3305406",
+    "municipio": "Sapucaia",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3305505",
+    "municipio": "Saquarema",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3305554",
+    "municipio": "Seropédica",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3305604",
+    "municipio": "Silva Jardim",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3305703",
+    "municipio": "Sumidouro",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3305752",
+    "municipio": "Tanguá",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3305802",
+    "municipio": "Teresópolis",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3305901",
+    "municipio": "Trajano de Moraes",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3306008",
+    "municipio": "Três Rios",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3306107",
+    "municipio": "Valença",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3306156",
+    "municipio": "Varre-Sai",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3306206",
+    "municipio": "Vassouras",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3306305",
+    "municipio": "Volta Redonda",
+    "uf": "RJ"
+  },
+  {
+    "codigo": "3500105",
+    "municipio": "Adamantina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3500204",
+    "municipio": "Adolfo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3500303",
+    "municipio": "Aguaí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3500402",
+    "municipio": "Águas da Prata",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3500501",
+    "municipio": "Águas de Lindóia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3500550",
+    "municipio": "Águas de Santa Bárbara",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3500600",
+    "municipio": "Águas de São Pedro",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3500709",
+    "municipio": "Agudos",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3500758",
+    "municipio": "Alambari",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3500808",
+    "municipio": "Alfredo Marcondes",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3500907",
+    "municipio": "Altair",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3501004",
+    "municipio": "Altinópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3501103",
+    "municipio": "Alto Alegre",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3501152",
+    "municipio": "Alumínio",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3501202",
+    "municipio": "Álvares Florence",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3501301",
+    "municipio": "Álvares Machado",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3501400",
+    "municipio": "Álvaro de Carvalho",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3501509",
+    "municipio": "Alvinlândia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3501608",
+    "municipio": "Americana",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3501707",
+    "municipio": "Américo Brasiliense",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3501806",
+    "municipio": "Américo de Campos",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3501905",
+    "municipio": "Amparo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3502002",
+    "municipio": "Analândia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3502101",
+    "municipio": "Andradina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3502200",
+    "municipio": "Angatuba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3502309",
+    "municipio": "Anhembi",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3502408",
+    "municipio": "Anhumas",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3502507",
+    "municipio": "Aparecida",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3502606",
+    "municipio": "Aparecida d'Oeste",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3502705",
+    "municipio": "Apiaí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3502754",
+    "municipio": "Araçariguama",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3502804",
+    "municipio": "Araçatuba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3502903",
+    "municipio": "Araçoiaba da Serra",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3503000",
+    "municipio": "Aramina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3503109",
+    "municipio": "Arandu",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3503158",
+    "municipio": "Arapeí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3503208",
+    "municipio": "Araraquara",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3503307",
+    "municipio": "Araras",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3503356",
+    "municipio": "Arco-Íris",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3503406",
+    "municipio": "Arealva",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3503505",
+    "municipio": "Areias",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3503604",
+    "municipio": "Areiópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3503703",
+    "municipio": "Ariranha",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3503802",
+    "municipio": "Artur Nogueira",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3503901",
+    "municipio": "Arujá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3503950",
+    "municipio": "Aspásia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3504008",
+    "municipio": "Assis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3504107",
+    "municipio": "Atibaia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3504206",
+    "municipio": "Auriflama",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3504305",
+    "municipio": "Avaí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3504404",
+    "municipio": "Avanhandava",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3504503",
+    "municipio": "Avaré",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3504602",
+    "municipio": "Bady Bassitt",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3504701",
+    "municipio": "Balbinos",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3504800",
+    "municipio": "Bálsamo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3504909",
+    "municipio": "Bananal",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3505005",
+    "municipio": "Barão de Antonina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3505104",
+    "municipio": "Barbosa",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3505203",
+    "municipio": "Bariri",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3505302",
+    "municipio": "Barra Bonita",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3505351",
+    "municipio": "Barra do Chapéu",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3505401",
+    "municipio": "Barra do Turvo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3505500",
+    "municipio": "Barretos",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3505609",
+    "municipio": "Barrinha",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3505708",
+    "municipio": "Barueri",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3505807",
+    "municipio": "Bastos",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3505906",
+    "municipio": "Batatais",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3506003",
+    "municipio": "Bauru",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3506102",
+    "municipio": "Bebedouro",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3506201",
+    "municipio": "Bento de Abreu",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3506300",
+    "municipio": "Bernardino de Campos",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3506359",
+    "municipio": "Bertioga",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3506409",
+    "municipio": "Bilac",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3506508",
+    "municipio": "Birigui",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3506607",
+    "municipio": "Biritiba Mirim",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3506706",
+    "municipio": "Boa Esperança do Sul",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3506805",
+    "municipio": "Bocaina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3506904",
+    "municipio": "Bofete",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3507001",
+    "municipio": "Boituva",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3507100",
+    "municipio": "Bom Jesus dos Perdões",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3507159",
+    "municipio": "Bom Sucesso de Itararé",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3507209",
+    "municipio": "Borá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3507308",
+    "municipio": "Boracéia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3507407",
+    "municipio": "Borborema",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3507456",
+    "municipio": "Borebi",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3507506",
+    "municipio": "Botucatu",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3507605",
+    "municipio": "Bragança Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3507704",
+    "municipio": "Braúna",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3507753",
+    "municipio": "Brejo Alegre",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3507803",
+    "municipio": "Brodowski",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3507902",
+    "municipio": "Brotas",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3508009",
+    "municipio": "Buri",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3508108",
+    "municipio": "Buritama",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3508207",
+    "municipio": "Buritizal",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3508306",
+    "municipio": "Cabrália Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3508405",
+    "municipio": "Cabreúva",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3508504",
+    "municipio": "Caçapava",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3508603",
+    "municipio": "Cachoeira Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3508702",
+    "municipio": "Caconde",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3508801",
+    "municipio": "Cafelândia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3508900",
+    "municipio": "Caiabu",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3509007",
+    "municipio": "Caieiras",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3509106",
+    "municipio": "Caiuá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3509205",
+    "municipio": "Cajamar",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3509254",
+    "municipio": "Cajati",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3509304",
+    "municipio": "Cajobi",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3509403",
+    "municipio": "Cajuru",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3509452",
+    "municipio": "Campina do Monte Alegre",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3509502",
+    "municipio": "Campinas",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3509601",
+    "municipio": "Campo Limpo Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3509700",
+    "municipio": "Campos do Jordão",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3509809",
+    "municipio": "Campos Novos Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3509908",
+    "municipio": "Cananéia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3509957",
+    "municipio": "Canas",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3510005",
+    "municipio": "Cândido Mota",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3510104",
+    "municipio": "Cândido Rodrigues",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3510153",
+    "municipio": "Canitar",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3510203",
+    "municipio": "Capão Bonito",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3510302",
+    "municipio": "Capela do Alto",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3510401",
+    "municipio": "Capivari",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3510500",
+    "municipio": "Caraguatatuba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3510609",
+    "municipio": "Carapicuíba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3510708",
+    "municipio": "Cardoso",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3510807",
+    "municipio": "Casa Branca",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3510906",
+    "municipio": "Cássia dos Coqueiros",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3511003",
+    "municipio": "Castilho",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3511102",
+    "municipio": "Catanduva",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3511201",
+    "municipio": "Catiguá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3511300",
+    "municipio": "Cedral",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3511409",
+    "municipio": "Cerqueira César",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3511508",
+    "municipio": "Cerquilho",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3511607",
+    "municipio": "Cesário Lange",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3511706",
+    "municipio": "Charqueada",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3511904",
+    "municipio": "Clementina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3512001",
+    "municipio": "Colina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3512100",
+    "municipio": "Colômbia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3512209",
+    "municipio": "Conchal",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3512308",
+    "municipio": "Conchas",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3512407",
+    "municipio": "Cordeirópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3512506",
+    "municipio": "Coroados",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3512605",
+    "municipio": "Coronel Macedo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3512704",
+    "municipio": "Corumbataí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3512803",
+    "municipio": "Cosmópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3512902",
+    "municipio": "Cosmorama",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3513009",
+    "municipio": "Cotia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3513108",
+    "municipio": "Cravinhos",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3513207",
+    "municipio": "Cristais Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3513306",
+    "municipio": "Cruzália",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3513405",
+    "municipio": "Cruzeiro",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3513504",
+    "municipio": "Cubatão",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3513603",
+    "municipio": "Cunha",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3513702",
+    "municipio": "Descalvado",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3513801",
+    "municipio": "Diadema",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3513850",
+    "municipio": "Dirce Reis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3513900",
+    "municipio": "Divinolândia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3514007",
+    "municipio": "Dobrada",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3514106",
+    "municipio": "Dois Córregos",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3514205",
+    "municipio": "Dolcinópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3514304",
+    "municipio": "Dourado",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3514403",
+    "municipio": "Dracena",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3514502",
+    "municipio": "Duartina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3514601",
+    "municipio": "Dumont",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3514700",
+    "municipio": "Echaporã",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3514809",
+    "municipio": "Eldorado",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3514908",
+    "municipio": "Elias Fausto",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3514924",
+    "municipio": "Elisiário",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3514957",
+    "municipio": "Embaúba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3515004",
+    "municipio": "Embu das Artes",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3515103",
+    "municipio": "Embu-Guaçu",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3515129",
+    "municipio": "Emilianópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3515152",
+    "municipio": "Engenheiro Coelho",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3515186",
+    "municipio": "Espírito Santo do Pinhal",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3515194",
+    "municipio": "Espírito Santo do Turvo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3515202",
+    "municipio": "Estrela d'Oeste",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3515301",
+    "municipio": "Estrela do Norte",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3515350",
+    "municipio": "Euclides da Cunha Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3515400",
+    "municipio": "Fartura",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3515509",
+    "municipio": "Fernandópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3515608",
+    "municipio": "Fernando Prestes",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3515657",
+    "municipio": "Fernão",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3515707",
+    "municipio": "Ferraz de Vasconcelos",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3515806",
+    "municipio": "Flora Rica",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3515905",
+    "municipio": "Floreal",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3516002",
+    "municipio": "Flórida Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3516101",
+    "municipio": "Florínea",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3516200",
+    "municipio": "Franca",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3516309",
+    "municipio": "Francisco Morato",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3516408",
+    "municipio": "Franco da Rocha",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3516507",
+    "municipio": "Gabriel Monteiro",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3516606",
+    "municipio": "Gália",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3516705",
+    "municipio": "Garça",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3516804",
+    "municipio": "Gastão Vidigal",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3516853",
+    "municipio": "Gavião Peixoto",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3516903",
+    "municipio": "General Salgado",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3517000",
+    "municipio": "Getulina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3517109",
+    "municipio": "Glicério",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3517208",
+    "municipio": "Guaiçara",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3517307",
+    "municipio": "Guaimbê",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3517406",
+    "municipio": "Guaíra",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3517505",
+    "municipio": "Guapiaçu",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3517604",
+    "municipio": "Guapiara",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3517703",
+    "municipio": "Guará",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3517802",
+    "municipio": "Guaraçaí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3517901",
+    "municipio": "Guaraci",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3518008",
+    "municipio": "Guarani d'Oeste",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3518107",
+    "municipio": "Guarantã",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3518206",
+    "municipio": "Guararapes",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3518305",
+    "municipio": "Guararema",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3518404",
+    "municipio": "Guaratinguetá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3518503",
+    "municipio": "Guareí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3518602",
+    "municipio": "Guariba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3518701",
+    "municipio": "Guarujá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3518800",
+    "municipio": "Guarulhos",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3518859",
+    "municipio": "Guatapará",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3518909",
+    "municipio": "Guzolândia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3519006",
+    "municipio": "Herculândia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3519055",
+    "municipio": "Holambra",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3519071",
+    "municipio": "Hortolândia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3519105",
+    "municipio": "Iacanga",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3519204",
+    "municipio": "Iacri",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3519253",
+    "municipio": "Iaras",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3519303",
+    "municipio": "Ibaté",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3519402",
+    "municipio": "Ibirá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3519501",
+    "municipio": "Ibirarema",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3519600",
+    "municipio": "Ibitinga",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3519709",
+    "municipio": "Ibiúna",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3519808",
+    "municipio": "Icém",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3519907",
+    "municipio": "Iepê",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3520004",
+    "municipio": "Igaraçu do Tietê",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3520103",
+    "municipio": "Igarapava",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3520202",
+    "municipio": "Igaratá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3520301",
+    "municipio": "Iguape",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3520400",
+    "municipio": "Ilhabela",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3520426",
+    "municipio": "Ilha Comprida",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3520442",
+    "municipio": "Ilha Solteira",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3520509",
+    "municipio": "Indaiatuba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3520608",
+    "municipio": "Indiana",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3520707",
+    "municipio": "Indiaporã",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3520806",
+    "municipio": "Inúbia Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3520905",
+    "municipio": "Ipaussu",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3521002",
+    "municipio": "Iperó",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3521101",
+    "municipio": "Ipeúna",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3521150",
+    "municipio": "Ipiguá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3521200",
+    "municipio": "Iporanga",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3521309",
+    "municipio": "Ipuã",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3521408",
+    "municipio": "Iracemápolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3521507",
+    "municipio": "Irapuã",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3521606",
+    "municipio": "Irapuru",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3521705",
+    "municipio": "Itaberá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3521804",
+    "municipio": "Itaí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3521903",
+    "municipio": "Itajobi",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3522000",
+    "municipio": "Itaju",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3522109",
+    "municipio": "Itanhaém",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3522158",
+    "municipio": "Itaoca",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3522208",
+    "municipio": "Itapecerica da Serra",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3522307",
+    "municipio": "Itapetininga",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3522406",
+    "municipio": "Itapeva",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3522505",
+    "municipio": "Itapevi",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3522604",
+    "municipio": "Itapira",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3522653",
+    "municipio": "Itapirapuã Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3522703",
+    "municipio": "Itápolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3522802",
+    "municipio": "Itaporanga",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3522901",
+    "municipio": "Itapuí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3523008",
+    "municipio": "Itapura",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3523107",
+    "municipio": "Itaquaquecetuba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3523206",
+    "municipio": "Itararé",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3523305",
+    "municipio": "Itariri",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3523404",
+    "municipio": "Itatiba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3523503",
+    "municipio": "Itatinga",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3523602",
+    "municipio": "Itirapina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3523701",
+    "municipio": "Itirapuã",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3523800",
+    "municipio": "Itobi",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3523909",
+    "municipio": "Itu",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3524006",
+    "municipio": "Itupeva",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3524105",
+    "municipio": "Ituverava",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3524204",
+    "municipio": "Jaborandi",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3524303",
+    "municipio": "Jaboticabal",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3524402",
+    "municipio": "Jacareí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3524501",
+    "municipio": "Jaci",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3524600",
+    "municipio": "Jacupiranga",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3524709",
+    "municipio": "Jaguariúna",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3524808",
+    "municipio": "Jales",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3524907",
+    "municipio": "Jambeiro",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3525003",
+    "municipio": "Jandira",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3525102",
+    "municipio": "Jardinópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3525201",
+    "municipio": "Jarinu",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3525300",
+    "municipio": "Jaú",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3525409",
+    "municipio": "Jeriquara",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3525508",
+    "municipio": "Joanópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3525607",
+    "municipio": "João Ramalho",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3525706",
+    "municipio": "José Bonifácio",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3525805",
+    "municipio": "Júlio Mesquita",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3525854",
+    "municipio": "Jumirim",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3525904",
+    "municipio": "Jundiaí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3526001",
+    "municipio": "Junqueirópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3526100",
+    "municipio": "Juquiá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3526209",
+    "municipio": "Juquitiba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3526308",
+    "municipio": "Lagoinha",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3526407",
+    "municipio": "Laranjal Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3526506",
+    "municipio": "Lavínia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3526605",
+    "municipio": "Lavrinhas",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3526704",
+    "municipio": "Leme",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3526803",
+    "municipio": "Lençóis Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3526902",
+    "municipio": "Limeira",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3527009",
+    "municipio": "Lindóia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3527108",
+    "municipio": "Lins",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3527207",
+    "municipio": "Lorena",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3527256",
+    "municipio": "Lourdes",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3527306",
+    "municipio": "Louveira",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3527405",
+    "municipio": "Lucélia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3527504",
+    "municipio": "Lucianópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3527603",
+    "municipio": "Luís Antônio",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3527702",
+    "municipio": "Luiziânia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3527801",
+    "municipio": "Lupércio",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3527900",
+    "municipio": "Lutécia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3528007",
+    "municipio": "Macatuba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3528106",
+    "municipio": "Macaubal",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3528205",
+    "municipio": "Macedônia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3528304",
+    "municipio": "Magda",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3528403",
+    "municipio": "Mairinque",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3528502",
+    "municipio": "Mairiporã",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3528601",
+    "municipio": "Manduri",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3528700",
+    "municipio": "Marabá Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3528809",
+    "municipio": "Maracaí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3528858",
+    "municipio": "Marapoama",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3528908",
+    "municipio": "Mariápolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3529005",
+    "municipio": "Marília",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3529104",
+    "municipio": "Marinópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3529203",
+    "municipio": "Martinópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3529302",
+    "municipio": "Matão",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3529401",
+    "municipio": "Mauá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3529500",
+    "municipio": "Mendonça",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3529609",
+    "municipio": "Meridiano",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3529658",
+    "municipio": "Mesópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3529708",
+    "municipio": "Miguelópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3529807",
+    "municipio": "Mineiros do Tietê",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3529906",
+    "municipio": "Miracatu",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3530003",
+    "municipio": "Mira Estrela",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3530102",
+    "municipio": "Mirandópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3530201",
+    "municipio": "Mirante do Paranapanema",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3530300",
+    "municipio": "Mirassol",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3530409",
+    "municipio": "Mirassolândia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3530508",
+    "municipio": "Mococa",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3530607",
+    "municipio": "Mogi das Cruzes",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3530706",
+    "municipio": "Mogi Guaçu",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3530805",
+    "municipio": "Mogi Mirim",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3530904",
+    "municipio": "Mombuca",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3531001",
+    "municipio": "Monções",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3531100",
+    "municipio": "Mongaguá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3531209",
+    "municipio": "Monte Alegre do Sul",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3531308",
+    "municipio": "Monte Alto",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3531407",
+    "municipio": "Monte Aprazível",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3531506",
+    "municipio": "Monte Azul Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3531605",
+    "municipio": "Monte Castelo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3531704",
+    "municipio": "Monteiro Lobato",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3531803",
+    "municipio": "Monte Mor",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3531902",
+    "municipio": "Morro Agudo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3532009",
+    "municipio": "Morungaba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3532058",
+    "municipio": "Motuca",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3532108",
+    "municipio": "Murutinga do Sul",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3532157",
+    "municipio": "Nantes",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3532207",
+    "municipio": "Narandiba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3532306",
+    "municipio": "Natividade da Serra",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3532405",
+    "municipio": "Nazaré Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3532504",
+    "municipio": "Neves Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3532603",
+    "municipio": "Nhandeara",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3532702",
+    "municipio": "Nipoã",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3532801",
+    "municipio": "Nova Aliança",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3532827",
+    "municipio": "Nova Campina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3532843",
+    "municipio": "Nova Canaã Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3532868",
+    "municipio": "Nova Castilho",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3532900",
+    "municipio": "Nova Europa",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3533007",
+    "municipio": "Nova Granada",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3533106",
+    "municipio": "Nova Guataporanga",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3533205",
+    "municipio": "Nova Independência",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3533254",
+    "municipio": "Novais",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3533304",
+    "municipio": "Nova Luzitânia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3533403",
+    "municipio": "Nova Odessa",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3533502",
+    "municipio": "Novo Horizonte",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3533601",
+    "municipio": "Nuporanga",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3533700",
+    "municipio": "Ocauçu",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3533809",
+    "municipio": "Óleo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3533908",
+    "municipio": "Olímpia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3534005",
+    "municipio": "Onda Verde",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3534104",
+    "municipio": "Oriente",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3534203",
+    "municipio": "Orindiúva",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3534302",
+    "municipio": "Orlândia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3534401",
+    "municipio": "Osasco",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3534500",
+    "municipio": "Oscar Bressane",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3534609",
+    "municipio": "Osvaldo Cruz",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3534708",
+    "municipio": "Ourinhos",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3534757",
+    "municipio": "Ouroeste",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3534807",
+    "municipio": "Ouro Verde",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3534906",
+    "municipio": "Pacaembu",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3535002",
+    "municipio": "Palestina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3535101",
+    "municipio": "Palmares Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3535200",
+    "municipio": "Palmeira d'Oeste",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3535309",
+    "municipio": "Palmital",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3535408",
+    "municipio": "Panorama",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3535507",
+    "municipio": "Paraguaçu Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3535606",
+    "municipio": "Paraibuna",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3535705",
+    "municipio": "Paraíso",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3535804",
+    "municipio": "Paranapanema",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3535903",
+    "municipio": "Paranapuã",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3536000",
+    "municipio": "Parapuã",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3536109",
+    "municipio": "Pardinho",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3536208",
+    "municipio": "Pariquera-Açu",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3536257",
+    "municipio": "Parisi",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3536307",
+    "municipio": "Patrocínio Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3536406",
+    "municipio": "Paulicéia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3536505",
+    "municipio": "Paulínia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3536570",
+    "municipio": "Paulistânia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3536604",
+    "municipio": "Paulo de Faria",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3536703",
+    "municipio": "Pederneiras",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3536802",
+    "municipio": "Pedra Bela",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3536901",
+    "municipio": "Pedranópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3537008",
+    "municipio": "Pedregulho",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3537107",
+    "municipio": "Pedreira",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3537156",
+    "municipio": "Pedrinhas Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3537206",
+    "municipio": "Pedro de Toledo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3537305",
+    "municipio": "Penápolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3537404",
+    "municipio": "Pereira Barreto",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3537503",
+    "municipio": "Pereiras",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3537602",
+    "municipio": "Peruíbe",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3537701",
+    "municipio": "Piacatu",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3537800",
+    "municipio": "Piedade",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3537909",
+    "municipio": "Pilar do Sul",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3538006",
+    "municipio": "Pindamonhangaba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3538105",
+    "municipio": "Pindorama",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3538204",
+    "municipio": "Pinhalzinho",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3538303",
+    "municipio": "Piquerobi",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3538501",
+    "municipio": "Piquete",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3538600",
+    "municipio": "Piracaia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3538709",
+    "municipio": "Piracicaba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3538808",
+    "municipio": "Piraju",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3538907",
+    "municipio": "Pirajuí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3539004",
+    "municipio": "Pirangi",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3539103",
+    "municipio": "Pirapora do Bom Jesus",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3539202",
+    "municipio": "Pirapozinho",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3539301",
+    "municipio": "Pirassununga",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3539400",
+    "municipio": "Piratininga",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3539509",
+    "municipio": "Pitangueiras",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3539608",
+    "municipio": "Planalto",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3539707",
+    "municipio": "Platina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3539806",
+    "municipio": "Poá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3539905",
+    "municipio": "Poloni",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3540002",
+    "municipio": "Pompéia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3540101",
+    "municipio": "Pongaí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3540200",
+    "municipio": "Pontal",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3540259",
+    "municipio": "Pontalinda",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3540309",
+    "municipio": "Pontes Gestal",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3540408",
+    "municipio": "Populina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3540507",
+    "municipio": "Porangaba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3540606",
+    "municipio": "Porto Feliz",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3540705",
+    "municipio": "Porto Ferreira",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3540754",
+    "municipio": "Potim",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3540804",
+    "municipio": "Potirendaba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3540853",
+    "municipio": "Pracinha",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3540903",
+    "municipio": "Pradópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3541000",
+    "municipio": "Praia Grande",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3541059",
+    "municipio": "Pratânia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3541109",
+    "municipio": "Presidente Alves",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3541208",
+    "municipio": "Presidente Bernardes",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3541307",
+    "municipio": "Presidente Epitácio",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3541406",
+    "municipio": "Presidente Prudente",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3541505",
+    "municipio": "Presidente Venceslau",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3541604",
+    "municipio": "Promissão",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3541653",
+    "municipio": "Quadra",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3541703",
+    "municipio": "Quatá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3541802",
+    "municipio": "Queiroz",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3541901",
+    "municipio": "Queluz",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3542008",
+    "municipio": "Quintana",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3542107",
+    "municipio": "Rafard",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3542206",
+    "municipio": "Rancharia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3542305",
+    "municipio": "Redenção da Serra",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3542404",
+    "municipio": "Regente Feijó",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3542503",
+    "municipio": "Reginópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3542602",
+    "municipio": "Registro",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3542701",
+    "municipio": "Restinga",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3542800",
+    "municipio": "Ribeira",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3542909",
+    "municipio": "Ribeirão Bonito",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3543006",
+    "municipio": "Ribeirão Branco",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3543105",
+    "municipio": "Ribeirão Corrente",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3543204",
+    "municipio": "Ribeirão do Sul",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3543238",
+    "municipio": "Ribeirão dos Índios",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3543253",
+    "municipio": "Ribeirão Grande",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3543303",
+    "municipio": "Ribeirão Pires",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3543402",
+    "municipio": "Ribeirão Preto",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3543501",
+    "municipio": "Riversul",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3543600",
+    "municipio": "Rifaina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3543709",
+    "municipio": "Rincão",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3543808",
+    "municipio": "Rinópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3543907",
+    "municipio": "Rio Claro",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3544004",
+    "municipio": "Rio das Pedras",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3544103",
+    "municipio": "Rio Grande da Serra",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3544202",
+    "municipio": "Riolândia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3544251",
+    "municipio": "Rosana",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3544301",
+    "municipio": "Roseira",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3544400",
+    "municipio": "Rubiácea",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3544509",
+    "municipio": "Rubinéia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3544608",
+    "municipio": "Sabino",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3544707",
+    "municipio": "Sagres",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3544806",
+    "municipio": "Sales",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3544905",
+    "municipio": "Sales Oliveira",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3545001",
+    "municipio": "Salesópolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3545100",
+    "municipio": "Salmourão",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3545159",
+    "municipio": "Saltinho",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3545209",
+    "municipio": "Salto",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3545308",
+    "municipio": "Salto de Pirapora",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3545407",
+    "municipio": "Salto Grande",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3545506",
+    "municipio": "Sandovalina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3545605",
+    "municipio": "Santa Adélia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3545704",
+    "municipio": "Santa Albertina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3545803",
+    "municipio": "Santa Bárbara d'Oeste",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3546009",
+    "municipio": "Santa Branca",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3546108",
+    "municipio": "Santa Clara d'Oeste",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3546207",
+    "municipio": "Santa Cruz da Conceição",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3546256",
+    "municipio": "Santa Cruz da Esperança",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3546306",
+    "municipio": "Santa Cruz das Palmeiras",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3546405",
+    "municipio": "Santa Cruz do Rio Pardo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3546504",
+    "municipio": "Santa Ernestina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3546603",
+    "municipio": "Santa Fé do Sul",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3546702",
+    "municipio": "Santa Gertrudes",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3546801",
+    "municipio": "Santa Isabel",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3546900",
+    "municipio": "Santa Lúcia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3547007",
+    "municipio": "Santa Maria da Serra",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3547106",
+    "municipio": "Santa Mercedes",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3547205",
+    "municipio": "Santana da Ponte Pensa",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3547304",
+    "municipio": "Santana de Parnaíba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3547403",
+    "municipio": "Santa Rita d'Oeste",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3547502",
+    "municipio": "Santa Rita do Passa Quatro",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3547601",
+    "municipio": "Santa Rosa de Viterbo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3547650",
+    "municipio": "Santa Salete",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3547700",
+    "municipio": "Santo Anastácio",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3547809",
+    "municipio": "Santo André",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3547908",
+    "municipio": "Santo Antônio da Alegria",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3548005",
+    "municipio": "Santo Antônio de Posse",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3548054",
+    "municipio": "Santo Antônio do Aracanguá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3548104",
+    "municipio": "Santo Antônio do Jardim",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3548203",
+    "municipio": "Santo Antônio do Pinhal",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3548302",
+    "municipio": "Santo Expedito",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3548401",
+    "municipio": "Santópolis do Aguapeí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3548500",
+    "municipio": "Santos",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3548609",
+    "municipio": "São Bento do Sapucaí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3548708",
+    "municipio": "São Bernardo do Campo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3548807",
+    "municipio": "São Caetano do Sul",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3548906",
+    "municipio": "São Carlos",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3549003",
+    "municipio": "São Francisco",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3549102",
+    "municipio": "São João da Boa Vista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3549201",
+    "municipio": "São João das Duas Pontes",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3549250",
+    "municipio": "São João de Iracema",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3549300",
+    "municipio": "São João do Pau d'Alho",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3549409",
+    "municipio": "São Joaquim da Barra",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3549508",
+    "municipio": "São José da Bela Vista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3549607",
+    "municipio": "São José do Barreiro",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3549706",
+    "municipio": "São José do Rio Pardo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3549805",
+    "municipio": "São José do Rio Preto",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3549904",
+    "municipio": "São José dos Campos",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3549953",
+    "municipio": "São Lourenço da Serra",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3550001",
+    "municipio": "São Luiz do Paraitinga",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3550100",
+    "municipio": "São Manuel",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3550209",
+    "municipio": "São Miguel Arcanjo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3550308",
+    "municipio": "São Paulo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3550407",
+    "municipio": "São Pedro",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3550506",
+    "municipio": "São Pedro do Turvo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3550605",
+    "municipio": "São Roque",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3550704",
+    "municipio": "São Sebastião",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3550803",
+    "municipio": "São Sebastião da Grama",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3550902",
+    "municipio": "São Simão",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3551009",
+    "municipio": "São Vicente",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3551108",
+    "municipio": "Sarapuí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3551207",
+    "municipio": "Sarutaiá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3551306",
+    "municipio": "Sebastianópolis do Sul",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3551405",
+    "municipio": "Serra Azul",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3551504",
+    "municipio": "Serrana",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3551603",
+    "municipio": "Serra Negra",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3551702",
+    "municipio": "Sertãozinho",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3551801",
+    "municipio": "Sete Barras",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3551900",
+    "municipio": "Severínia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3552007",
+    "municipio": "Silveiras",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3552106",
+    "municipio": "Socorro",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3552205",
+    "municipio": "Sorocaba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3552304",
+    "municipio": "Sud Mennucci",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3552403",
+    "municipio": "Sumaré",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3552502",
+    "municipio": "Suzano",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3552551",
+    "municipio": "Suzanápolis",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3552601",
+    "municipio": "Tabapuã",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3552700",
+    "municipio": "Tabatinga",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3552809",
+    "municipio": "Taboão da Serra",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3552908",
+    "municipio": "Taciba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3553005",
+    "municipio": "Taguaí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3553104",
+    "municipio": "Taiaçu",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3553203",
+    "municipio": "Taiúva",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3553302",
+    "municipio": "Tambaú",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3553401",
+    "municipio": "Tanabi",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3553500",
+    "municipio": "Tapiraí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3553609",
+    "municipio": "Tapiratiba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3553658",
+    "municipio": "Taquaral",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3553708",
+    "municipio": "Taquaritinga",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3553807",
+    "municipio": "Taquarituba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3553856",
+    "municipio": "Taquarivaí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3553906",
+    "municipio": "Tarabai",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3553955",
+    "municipio": "Tarumã",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3554003",
+    "municipio": "Tatuí",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3554102",
+    "municipio": "Taubaté",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3554201",
+    "municipio": "Tejupá",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3554300",
+    "municipio": "Teodoro Sampaio",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3554409",
+    "municipio": "Terra Roxa",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3554508",
+    "municipio": "Tietê",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3554607",
+    "municipio": "Timburi",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3554656",
+    "municipio": "Torre de Pedra",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3554706",
+    "municipio": "Torrinha",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3554755",
+    "municipio": "Trabiju",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3554805",
+    "municipio": "Tremembé",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3554904",
+    "municipio": "Três Fronteiras",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3554953",
+    "municipio": "Tuiuti",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3555000",
+    "municipio": "Tupã",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3555109",
+    "municipio": "Tupi Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3555208",
+    "municipio": "Turiúba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3555307",
+    "municipio": "Turmalina",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3555356",
+    "municipio": "Ubarana",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3555406",
+    "municipio": "Ubatuba",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3555505",
+    "municipio": "Ubirajara",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3555604",
+    "municipio": "Uchoa",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3555703",
+    "municipio": "União Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3555802",
+    "municipio": "Urânia",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3555901",
+    "municipio": "Uru",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3556008",
+    "municipio": "Urupês",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3556107",
+    "municipio": "Valentim Gentil",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3556206",
+    "municipio": "Valinhos",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3556305",
+    "municipio": "Valparaíso",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3556354",
+    "municipio": "Vargem",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3556404",
+    "municipio": "Vargem Grande do Sul",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3556453",
+    "municipio": "Vargem Grande Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3556503",
+    "municipio": "Várzea Paulista",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3556602",
+    "municipio": "Vera Cruz",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3556701",
+    "municipio": "Vinhedo",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3556800",
+    "municipio": "Viradouro",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3556909",
+    "municipio": "Vista Alegre do Alto",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3556958",
+    "municipio": "Vitória Brasil",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3557006",
+    "municipio": "Votorantim",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3557105",
+    "municipio": "Votuporanga",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3557154",
+    "municipio": "Zacarias",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3557204",
+    "municipio": "Chavantes",
+    "uf": "SP"
+  },
+  {
+    "codigo": "3557303",
+    "municipio": "Estiva Gerbi",
+    "uf": "SP"
+  },
+  {
+    "codigo": "4100103",
+    "municipio": "Abatiá",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4100202",
+    "municipio": "Adrianópolis",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4100301",
+    "municipio": "Agudos do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4100400",
+    "municipio": "Almirante Tamandaré",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4100459",
+    "municipio": "Altamira do Paraná",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4100509",
+    "municipio": "Altônia",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4100608",
+    "municipio": "Alto Paraná",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4100707",
+    "municipio": "Alto Piquiri",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4100806",
+    "municipio": "Alvorada do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4100905",
+    "municipio": "Amaporã",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4101002",
+    "municipio": "Ampére",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4101051",
+    "municipio": "Anahy",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4101101",
+    "municipio": "Andirá",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4101150",
+    "municipio": "Ângulo",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4101200",
+    "municipio": "Antonina",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4101309",
+    "municipio": "Antônio Olinto",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4101408",
+    "municipio": "Apucarana",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4101507",
+    "municipio": "Arapongas",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4101606",
+    "municipio": "Arapoti",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4101655",
+    "municipio": "Arapuã",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4101705",
+    "municipio": "Araruna",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4101804",
+    "municipio": "Araucária",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4101853",
+    "municipio": "Ariranha do Ivaí",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4101903",
+    "municipio": "Assaí",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4102000",
+    "municipio": "Assis Chateaubriand",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4102109",
+    "municipio": "Astorga",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4102208",
+    "municipio": "Atalaia",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4102307",
+    "municipio": "Balsa Nova",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4102406",
+    "municipio": "Bandeirantes",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4102505",
+    "municipio": "Barbosa Ferraz",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4102604",
+    "municipio": "Barracão",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4102703",
+    "municipio": "Barra do Jacaré",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4102752",
+    "municipio": "Bela Vista da Caroba",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4102802",
+    "municipio": "Bela Vista do Paraíso",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4102901",
+    "municipio": "Bituruna",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103008",
+    "municipio": "Boa Esperança",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103024",
+    "municipio": "Boa Esperança do Iguaçu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103040",
+    "municipio": "Boa Ventura de São Roque",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103057",
+    "municipio": "Boa Vista da Aparecida",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103107",
+    "municipio": "Bocaiúva do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103156",
+    "municipio": "Bom Jesus do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103206",
+    "municipio": "Bom Sucesso",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103222",
+    "municipio": "Bom Sucesso do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103305",
+    "municipio": "Borrazópolis",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103354",
+    "municipio": "Braganey",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103370",
+    "municipio": "Brasilândia do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103404",
+    "municipio": "Cafeara",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103453",
+    "municipio": "Cafelândia",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103479",
+    "municipio": "Cafezal do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103503",
+    "municipio": "Califórnia",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103602",
+    "municipio": "Cambará",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103701",
+    "municipio": "Cambé",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103800",
+    "municipio": "Cambira",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103909",
+    "municipio": "Campina da Lagoa",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4103958",
+    "municipio": "Campina do Simão",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4104006",
+    "municipio": "Campina Grande do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4104055",
+    "municipio": "Campo Bonito",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4104105",
+    "municipio": "Campo do Tenente",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4104204",
+    "municipio": "Campo Largo",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4104253",
+    "municipio": "Campo Magro",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4104303",
+    "municipio": "Campo Mourão",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4104402",
+    "municipio": "Cândido de Abreu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4104428",
+    "municipio": "Candói",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4104451",
+    "municipio": "Cantagalo",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4104501",
+    "municipio": "Capanema",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4104600",
+    "municipio": "Capitão Leônidas Marques",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4104659",
+    "municipio": "Carambeí",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4104709",
+    "municipio": "Carlópolis",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4104808",
+    "municipio": "Cascavel",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4104907",
+    "municipio": "Castro",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4105003",
+    "municipio": "Catanduvas",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4105102",
+    "municipio": "Centenário do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4105201",
+    "municipio": "Cerro Azul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4105300",
+    "municipio": "Céu Azul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4105409",
+    "municipio": "Chopinzinho",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4105508",
+    "municipio": "Cianorte",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4105607",
+    "municipio": "Cidade Gaúcha",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4105706",
+    "municipio": "Clevelândia",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4105805",
+    "municipio": "Colombo",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4105904",
+    "municipio": "Colorado",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4106001",
+    "municipio": "Congonhinhas",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4106100",
+    "municipio": "Conselheiro Mairinck",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4106209",
+    "municipio": "Contenda",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4106308",
+    "municipio": "Corbélia",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4106407",
+    "municipio": "Cornélio Procópio",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4106456",
+    "municipio": "Coronel Domingos Soares",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4106506",
+    "municipio": "Coronel Vivida",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4106555",
+    "municipio": "Corumbataí do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4106571",
+    "municipio": "Cruzeiro do Iguaçu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4106605",
+    "municipio": "Cruzeiro do Oeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4106704",
+    "municipio": "Cruzeiro do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4106803",
+    "municipio": "Cruz Machado",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4106852",
+    "municipio": "Cruzmaltina",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4106902",
+    "municipio": "Curitiba",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107009",
+    "municipio": "Curiúva",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107108",
+    "municipio": "Diamante do Norte",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107124",
+    "municipio": "Diamante do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107157",
+    "municipio": "Diamante D'Oeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107207",
+    "municipio": "Dois Vizinhos",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107256",
+    "municipio": "Douradina",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107306",
+    "municipio": "Doutor Camargo",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107405",
+    "municipio": "Enéas Marques",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107504",
+    "municipio": "Engenheiro Beltrão",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107520",
+    "municipio": "Esperança Nova",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107538",
+    "municipio": "Entre Rios do Oeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107546",
+    "municipio": "Espigão Alto do Iguaçu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107553",
+    "municipio": "Farol",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107603",
+    "municipio": "Faxinal",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107652",
+    "municipio": "Fazenda Rio Grande",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107702",
+    "municipio": "Fênix",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107736",
+    "municipio": "Fernandes Pinheiro",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107751",
+    "municipio": "Figueira",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107801",
+    "municipio": "Floraí",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107850",
+    "municipio": "Flor da Serra do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4107900",
+    "municipio": "Floresta",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4108007",
+    "municipio": "Florestópolis",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4108106",
+    "municipio": "Flórida",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4108205",
+    "municipio": "Formosa do Oeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4108304",
+    "municipio": "Foz do Iguaçu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4108320",
+    "municipio": "Francisco Alves",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4108403",
+    "municipio": "Francisco Beltrão",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4108452",
+    "municipio": "Foz do Jordão",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4108502",
+    "municipio": "General Carneiro",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4108551",
+    "municipio": "Godoy Moreira",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4108601",
+    "municipio": "Goioerê",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4108650",
+    "municipio": "Goioxim",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4108700",
+    "municipio": "Grandes Rios",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4108809",
+    "municipio": "Guaíra",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4108908",
+    "municipio": "Guairaçá",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4108957",
+    "municipio": "Guamiranga",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4109005",
+    "municipio": "Guapirama",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4109104",
+    "municipio": "Guaporema",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4109203",
+    "municipio": "Guaraci",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4109302",
+    "municipio": "Guaraniaçu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4109401",
+    "municipio": "Guarapuava",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4109500",
+    "municipio": "Guaraqueçaba",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4109609",
+    "municipio": "Guaratuba",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4109658",
+    "municipio": "Honório Serpa",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4109708",
+    "municipio": "Ibaiti",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4109757",
+    "municipio": "Ibema",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4109807",
+    "municipio": "Ibiporã",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4109906",
+    "municipio": "Icaraíma",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4110003",
+    "municipio": "Iguaraçu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4110052",
+    "municipio": "Iguatu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4110078",
+    "municipio": "Imbaú",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4110102",
+    "municipio": "Imbituva",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4110201",
+    "municipio": "Inácio Martins",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4110300",
+    "municipio": "Inajá",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4110409",
+    "municipio": "Indianópolis",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4110508",
+    "municipio": "Ipiranga",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4110607",
+    "municipio": "Iporã",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4110656",
+    "municipio": "Iracema do Oeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4110706",
+    "municipio": "Irati",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4110805",
+    "municipio": "Iretama",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4110904",
+    "municipio": "Itaguajé",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4110953",
+    "municipio": "Itaipulândia",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4111001",
+    "municipio": "Itambaracá",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4111100",
+    "municipio": "Itambé",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4111209",
+    "municipio": "Itapejara d'Oeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4111258",
+    "municipio": "Itaperuçu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4111308",
+    "municipio": "Itaúna do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4111407",
+    "municipio": "Ivaí",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4111506",
+    "municipio": "Ivaiporã",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4111555",
+    "municipio": "Ivaté",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4111605",
+    "municipio": "Ivatuba",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4111704",
+    "municipio": "Jaboti",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4111803",
+    "municipio": "Jacarezinho",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4111902",
+    "municipio": "Jaguapitã",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4112009",
+    "municipio": "Jaguariaíva",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4112108",
+    "municipio": "Jandaia do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4112207",
+    "municipio": "Janiópolis",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4112306",
+    "municipio": "Japira",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4112405",
+    "municipio": "Japurá",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4112504",
+    "municipio": "Jardim Alegre",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4112603",
+    "municipio": "Jardim Olinda",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4112702",
+    "municipio": "Jataizinho",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4112751",
+    "municipio": "Jesuítas",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4112801",
+    "municipio": "Joaquim Távora",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4112900",
+    "municipio": "Jundiaí do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4112959",
+    "municipio": "Juranda",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4113007",
+    "municipio": "Jussara",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4113106",
+    "municipio": "Kaloré",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4113205",
+    "municipio": "Lapa",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4113254",
+    "municipio": "Laranjal",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4113304",
+    "municipio": "Laranjeiras do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4113403",
+    "municipio": "Leópolis",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4113429",
+    "municipio": "Lidianópolis",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4113452",
+    "municipio": "Lindoeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4113502",
+    "municipio": "Loanda",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4113601",
+    "municipio": "Lobato",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4113700",
+    "municipio": "Londrina",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4113734",
+    "municipio": "Luiziana",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4113759",
+    "municipio": "Lunardelli",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4113809",
+    "municipio": "Lupionópolis",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4113908",
+    "municipio": "Mallet",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4114005",
+    "municipio": "Mamborê",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4114104",
+    "municipio": "Mandaguaçu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4114203",
+    "municipio": "Mandaguari",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4114302",
+    "municipio": "Mandirituba",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4114351",
+    "municipio": "Manfrinópolis",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4114401",
+    "municipio": "Mangueirinha",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4114500",
+    "municipio": "Manoel Ribas",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4114609",
+    "municipio": "Marechal Cândido Rondon",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4114708",
+    "municipio": "Maria Helena",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4114807",
+    "municipio": "Marialva",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4114906",
+    "municipio": "Marilândia do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4115002",
+    "municipio": "Marilena",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4115101",
+    "municipio": "Mariluz",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4115200",
+    "municipio": "Maringá",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4115309",
+    "municipio": "Mariópolis",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4115358",
+    "municipio": "Maripá",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4115408",
+    "municipio": "Marmeleiro",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4115457",
+    "municipio": "Marquinho",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4115507",
+    "municipio": "Marumbi",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4115606",
+    "municipio": "Matelândia",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4115705",
+    "municipio": "Matinhos",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4115739",
+    "municipio": "Mato Rico",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4115754",
+    "municipio": "Mauá da Serra",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4115804",
+    "municipio": "Medianeira",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4115853",
+    "municipio": "Mercedes",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4115903",
+    "municipio": "Mirador",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4116000",
+    "municipio": "Miraselva",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4116059",
+    "municipio": "Missal",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4116109",
+    "municipio": "Moreira Sales",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4116208",
+    "municipio": "Morretes",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4116307",
+    "municipio": "Munhoz de Melo",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4116406",
+    "municipio": "Nossa Senhora das Graças",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4116505",
+    "municipio": "Nova Aliança do Ivaí",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4116604",
+    "municipio": "Nova América da Colina",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4116703",
+    "municipio": "Nova Aurora",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4116802",
+    "municipio": "Nova Cantu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4116901",
+    "municipio": "Nova Esperança",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4116950",
+    "municipio": "Nova Esperança do Sudoeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4117008",
+    "municipio": "Nova Fátima",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4117057",
+    "municipio": "Nova Laranjeiras",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4117107",
+    "municipio": "Nova Londrina",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4117206",
+    "municipio": "Nova Olímpia",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4117214",
+    "municipio": "Nova Santa Bárbara",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4117222",
+    "municipio": "Nova Santa Rosa",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4117255",
+    "municipio": "Nova Prata do Iguaçu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4117271",
+    "municipio": "Nova Tebas",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4117297",
+    "municipio": "Novo Itacolomi",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4117305",
+    "municipio": "Ortigueira",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4117404",
+    "municipio": "Ourizona",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4117453",
+    "municipio": "Ouro Verde do Oeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4117503",
+    "municipio": "Paiçandu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4117602",
+    "municipio": "Palmas",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4117701",
+    "municipio": "Palmeira",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4117800",
+    "municipio": "Palmital",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4117909",
+    "municipio": "Palotina",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4118006",
+    "municipio": "Paraíso do Norte",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4118105",
+    "municipio": "Paranacity",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4118204",
+    "municipio": "Paranaguá",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4118303",
+    "municipio": "Paranapoema",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4118402",
+    "municipio": "Paranavaí",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4118451",
+    "municipio": "Pato Bragado",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4118501",
+    "municipio": "Pato Branco",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4118600",
+    "municipio": "Paula Freitas",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4118709",
+    "municipio": "Paulo Frontin",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4118808",
+    "municipio": "Peabiru",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4118857",
+    "municipio": "Perobal",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4118907",
+    "municipio": "Pérola",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4119004",
+    "municipio": "Pérola d'Oeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4119103",
+    "municipio": "Piên",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4119152",
+    "municipio": "Pinhais",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4119202",
+    "municipio": "Pinhalão",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4119251",
+    "municipio": "Pinhal de São Bento",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4119301",
+    "municipio": "Pinhão",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4119400",
+    "municipio": "Piraí do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4119509",
+    "municipio": "Piraquara",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4119608",
+    "municipio": "Pitanga",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4119657",
+    "municipio": "Pitangueiras",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4119707",
+    "municipio": "Planaltina do Paraná",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4119806",
+    "municipio": "Planalto",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4119905",
+    "municipio": "Ponta Grossa",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4119954",
+    "municipio": "Pontal do Paraná",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4120002",
+    "municipio": "Porecatu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4120101",
+    "municipio": "Porto Amazonas",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4120150",
+    "municipio": "Porto Barreiro",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4120200",
+    "municipio": "Porto Rico",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4120309",
+    "municipio": "Porto Vitória",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4120333",
+    "municipio": "Prado Ferreira",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4120358",
+    "municipio": "Pranchita",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4120408",
+    "municipio": "Presidente Castelo Branco",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4120507",
+    "municipio": "Primeiro de Maio",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4120606",
+    "municipio": "Prudentópolis",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4120655",
+    "municipio": "Quarto Centenário",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4120705",
+    "municipio": "Quatiguá",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4120804",
+    "municipio": "Quatro Barras",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4120853",
+    "municipio": "Quatro Pontes",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4120903",
+    "municipio": "Quedas do Iguaçu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4121000",
+    "municipio": "Querência do Norte",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4121109",
+    "municipio": "Quinta do Sol",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4121208",
+    "municipio": "Quitandinha",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4121257",
+    "municipio": "Ramilândia",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4121307",
+    "municipio": "Rancho Alegre",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4121356",
+    "municipio": "Rancho Alegre D'Oeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4121406",
+    "municipio": "Realeza",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4121505",
+    "municipio": "Rebouças",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4121604",
+    "municipio": "Renascença",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4121703",
+    "municipio": "Reserva",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4121752",
+    "municipio": "Reserva do Iguaçu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4121802",
+    "municipio": "Ribeirão Claro",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4121901",
+    "municipio": "Ribeirão do Pinhal",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4122008",
+    "municipio": "Rio Azul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4122107",
+    "municipio": "Rio Bom",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4122156",
+    "municipio": "Rio Bonito do Iguaçu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4122172",
+    "municipio": "Rio Branco do Ivaí",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4122206",
+    "municipio": "Rio Branco do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4122305",
+    "municipio": "Rio Negro",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4122404",
+    "municipio": "Rolândia",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4122503",
+    "municipio": "Roncador",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4122602",
+    "municipio": "Rondon",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4122651",
+    "municipio": "Rosário do Ivaí",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4122701",
+    "municipio": "Sabáudia",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4122800",
+    "municipio": "Salgado Filho",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4122909",
+    "municipio": "Salto do Itararé",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4123006",
+    "municipio": "Salto do Lontra",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4123105",
+    "municipio": "Santa Amélia",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4123204",
+    "municipio": "Santa Cecília do Pavão",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4123303",
+    "municipio": "Santa Cruz de Monte Castelo",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4123402",
+    "municipio": "Santa Fé",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4123501",
+    "municipio": "Santa Helena",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4123600",
+    "municipio": "Santa Inês",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4123709",
+    "municipio": "Santa Isabel do Ivaí",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4123808",
+    "municipio": "Santa Izabel do Oeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4123824",
+    "municipio": "Santa Lúcia",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4123857",
+    "municipio": "Santa Maria do Oeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4123907",
+    "municipio": "Santa Mariana",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4123956",
+    "municipio": "Santa Mônica",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4124004",
+    "municipio": "Santana do Itararé",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4124020",
+    "municipio": "Santa Tereza do Oeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4124053",
+    "municipio": "Santa Terezinha de Itaipu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4124103",
+    "municipio": "Santo Antônio da Platina",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4124202",
+    "municipio": "Santo Antônio do Caiuá",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4124301",
+    "municipio": "Santo Antônio do Paraíso",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4124400",
+    "municipio": "Santo Antônio do Sudoeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4124509",
+    "municipio": "Santo Inácio",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4124608",
+    "municipio": "São Carlos do Ivaí",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4124707",
+    "municipio": "São Jerônimo da Serra",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4124806",
+    "municipio": "São João",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4124905",
+    "municipio": "São João do Caiuá",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4125001",
+    "municipio": "São João do Ivaí",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4125100",
+    "municipio": "São João do Triunfo",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4125209",
+    "municipio": "São Jorge d'Oeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4125308",
+    "municipio": "São Jorge do Ivaí",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4125357",
+    "municipio": "São Jorge do Patrocínio",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4125407",
+    "municipio": "São José da Boa Vista",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4125456",
+    "municipio": "São José das Palmeiras",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4125506",
+    "municipio": "São José dos Pinhais",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4125555",
+    "municipio": "São Manoel do Paraná",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4125605",
+    "municipio": "São Mateus do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4125704",
+    "municipio": "São Miguel do Iguaçu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4125753",
+    "municipio": "São Pedro do Iguaçu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4125803",
+    "municipio": "São Pedro do Ivaí",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4125902",
+    "municipio": "São Pedro do Paraná",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4126009",
+    "municipio": "São Sebastião da Amoreira",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4126108",
+    "municipio": "São Tomé",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4126207",
+    "municipio": "Sapopema",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4126256",
+    "municipio": "Sarandi",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4126272",
+    "municipio": "Saudade do Iguaçu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4126306",
+    "municipio": "Sengés",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4126355",
+    "municipio": "Serranópolis do Iguaçu",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4126405",
+    "municipio": "Sertaneja",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4126504",
+    "municipio": "Sertanópolis",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4126603",
+    "municipio": "Siqueira Campos",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4126652",
+    "municipio": "Sulina",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4126678",
+    "municipio": "Tamarana",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4126702",
+    "municipio": "Tamboara",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4126801",
+    "municipio": "Tapejara",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4126900",
+    "municipio": "Tapira",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4127007",
+    "municipio": "Teixeira Soares",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4127106",
+    "municipio": "Telêmaco Borba",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4127205",
+    "municipio": "Terra Boa",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4127304",
+    "municipio": "Terra Rica",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4127403",
+    "municipio": "Terra Roxa",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4127502",
+    "municipio": "Tibagi",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4127601",
+    "municipio": "Tijucas do Sul",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4127700",
+    "municipio": "Toledo",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4127809",
+    "municipio": "Tomazina",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4127858",
+    "municipio": "Três Barras do Paraná",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4127882",
+    "municipio": "Tunas do Paraná",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4127908",
+    "municipio": "Tuneiras do Oeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4127957",
+    "municipio": "Tupãssi",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4127965",
+    "municipio": "Turvo",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4128005",
+    "municipio": "Ubiratã",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4128104",
+    "municipio": "Umuarama",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4128203",
+    "municipio": "União da Vitória",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4128302",
+    "municipio": "Uniflor",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4128401",
+    "municipio": "Uraí",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4128500",
+    "municipio": "Wenceslau Braz",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4128534",
+    "municipio": "Ventania",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4128559",
+    "municipio": "Vera Cruz do Oeste",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4128609",
+    "municipio": "Verê",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4128625",
+    "municipio": "Alto Paraíso",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4128633",
+    "municipio": "Doutor Ulysses",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4128658",
+    "municipio": "Virmond",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4128708",
+    "municipio": "Vitorino",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4128807",
+    "municipio": "Xambrê",
+    "uf": "PR"
+  },
+  {
+    "codigo": "4200051",
+    "municipio": "Abdon Batista",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4200101",
+    "municipio": "Abelardo Luz",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4200200",
+    "municipio": "Agrolândia",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4200309",
+    "municipio": "Agronômica",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4200408",
+    "municipio": "Água Doce",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4200507",
+    "municipio": "Águas de Chapecó",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4200556",
+    "municipio": "Águas Frias",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4200606",
+    "municipio": "Águas Mornas",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4200705",
+    "municipio": "Alfredo Wagner",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4200754",
+    "municipio": "Alto Bela Vista",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4200804",
+    "municipio": "Anchieta",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4200903",
+    "municipio": "Angelina",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4201000",
+    "municipio": "Anita Garibaldi",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4201109",
+    "municipio": "Anitápolis",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4201208",
+    "municipio": "Antônio Carlos",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4201257",
+    "municipio": "Apiúna",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4201273",
+    "municipio": "Arabutã",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4201307",
+    "municipio": "Araquari",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4201406",
+    "municipio": "Araranguá",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4201505",
+    "municipio": "Armazém",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4201604",
+    "municipio": "Arroio Trinta",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4201653",
+    "municipio": "Arvoredo",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4201703",
+    "municipio": "Ascurra",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4201802",
+    "municipio": "Atalanta",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4201901",
+    "municipio": "Aurora",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4201950",
+    "municipio": "Balneário Arroio do Silva",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202008",
+    "municipio": "Balneário Camboriú",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202057",
+    "municipio": "Balneário Barra do Sul",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202073",
+    "municipio": "Balneário Gaivota",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202081",
+    "municipio": "Bandeirante",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202099",
+    "municipio": "Barra Bonita",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202107",
+    "municipio": "Barra Velha",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202131",
+    "municipio": "Bela Vista do Toldo",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202156",
+    "municipio": "Belmonte",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202206",
+    "municipio": "Benedito Novo",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202305",
+    "municipio": "Biguaçu",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202404",
+    "municipio": "Blumenau",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202438",
+    "municipio": "Bocaina do Sul",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202453",
+    "municipio": "Bombinhas",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202503",
+    "municipio": "Bom Jardim da Serra",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202537",
+    "municipio": "Bom Jesus",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202578",
+    "municipio": "Bom Jesus do Oeste",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202602",
+    "municipio": "Bom Retiro",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202701",
+    "municipio": "Botuverá",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202800",
+    "municipio": "Braço do Norte",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202859",
+    "municipio": "Braço do Trombudo",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202875",
+    "municipio": "Brunópolis",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4202909",
+    "municipio": "Brusque",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4203006",
+    "municipio": "Caçador",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4203105",
+    "municipio": "Caibi",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4203154",
+    "municipio": "Calmon",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4203204",
+    "municipio": "Camboriú",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4203253",
+    "municipio": "Capão Alto",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4203303",
+    "municipio": "Campo Alegre",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4203402",
+    "municipio": "Campo Belo do Sul",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4203501",
+    "municipio": "Campo Erê",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4203600",
+    "municipio": "Campos Novos",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4203709",
+    "municipio": "Canelinha",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4203808",
+    "municipio": "Canoinhas",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4203907",
+    "municipio": "Capinzal",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4203956",
+    "municipio": "Capivari de Baixo",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204004",
+    "municipio": "Catanduvas",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204103",
+    "municipio": "Caxambu do Sul",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204152",
+    "municipio": "Celso Ramos",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204178",
+    "municipio": "Cerro Negro",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204194",
+    "municipio": "Chapadão do Lageado",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204202",
+    "municipio": "Chapecó",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204251",
+    "municipio": "Cocal do Sul",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204301",
+    "municipio": "Concórdia",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204350",
+    "municipio": "Cordilheira Alta",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204400",
+    "municipio": "Coronel Freitas",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204459",
+    "municipio": "Coronel Martins",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204509",
+    "municipio": "Corupá",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204558",
+    "municipio": "Correia Pinto",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204608",
+    "municipio": "Criciúma",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204707",
+    "municipio": "Cunha Porã",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204756",
+    "municipio": "Cunhataí",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204806",
+    "municipio": "Curitibanos",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4204905",
+    "municipio": "Descanso",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4205001",
+    "municipio": "Dionísio Cerqueira",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4205100",
+    "municipio": "Dona Emma",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4205159",
+    "municipio": "Doutor Pedrinho",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4205175",
+    "municipio": "Entre Rios",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4205191",
+    "municipio": "Ermo",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4205209",
+    "municipio": "Erval Velho",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4205308",
+    "municipio": "Faxinal dos Guedes",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4205357",
+    "municipio": "Flor do Sertão",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4205407",
+    "municipio": "Florianópolis",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4205431",
+    "municipio": "Formosa do Sul",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4205456",
+    "municipio": "Forquilhinha",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4205506",
+    "municipio": "Fraiburgo",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4205555",
+    "municipio": "Frei Rogério",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4205605",
+    "municipio": "Galvão",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4205704",
+    "municipio": "Garopaba",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4205803",
+    "municipio": "Garuva",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4205902",
+    "municipio": "Gaspar",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4206009",
+    "municipio": "Governador Celso Ramos",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4206108",
+    "municipio": "Grão-Pará",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4206207",
+    "municipio": "Gravatal",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4206306",
+    "municipio": "Guabiruba",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4206405",
+    "municipio": "Guaraciaba",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4206504",
+    "municipio": "Guaramirim",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4206603",
+    "municipio": "Guarujá do Sul",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4206652",
+    "municipio": "Guatambú",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4206702",
+    "municipio": "Herval d'Oeste",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4206751",
+    "municipio": "Ibiam",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4206801",
+    "municipio": "Ibicaré",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4206900",
+    "municipio": "Ibirama",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4207007",
+    "municipio": "Içara",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4207106",
+    "municipio": "Ilhota",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4207205",
+    "municipio": "Imaruí",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4207304",
+    "municipio": "Imbituba",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4207403",
+    "municipio": "Imbuia",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4207502",
+    "municipio": "Indaial",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4207577",
+    "municipio": "Iomerê",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4207601",
+    "municipio": "Ipira",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4207650",
+    "municipio": "Iporã do Oeste",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4207684",
+    "municipio": "Ipuaçu",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4207700",
+    "municipio": "Ipumirim",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4207759",
+    "municipio": "Iraceminha",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4207809",
+    "municipio": "Irani",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4207858",
+    "municipio": "Irati",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4207908",
+    "municipio": "Irineópolis",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4208005",
+    "municipio": "Itá",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4208104",
+    "municipio": "Itaiópolis",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4208203",
+    "municipio": "Itajaí",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4208302",
+    "municipio": "Itapema",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4208401",
+    "municipio": "Itapiranga",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4208450",
+    "municipio": "Itapoá",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4208500",
+    "municipio": "Ituporanga",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4208609",
+    "municipio": "Jaborá",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4208708",
+    "municipio": "Jacinto Machado",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4208807",
+    "municipio": "Jaguaruna",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4208906",
+    "municipio": "Jaraguá do Sul",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4208955",
+    "municipio": "Jardinópolis",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4209003",
+    "municipio": "Joaçaba",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4209102",
+    "municipio": "Joinville",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4209151",
+    "municipio": "José Boiteux",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4209177",
+    "municipio": "Jupiá",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4209201",
+    "municipio": "Lacerdópolis",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4209300",
+    "municipio": "Lages",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4209409",
+    "municipio": "Laguna",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4209458",
+    "municipio": "Lajeado Grande",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4209508",
+    "municipio": "Laurentino",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4209607",
+    "municipio": "Lauro Müller",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4209706",
+    "municipio": "Lebon Régis",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4209805",
+    "municipio": "Leoberto Leal",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4209854",
+    "municipio": "Lindóia do Sul",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4209904",
+    "municipio": "Lontras",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4210001",
+    "municipio": "Luiz Alves",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4210035",
+    "municipio": "Luzerna",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4210050",
+    "municipio": "Macieira",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4210100",
+    "municipio": "Mafra",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4210209",
+    "municipio": "Major Gercino",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4210308",
+    "municipio": "Major Vieira",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4210407",
+    "municipio": "Maracajá",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4210506",
+    "municipio": "Maravilha",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4210555",
+    "municipio": "Marema",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4210605",
+    "municipio": "Massaranduba",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4210704",
+    "municipio": "Matos Costa",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4210803",
+    "municipio": "Meleiro",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4210852",
+    "municipio": "Mirim Doce",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4210902",
+    "municipio": "Modelo",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211009",
+    "municipio": "Mondaí",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211058",
+    "municipio": "Monte Carlo",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211108",
+    "municipio": "Monte Castelo",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211207",
+    "municipio": "Morro da Fumaça",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211256",
+    "municipio": "Morro Grande",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211306",
+    "municipio": "Navegantes",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211405",
+    "municipio": "Nova Erechim",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211454",
+    "municipio": "Nova Itaberaba",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211504",
+    "municipio": "Nova Trento",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211603",
+    "municipio": "Nova Veneza",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211652",
+    "municipio": "Novo Horizonte",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211702",
+    "municipio": "Orleans",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211751",
+    "municipio": "Otacílio Costa",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211801",
+    "municipio": "Ouro",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211850",
+    "municipio": "Ouro Verde",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211876",
+    "municipio": "Paial",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211892",
+    "municipio": "Painel",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4211900",
+    "municipio": "Palhoça",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4212007",
+    "municipio": "Palma Sola",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4212056",
+    "municipio": "Palmeira",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4212106",
+    "municipio": "Palmitos",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4212205",
+    "municipio": "Papanduva",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4212239",
+    "municipio": "Paraíso",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4212254",
+    "municipio": "Passo de Torres",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4212270",
+    "municipio": "Passos Maia",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4212304",
+    "municipio": "Paulo Lopes",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4212403",
+    "municipio": "Pedras Grandes",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4212502",
+    "municipio": "Penha",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4212601",
+    "municipio": "Peritiba",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4212650",
+    "municipio": "Pescaria Brava",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4212700",
+    "municipio": "Petrolândia",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4212809",
+    "municipio": "Balneário Piçarras",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4212908",
+    "municipio": "Pinhalzinho",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4213005",
+    "municipio": "Pinheiro Preto",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4213104",
+    "municipio": "Piratuba",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4213153",
+    "municipio": "Planalto Alegre",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4213203",
+    "municipio": "Pomerode",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4213302",
+    "municipio": "Ponte Alta",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4213351",
+    "municipio": "Ponte Alta do Norte",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4213401",
+    "municipio": "Ponte Serrada",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4213500",
+    "municipio": "Porto Belo",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4213609",
+    "municipio": "Porto União",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4213708",
+    "municipio": "Pouso Redondo",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4213807",
+    "municipio": "Praia Grande",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4213906",
+    "municipio": "Presidente Castello Branco",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4214003",
+    "municipio": "Presidente Getúlio",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4214102",
+    "municipio": "Presidente Nereu",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4214151",
+    "municipio": "Princesa",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4214201",
+    "municipio": "Quilombo",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4214300",
+    "municipio": "Rancho Queimado",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4214409",
+    "municipio": "Rio das Antas",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4214508",
+    "municipio": "Rio do Campo",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4214607",
+    "municipio": "Rio do Oeste",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4214706",
+    "municipio": "Rio dos Cedros",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4214805",
+    "municipio": "Rio do Sul",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4214904",
+    "municipio": "Rio Fortuna",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215000",
+    "municipio": "Rio Negrinho",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215059",
+    "municipio": "Rio Rufino",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215075",
+    "municipio": "Riqueza",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215109",
+    "municipio": "Rodeio",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215208",
+    "municipio": "Romelândia",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215307",
+    "municipio": "Salete",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215356",
+    "municipio": "Saltinho",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215406",
+    "municipio": "Salto Veloso",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215455",
+    "municipio": "Sangão",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215505",
+    "municipio": "Santa Cecília",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215554",
+    "municipio": "Santa Helena",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215604",
+    "municipio": "Santa Rosa de Lima",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215653",
+    "municipio": "Santa Rosa do Sul",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215679",
+    "municipio": "Santa Terezinha",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215687",
+    "municipio": "Santa Terezinha do Progresso",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215695",
+    "municipio": "Santiago do Sul",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215703",
+    "municipio": "Santo Amaro da Imperatriz",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215752",
+    "municipio": "São Bernardino",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215802",
+    "municipio": "São Bento do Sul",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4215901",
+    "municipio": "São Bonifácio",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4216008",
+    "municipio": "São Carlos",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4216057",
+    "municipio": "São Cristóvão do Sul",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4216107",
+    "municipio": "São Domingos",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4216206",
+    "municipio": "São Francisco do Sul",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4216255",
+    "municipio": "São João do Oeste",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4216305",
+    "municipio": "São João Batista",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4216354",
+    "municipio": "São João do Itaperiú",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4216404",
+    "municipio": "São João do Sul",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4216503",
+    "municipio": "São Joaquim",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4216602",
+    "municipio": "São José",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4216701",
+    "municipio": "São José do Cedro",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4216800",
+    "municipio": "São José do Cerrito",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4216909",
+    "municipio": "São Lourenço do Oeste",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4217006",
+    "municipio": "São Ludgero",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4217105",
+    "municipio": "São Martinho",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4217154",
+    "municipio": "São Miguel da Boa Vista",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4217204",
+    "municipio": "São Miguel do Oeste",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4217253",
+    "municipio": "São Pedro de Alcântara",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4217303",
+    "municipio": "Saudades",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4217402",
+    "municipio": "Schroeder",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4217501",
+    "municipio": "Seara",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4217550",
+    "municipio": "Serra Alta",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4217600",
+    "municipio": "Siderópolis",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4217709",
+    "municipio": "Sombrio",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4217758",
+    "municipio": "Sul Brasil",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4217808",
+    "municipio": "Taió",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4217907",
+    "municipio": "Tangará",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4217956",
+    "municipio": "Tigrinhos",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4218004",
+    "municipio": "Tijucas",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4218103",
+    "municipio": "Timbé do Sul",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4218202",
+    "municipio": "Timbó",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4218251",
+    "municipio": "Timbó Grande",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4218301",
+    "municipio": "Três Barras",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4218350",
+    "municipio": "Treviso",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4218400",
+    "municipio": "Treze de Maio",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4218509",
+    "municipio": "Treze Tílias",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4218608",
+    "municipio": "Trombudo Central",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4218707",
+    "municipio": "Tubarão",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4218756",
+    "municipio": "Tunápolis",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4218806",
+    "municipio": "Turvo",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4218855",
+    "municipio": "União do Oeste",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4218905",
+    "municipio": "Urubici",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4218954",
+    "municipio": "Urupema",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4219002",
+    "municipio": "Urussanga",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4219101",
+    "municipio": "Vargeão",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4219150",
+    "municipio": "Vargem",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4219176",
+    "municipio": "Vargem Bonita",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4219200",
+    "municipio": "Vidal Ramos",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4219309",
+    "municipio": "Videira",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4219358",
+    "municipio": "Vitor Meireles",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4219408",
+    "municipio": "Witmarsum",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4219507",
+    "municipio": "Xanxerê",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4219606",
+    "municipio": "Xavantina",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4219705",
+    "municipio": "Xaxim",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4219853",
+    "municipio": "Zortéa",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4220000",
+    "municipio": "Balneário Rincão",
+    "uf": "SC"
+  },
+  {
+    "codigo": "4300034",
+    "municipio": "Aceguá",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300059",
+    "municipio": "Água Santa",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300109",
+    "municipio": "Agudo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300208",
+    "municipio": "Ajuricaba",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300307",
+    "municipio": "Alecrim",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300406",
+    "municipio": "Alegrete",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300455",
+    "municipio": "Alegria",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300471",
+    "municipio": "Almirante Tamandaré do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300505",
+    "municipio": "Alpestre",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300554",
+    "municipio": "Alto Alegre",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300570",
+    "municipio": "Alto Feliz",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300604",
+    "municipio": "Alvorada",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300638",
+    "municipio": "Amaral Ferrador",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300646",
+    "municipio": "Ametista do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300661",
+    "municipio": "André da Rocha",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300703",
+    "municipio": "Anta Gorda",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300802",
+    "municipio": "Antônio Prado",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300851",
+    "municipio": "Arambaré",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300877",
+    "municipio": "Araricá",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4300901",
+    "municipio": "Aratiba",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301008",
+    "municipio": "Arroio do Meio",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301057",
+    "municipio": "Arroio do Sal",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301073",
+    "municipio": "Arroio do Padre",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301107",
+    "municipio": "Arroio dos Ratos",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301206",
+    "municipio": "Arroio do Tigre",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301305",
+    "municipio": "Arroio Grande",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301404",
+    "municipio": "Arvorezinha",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301503",
+    "municipio": "Augusto Pestana",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301552",
+    "municipio": "Áurea",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301602",
+    "municipio": "Bagé",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301636",
+    "municipio": "Balneário Pinhal",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301651",
+    "municipio": "Barão",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301701",
+    "municipio": "Barão de Cotegipe",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301750",
+    "municipio": "Barão do Triunfo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301800",
+    "municipio": "Barracão",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301859",
+    "municipio": "Barra do Guarita",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301875",
+    "municipio": "Barra do Quaraí",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301909",
+    "municipio": "Barra do Ribeiro",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301925",
+    "municipio": "Barra do Rio Azul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4301958",
+    "municipio": "Barra Funda",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302006",
+    "municipio": "Barros Cassal",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302055",
+    "municipio": "Benjamin Constant do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302105",
+    "municipio": "Bento Gonçalves",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302154",
+    "municipio": "Boa Vista das Missões",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302204",
+    "municipio": "Boa Vista do Buricá",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302220",
+    "municipio": "Boa Vista do Cadeado",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302238",
+    "municipio": "Boa Vista do Incra",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302253",
+    "municipio": "Boa Vista do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302303",
+    "municipio": "Bom Jesus",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302352",
+    "municipio": "Bom Princípio",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302378",
+    "municipio": "Bom Progresso",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302402",
+    "municipio": "Bom Retiro do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302451",
+    "municipio": "Boqueirão do Leão",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302501",
+    "municipio": "Bossoroca",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302584",
+    "municipio": "Bozano",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302600",
+    "municipio": "Braga",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302659",
+    "municipio": "Brochier",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302709",
+    "municipio": "Butiá",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302808",
+    "municipio": "Caçapava do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4302907",
+    "municipio": "Cacequi",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4303004",
+    "municipio": "Cachoeira do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4303103",
+    "municipio": "Cachoeirinha",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4303202",
+    "municipio": "Cacique Doble",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4303301",
+    "municipio": "Caibaté",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4303400",
+    "municipio": "Caiçara",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4303509",
+    "municipio": "Camaquã",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4303558",
+    "municipio": "Camargo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4303608",
+    "municipio": "Cambará do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4303673",
+    "municipio": "Campestre da Serra",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4303707",
+    "municipio": "Campina das Missões",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4303806",
+    "municipio": "Campinas do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4303905",
+    "municipio": "Campo Bom",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304002",
+    "municipio": "Campo Novo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304101",
+    "municipio": "Campos Borges",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304200",
+    "municipio": "Candelária",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304309",
+    "municipio": "Cândido Godói",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304358",
+    "municipio": "Candiota",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304408",
+    "municipio": "Canela",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304507",
+    "municipio": "Canguçu",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304606",
+    "municipio": "Canoas",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304614",
+    "municipio": "Canudos do Vale",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304622",
+    "municipio": "Capão Bonito do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304630",
+    "municipio": "Capão da Canoa",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304655",
+    "municipio": "Capão do Cipó",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304663",
+    "municipio": "Capão do Leão",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304671",
+    "municipio": "Capivari do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304689",
+    "municipio": "Capela de Santana",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304697",
+    "municipio": "Capitão",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304705",
+    "municipio": "Carazinho",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304713",
+    "municipio": "Caraá",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304804",
+    "municipio": "Carlos Barbosa",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304853",
+    "municipio": "Carlos Gomes",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304903",
+    "municipio": "Casca",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4304952",
+    "municipio": "Caseiros",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305009",
+    "municipio": "Catuípe",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305108",
+    "municipio": "Caxias do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305116",
+    "municipio": "Centenário",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305124",
+    "municipio": "Cerrito",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305132",
+    "municipio": "Cerro Branco",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305157",
+    "municipio": "Cerro Grande",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305173",
+    "municipio": "Cerro Grande do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305207",
+    "municipio": "Cerro Largo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305306",
+    "municipio": "Chapada",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305355",
+    "municipio": "Charqueadas",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305371",
+    "municipio": "Charrua",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305405",
+    "municipio": "Chiapetta",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305439",
+    "municipio": "Chuí",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305447",
+    "municipio": "Chuvisca",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305454",
+    "municipio": "Cidreira",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305504",
+    "municipio": "Ciríaco",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305587",
+    "municipio": "Colinas",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305603",
+    "municipio": "Colorado",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305702",
+    "municipio": "Condor",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305801",
+    "municipio": "Constantina",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305835",
+    "municipio": "Coqueiro Baixo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305850",
+    "municipio": "Coqueiros do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305871",
+    "municipio": "Coronel Barros",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305900",
+    "municipio": "Coronel Bicaco",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305934",
+    "municipio": "Coronel Pilar",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305959",
+    "municipio": "Cotiporã",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4305975",
+    "municipio": "Coxilha",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306007",
+    "municipio": "Crissiumal",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306056",
+    "municipio": "Cristal",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306072",
+    "municipio": "Cristal do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306106",
+    "municipio": "Cruz Alta",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306130",
+    "municipio": "Cruzaltense",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306205",
+    "municipio": "Cruzeiro do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306304",
+    "municipio": "David Canabarro",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306320",
+    "municipio": "Derrubadas",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306353",
+    "municipio": "Dezesseis de Novembro",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306379",
+    "municipio": "Dilermando de Aguiar",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306403",
+    "municipio": "Dois Irmãos",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306429",
+    "municipio": "Dois Irmãos das Missões",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306452",
+    "municipio": "Dois Lajeados",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306502",
+    "municipio": "Dom Feliciano",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306551",
+    "municipio": "Dom Pedro de Alcântara",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306601",
+    "municipio": "Dom Pedrito",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306700",
+    "municipio": "Dona Francisca",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306734",
+    "municipio": "Doutor Maurício Cardoso",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306759",
+    "municipio": "Doutor Ricardo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306767",
+    "municipio": "Eldorado do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306809",
+    "municipio": "Encantado",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306908",
+    "municipio": "Encruzilhada do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306924",
+    "municipio": "Engenho Velho",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306932",
+    "municipio": "Entre-Ijuís",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306957",
+    "municipio": "Entre Rios do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4306973",
+    "municipio": "Erebango",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4307005",
+    "municipio": "Erechim",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4307054",
+    "municipio": "Ernestina",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4307104",
+    "municipio": "Herval",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4307203",
+    "municipio": "Erval Grande",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4307302",
+    "municipio": "Erval Seco",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4307401",
+    "municipio": "Esmeralda",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4307450",
+    "municipio": "Esperança do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4307500",
+    "municipio": "Espumoso",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4307559",
+    "municipio": "Estação",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4307609",
+    "municipio": "Estância Velha",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4307708",
+    "municipio": "Esteio",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4307807",
+    "municipio": "Estrela",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4307815",
+    "municipio": "Estrela Velha",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4307831",
+    "municipio": "Eugênio de Castro",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4307864",
+    "municipio": "Fagundes Varela",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4307906",
+    "municipio": "Farroupilha",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4308003",
+    "municipio": "Faxinal do Soturno",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4308052",
+    "municipio": "Faxinalzinho",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4308078",
+    "municipio": "Fazenda Vilanova",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4308102",
+    "municipio": "Feliz",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4308201",
+    "municipio": "Flores da Cunha",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4308250",
+    "municipio": "Floriano Peixoto",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4308300",
+    "municipio": "Fontoura Xavier",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4308409",
+    "municipio": "Formigueiro",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4308433",
+    "municipio": "Forquetinha",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4308458",
+    "municipio": "Fortaleza dos Valos",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4308508",
+    "municipio": "Frederico Westphalen",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4308607",
+    "municipio": "Garibaldi",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4308656",
+    "municipio": "Garruchos",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4308706",
+    "municipio": "Gaurama",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4308805",
+    "municipio": "General Câmara",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4308854",
+    "municipio": "Gentil",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4308904",
+    "municipio": "Getúlio Vargas",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309001",
+    "municipio": "Giruá",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309050",
+    "municipio": "Glorinha",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309100",
+    "municipio": "Gramado",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309126",
+    "municipio": "Gramado dos Loureiros",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309159",
+    "municipio": "Gramado Xavier",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309209",
+    "municipio": "Gravataí",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309258",
+    "municipio": "Guabiju",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309308",
+    "municipio": "Guaíba",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309407",
+    "municipio": "Guaporé",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309506",
+    "municipio": "Guarani das Missões",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309555",
+    "municipio": "Harmonia",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309571",
+    "municipio": "Herveiras",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309605",
+    "municipio": "Horizontina",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309654",
+    "municipio": "Hulha Negra",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309704",
+    "municipio": "Humaitá",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309753",
+    "municipio": "Ibarama",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309803",
+    "municipio": "Ibiaçá",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309902",
+    "municipio": "Ibiraiaras",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4309951",
+    "municipio": "Ibirapuitã",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310009",
+    "municipio": "Ibirubá",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310108",
+    "municipio": "Igrejinha",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310207",
+    "municipio": "Ijuí",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310306",
+    "municipio": "Ilópolis",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310330",
+    "municipio": "Imbé",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310363",
+    "municipio": "Imigrante",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310405",
+    "municipio": "Independência",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310413",
+    "municipio": "Inhacorá",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310439",
+    "municipio": "Ipê",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310462",
+    "municipio": "Ipiranga do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310504",
+    "municipio": "Iraí",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310538",
+    "municipio": "Itaara",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310553",
+    "municipio": "Itacurubi",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310579",
+    "municipio": "Itapuca",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310603",
+    "municipio": "Itaqui",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310652",
+    "municipio": "Itati",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310702",
+    "municipio": "Itatiba do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310751",
+    "municipio": "Ivorá",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310801",
+    "municipio": "Ivoti",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310850",
+    "municipio": "Jaboticaba",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310876",
+    "municipio": "Jacuizinho",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4310900",
+    "municipio": "Jacutinga",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311007",
+    "municipio": "Jaguarão",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311106",
+    "municipio": "Jaguari",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311122",
+    "municipio": "Jaquirana",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311130",
+    "municipio": "Jari",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311155",
+    "municipio": "Jóia",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311205",
+    "municipio": "Júlio de Castilhos",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311239",
+    "municipio": "Lagoa Bonita do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311254",
+    "municipio": "Lagoão",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311270",
+    "municipio": "Lagoa dos Três Cantos",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311304",
+    "municipio": "Lagoa Vermelha",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311403",
+    "municipio": "Lajeado",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311429",
+    "municipio": "Lajeado do Bugre",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311502",
+    "municipio": "Lavras do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311601",
+    "municipio": "Liberato Salzano",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311627",
+    "municipio": "Lindolfo Collor",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311643",
+    "municipio": "Linha Nova",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311700",
+    "municipio": "Machadinho",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311718",
+    "municipio": "Maçambará",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311734",
+    "municipio": "Mampituba",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311759",
+    "municipio": "Manoel Viana",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311775",
+    "municipio": "Maquiné",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311791",
+    "municipio": "Maratá",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311809",
+    "municipio": "Marau",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311908",
+    "municipio": "Marcelino Ramos",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4311981",
+    "municipio": "Mariana Pimentel",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312005",
+    "municipio": "Mariano Moro",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312054",
+    "municipio": "Marques de Souza",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312104",
+    "municipio": "Mata",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312138",
+    "municipio": "Mato Castelhano",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312153",
+    "municipio": "Mato Leitão",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312179",
+    "municipio": "Mato Queimado",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312203",
+    "municipio": "Maximiliano de Almeida",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312252",
+    "municipio": "Minas do Leão",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312302",
+    "municipio": "Miraguaí",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312351",
+    "municipio": "Montauri",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312377",
+    "municipio": "Monte Alegre dos Campos",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312385",
+    "municipio": "Monte Belo do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312401",
+    "municipio": "Montenegro",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312427",
+    "municipio": "Mormaço",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312443",
+    "municipio": "Morrinhos do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312450",
+    "municipio": "Morro Redondo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312476",
+    "municipio": "Morro Reuter",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312500",
+    "municipio": "Mostardas",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312609",
+    "municipio": "Muçum",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312617",
+    "municipio": "Muitos Capões",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312625",
+    "municipio": "Muliterno",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312658",
+    "municipio": "Não-Me-Toque",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312674",
+    "municipio": "Nicolau Vergueiro",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312708",
+    "municipio": "Nonoai",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312757",
+    "municipio": "Nova Alvorada",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312807",
+    "municipio": "Nova Araçá",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312906",
+    "municipio": "Nova Bassano",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4312955",
+    "municipio": "Nova Boa Vista",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313003",
+    "municipio": "Nova Bréscia",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313011",
+    "municipio": "Nova Candelária",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313037",
+    "municipio": "Nova Esperança do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313060",
+    "municipio": "Nova Hartz",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313086",
+    "municipio": "Nova Pádua",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313102",
+    "municipio": "Nova Palma",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313201",
+    "municipio": "Nova Petrópolis",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313300",
+    "municipio": "Nova Prata",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313334",
+    "municipio": "Nova Ramada",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313359",
+    "municipio": "Nova Roma do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313375",
+    "municipio": "Nova Santa Rita",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313391",
+    "municipio": "Novo Cabrais",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313409",
+    "municipio": "Novo Hamburgo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313425",
+    "municipio": "Novo Machado",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313441",
+    "municipio": "Novo Tiradentes",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313466",
+    "municipio": "Novo Xingu",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313490",
+    "municipio": "Novo Barreiro",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313508",
+    "municipio": "Osório",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313607",
+    "municipio": "Paim Filho",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313656",
+    "municipio": "Palmares do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313706",
+    "municipio": "Palmeira das Missões",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313805",
+    "municipio": "Palmitinho",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313904",
+    "municipio": "Panambi",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4313953",
+    "municipio": "Pantano Grande",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314001",
+    "municipio": "Paraí",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314027",
+    "municipio": "Paraíso do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314035",
+    "municipio": "Pareci Novo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314050",
+    "municipio": "Parobé",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314068",
+    "municipio": "Passa Sete",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314076",
+    "municipio": "Passo do Sobrado",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314100",
+    "municipio": "Passo Fundo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314134",
+    "municipio": "Paulo Bento",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314159",
+    "municipio": "Paverama",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314175",
+    "municipio": "Pedras Altas",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314209",
+    "municipio": "Pedro Osório",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314308",
+    "municipio": "Pejuçara",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314407",
+    "municipio": "Pelotas",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314423",
+    "municipio": "Picada Café",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314456",
+    "municipio": "Pinhal",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314464",
+    "municipio": "Pinhal da Serra",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314472",
+    "municipio": "Pinhal Grande",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314498",
+    "municipio": "Pinheirinho do Vale",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314506",
+    "municipio": "Pinheiro Machado",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314548",
+    "municipio": "Pinto Bandeira",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314555",
+    "municipio": "Pirapó",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314605",
+    "municipio": "Piratini",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314704",
+    "municipio": "Planalto",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314753",
+    "municipio": "Poço das Antas",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314779",
+    "municipio": "Pontão",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314787",
+    "municipio": "Ponte Preta",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314803",
+    "municipio": "Portão",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4314902",
+    "municipio": "Porto Alegre",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315008",
+    "municipio": "Porto Lucena",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315057",
+    "municipio": "Porto Mauá",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315073",
+    "municipio": "Porto Vera Cruz",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315107",
+    "municipio": "Porto Xavier",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315131",
+    "municipio": "Pouso Novo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315149",
+    "municipio": "Presidente Lucena",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315156",
+    "municipio": "Progresso",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315172",
+    "municipio": "Protásio Alves",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315206",
+    "municipio": "Putinga",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315305",
+    "municipio": "Quaraí",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315313",
+    "municipio": "Quatro Irmãos",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315321",
+    "municipio": "Quevedos",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315354",
+    "municipio": "Quinze de Novembro",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315404",
+    "municipio": "Redentora",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315453",
+    "municipio": "Relvado",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315503",
+    "municipio": "Restinga Sêca",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315552",
+    "municipio": "Rio dos Índios",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315602",
+    "municipio": "Rio Grande",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315701",
+    "municipio": "Rio Pardo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315750",
+    "municipio": "Riozinho",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315800",
+    "municipio": "Roca Sales",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315909",
+    "municipio": "Rodeio Bonito",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4315958",
+    "municipio": "Rolador",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316006",
+    "municipio": "Rolante",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316105",
+    "municipio": "Ronda Alta",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316204",
+    "municipio": "Rondinha",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316303",
+    "municipio": "Roque Gonzales",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316402",
+    "municipio": "Rosário do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316428",
+    "municipio": "Sagrada Família",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316436",
+    "municipio": "Saldanha Marinho",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316451",
+    "municipio": "Salto do Jacuí",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316477",
+    "municipio": "Salvador das Missões",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316501",
+    "municipio": "Salvador do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316600",
+    "municipio": "Sananduva",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316709",
+    "municipio": "Santa Bárbara do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316733",
+    "municipio": "Santa Cecília do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316758",
+    "municipio": "Santa Clara do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316808",
+    "municipio": "Santa Cruz do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316907",
+    "municipio": "Santa Maria",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316956",
+    "municipio": "Santa Maria do Herval",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4316972",
+    "municipio": "Santa Margarida do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4317004",
+    "municipio": "Santana da Boa Vista",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4317103",
+    "municipio": "Sant'Ana do Livramento",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4317202",
+    "municipio": "Santa Rosa",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4317251",
+    "municipio": "Santa Tereza",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4317301",
+    "municipio": "Santa Vitória do Palmar",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4317400",
+    "municipio": "Santiago",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4317509",
+    "municipio": "Santo Ângelo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4317558",
+    "municipio": "Santo Antônio do Palma",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4317608",
+    "municipio": "Santo Antônio da Patrulha",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4317707",
+    "municipio": "Santo Antônio das Missões",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4317756",
+    "municipio": "Santo Antônio do Planalto",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4317806",
+    "municipio": "Santo Augusto",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4317905",
+    "municipio": "Santo Cristo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4317954",
+    "municipio": "Santo Expedito do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318002",
+    "municipio": "São Borja",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318051",
+    "municipio": "São Domingos do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318101",
+    "municipio": "São Francisco de Assis",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318200",
+    "municipio": "São Francisco de Paula",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318309",
+    "municipio": "São Gabriel",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318408",
+    "municipio": "São Jerônimo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318424",
+    "municipio": "São João da Urtiga",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318432",
+    "municipio": "São João do Polêsine",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318440",
+    "municipio": "São Jorge",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318457",
+    "municipio": "São José das Missões",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318465",
+    "municipio": "São José do Herval",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318481",
+    "municipio": "São José do Hortêncio",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318499",
+    "municipio": "São José do Inhacorá",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318507",
+    "municipio": "São José do Norte",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318606",
+    "municipio": "São José do Ouro",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318614",
+    "municipio": "São José do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318622",
+    "municipio": "São José dos Ausentes",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318705",
+    "municipio": "São Leopoldo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318804",
+    "municipio": "São Lourenço do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4318903",
+    "municipio": "São Luiz Gonzaga",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319000",
+    "municipio": "São Marcos",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319109",
+    "municipio": "São Martinho",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319125",
+    "municipio": "São Martinho da Serra",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319158",
+    "municipio": "São Miguel das Missões",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319208",
+    "municipio": "São Nicolau",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319307",
+    "municipio": "São Paulo das Missões",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319356",
+    "municipio": "São Pedro da Serra",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319364",
+    "municipio": "São Pedro das Missões",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319372",
+    "municipio": "São Pedro do Butiá",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319406",
+    "municipio": "São Pedro do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319505",
+    "municipio": "São Sebastião do Caí",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319604",
+    "municipio": "São Sepé",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319703",
+    "municipio": "São Valentim",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319711",
+    "municipio": "São Valentim do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319737",
+    "municipio": "São Valério do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319752",
+    "municipio": "São Vendelino",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319802",
+    "municipio": "São Vicente do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4319901",
+    "municipio": "Sapiranga",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320008",
+    "municipio": "Sapucaia do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320107",
+    "municipio": "Sarandi",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320206",
+    "municipio": "Seberi",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320230",
+    "municipio": "Sede Nova",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320263",
+    "municipio": "Segredo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320305",
+    "municipio": "Selbach",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320321",
+    "municipio": "Senador Salgado Filho",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320354",
+    "municipio": "Sentinela do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320404",
+    "municipio": "Serafina Corrêa",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320453",
+    "municipio": "Sério",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320503",
+    "municipio": "Sertão",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320552",
+    "municipio": "Sertão Santana",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320578",
+    "municipio": "Sete de Setembro",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320602",
+    "municipio": "Severiano de Almeida",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320651",
+    "municipio": "Silveira Martins",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320677",
+    "municipio": "Sinimbu",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320701",
+    "municipio": "Sobradinho",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320800",
+    "municipio": "Soledade",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320859",
+    "municipio": "Tabaí",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4320909",
+    "municipio": "Tapejara",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321006",
+    "municipio": "Tapera",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321105",
+    "municipio": "Tapes",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321204",
+    "municipio": "Taquara",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321303",
+    "municipio": "Taquari",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321329",
+    "municipio": "Taquaruçu do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321352",
+    "municipio": "Tavares",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321402",
+    "municipio": "Tenente Portela",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321436",
+    "municipio": "Terra de Areia",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321451",
+    "municipio": "Teutônia",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321469",
+    "municipio": "Tio Hugo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321477",
+    "municipio": "Tiradentes do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321493",
+    "municipio": "Toropi",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321501",
+    "municipio": "Torres",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321600",
+    "municipio": "Tramandaí",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321626",
+    "municipio": "Travesseiro",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321634",
+    "municipio": "Três Arroios",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321667",
+    "municipio": "Três Cachoeiras",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321709",
+    "municipio": "Três Coroas",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321808",
+    "municipio": "Três de Maio",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321832",
+    "municipio": "Três Forquilhas",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321857",
+    "municipio": "Três Palmeiras",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321907",
+    "municipio": "Três Passos",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4321956",
+    "municipio": "Trindade do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322004",
+    "municipio": "Triunfo",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322103",
+    "municipio": "Tucunduva",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322152",
+    "municipio": "Tunas",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322186",
+    "municipio": "Tupanci do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322202",
+    "municipio": "Tupanciretã",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322251",
+    "municipio": "Tupandi",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322301",
+    "municipio": "Tuparendi",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322327",
+    "municipio": "Turuçu",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322343",
+    "municipio": "Ubiretama",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322350",
+    "municipio": "União da Serra",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322376",
+    "municipio": "Unistalda",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322400",
+    "municipio": "Uruguaiana",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322509",
+    "municipio": "Vacaria",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322525",
+    "municipio": "Vale Verde",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322533",
+    "municipio": "Vale do Sol",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322541",
+    "municipio": "Vale Real",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322558",
+    "municipio": "Vanini",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322608",
+    "municipio": "Venâncio Aires",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322707",
+    "municipio": "Vera Cruz",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322806",
+    "municipio": "Veranópolis",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322855",
+    "municipio": "Vespasiano Corrêa",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4322905",
+    "municipio": "Viadutos",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4323002",
+    "municipio": "Viamão",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4323101",
+    "municipio": "Vicente Dutra",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4323200",
+    "municipio": "Victor Graeff",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4323309",
+    "municipio": "Vila Flores",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4323358",
+    "municipio": "Vila Lângaro",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4323408",
+    "municipio": "Vila Maria",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4323457",
+    "municipio": "Vila Nova do Sul",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4323507",
+    "municipio": "Vista Alegre",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4323606",
+    "municipio": "Vista Alegre do Prata",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4323705",
+    "municipio": "Vista Gaúcha",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4323754",
+    "municipio": "Vitória das Missões",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4323770",
+    "municipio": "Westfália",
+    "uf": "RS"
+  },
+  {
+    "codigo": "4323804",
+    "municipio": "Xangri-lá",
+    "uf": "RS"
+  },
+  {
+    "codigo": "5000203",
+    "municipio": "Água Clara",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5000252",
+    "municipio": "Alcinópolis",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5000609",
+    "municipio": "Amambai",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5000708",
+    "municipio": "Anastácio",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5000807",
+    "municipio": "Anaurilândia",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5000856",
+    "municipio": "Angélica",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5000906",
+    "municipio": "Antônio João",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5001003",
+    "municipio": "Aparecida do Taboado",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5001102",
+    "municipio": "Aquidauana",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5001243",
+    "municipio": "Aral Moreira",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5001508",
+    "municipio": "Bandeirantes",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5001904",
+    "municipio": "Bataguassu",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5002001",
+    "municipio": "Batayporã",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5002100",
+    "municipio": "Bela Vista",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5002159",
+    "municipio": "Bodoquena",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5002209",
+    "municipio": "Bonito",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5002308",
+    "municipio": "Brasilândia",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5002407",
+    "municipio": "Caarapó",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5002605",
+    "municipio": "Camapuã",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5002704",
+    "municipio": "Campo Grande",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5002803",
+    "municipio": "Caracol",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5002902",
+    "municipio": "Cassilândia",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5002951",
+    "municipio": "Chapadão do Sul",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5003108",
+    "municipio": "Corguinho",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5003157",
+    "municipio": "Coronel Sapucaia",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5003207",
+    "municipio": "Corumbá",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5003256",
+    "municipio": "Costa Rica",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5003306",
+    "municipio": "Coxim",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5003454",
+    "municipio": "Deodápolis",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5003488",
+    "municipio": "Dois Irmãos do Buriti",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5003504",
+    "municipio": "Douradina",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5003702",
+    "municipio": "Dourados",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5003751",
+    "municipio": "Eldorado",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5003801",
+    "municipio": "Fátima do Sul",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5003900",
+    "municipio": "Figueirão",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5004007",
+    "municipio": "Glória de Dourados",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5004106",
+    "municipio": "Guia Lopes da Laguna",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5004304",
+    "municipio": "Iguatemi",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5004403",
+    "municipio": "Inocência",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5004502",
+    "municipio": "Itaporã",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5004601",
+    "municipio": "Itaquiraí",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5004700",
+    "municipio": "Ivinhema",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5004809",
+    "municipio": "Japorã",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5004908",
+    "municipio": "Jaraguari",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5005004",
+    "municipio": "Jardim",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5005103",
+    "municipio": "Jateí",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5005152",
+    "municipio": "Juti",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5005202",
+    "municipio": "Ladário",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5005251",
+    "municipio": "Laguna Carapã",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5005400",
+    "municipio": "Maracaju",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5005608",
+    "municipio": "Miranda",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5005681",
+    "municipio": "Mundo Novo",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5005707",
+    "municipio": "Naviraí",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5005806",
+    "municipio": "Nioaque",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5006002",
+    "municipio": "Nova Alvorada do Sul",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5006200",
+    "municipio": "Nova Andradina",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5006259",
+    "municipio": "Novo Horizonte do Sul",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5006275",
+    "municipio": "Paraíso das Águas",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5006309",
+    "municipio": "Paranaíba",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5006358",
+    "municipio": "Paranhos",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5006408",
+    "municipio": "Pedro Gomes",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5006606",
+    "municipio": "Ponta Porã",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5006903",
+    "municipio": "Porto Murtinho",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5007109",
+    "municipio": "Ribas do Rio Pardo",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5007208",
+    "municipio": "Rio Brilhante",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5007307",
+    "municipio": "Rio Negro",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5007406",
+    "municipio": "Rio Verde de Mato Grosso",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5007505",
+    "municipio": "Rochedo",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5007554",
+    "municipio": "Santa Rita do Pardo",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5007695",
+    "municipio": "São Gabriel do Oeste",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5007703",
+    "municipio": "Sete Quedas",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5007802",
+    "municipio": "Selvíria",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5007901",
+    "municipio": "Sidrolândia",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5007935",
+    "municipio": "Sonora",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5007950",
+    "municipio": "Tacuru",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5007976",
+    "municipio": "Taquarussu",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5008008",
+    "municipio": "Terenos",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5008305",
+    "municipio": "Três Lagoas",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5008404",
+    "municipio": "Vicentina",
+    "uf": "MS"
+  },
+  {
+    "codigo": "5100102",
+    "municipio": "Acorizal",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5100201",
+    "municipio": "Água Boa",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5100250",
+    "municipio": "Alta Floresta",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5100300",
+    "municipio": "Alto Araguaia",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5100359",
+    "municipio": "Alto Boa Vista",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5100409",
+    "municipio": "Alto Garças",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5100508",
+    "municipio": "Alto Paraguai",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5100607",
+    "municipio": "Alto Taquari",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5100805",
+    "municipio": "Apiacás",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5101001",
+    "municipio": "Araguaiana",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5101209",
+    "municipio": "Araguainha",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5101258",
+    "municipio": "Araputanga",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5101308",
+    "municipio": "Arenápolis",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5101407",
+    "municipio": "Aripuanã",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5101605",
+    "municipio": "Barão de Melgaço",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5101704",
+    "municipio": "Barra do Bugres",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5101803",
+    "municipio": "Barra do Garças",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5101837",
+    "municipio": "Boa Esperança do Norte",
+    "uf": null
+  },
+  {
+    "codigo": "5101852",
+    "municipio": "Bom Jesus do Araguaia",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5101902",
+    "municipio": "Brasnorte",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5102504",
+    "municipio": "Cáceres",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5102603",
+    "municipio": "Campinápolis",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5102637",
+    "municipio": "Campo Novo do Parecis",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5102678",
+    "municipio": "Campo Verde",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5102686",
+    "municipio": "Campos de Júlio",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5102694",
+    "municipio": "Canabrava do Norte",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5102702",
+    "municipio": "Canarana",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5102793",
+    "municipio": "Carlinda",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5102850",
+    "municipio": "Castanheira",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103007",
+    "municipio": "Chapada dos Guimarães",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103056",
+    "municipio": "Cláudia",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103106",
+    "municipio": "Cocalinho",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103205",
+    "municipio": "Colíder",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103254",
+    "municipio": "Colniza",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103304",
+    "municipio": "Comodoro",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103353",
+    "municipio": "Confresa",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103361",
+    "municipio": "Conquista D'Oeste",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103379",
+    "municipio": "Cotriguaçu",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103403",
+    "municipio": "Cuiabá",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103437",
+    "municipio": "Curvelândia",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103452",
+    "municipio": "Denise",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103502",
+    "municipio": "Diamantino",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103601",
+    "municipio": "Dom Aquino",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103700",
+    "municipio": "Feliz Natal",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103809",
+    "municipio": "Figueirópolis D'Oeste",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103858",
+    "municipio": "Gaúcha do Norte",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103908",
+    "municipio": "General Carneiro",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5103957",
+    "municipio": "Glória D'Oeste",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5104104",
+    "municipio": "Guarantã do Norte",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5104203",
+    "municipio": "Guiratinga",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5104500",
+    "municipio": "Indiavaí",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5104526",
+    "municipio": "Ipiranga do Norte",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5104542",
+    "municipio": "Itanhangá",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5104559",
+    "municipio": "Itaúba",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5104609",
+    "municipio": "Itiquira",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5104807",
+    "municipio": "Jaciara",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5104906",
+    "municipio": "Jangada",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5105002",
+    "municipio": "Jauru",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5105101",
+    "municipio": "Juara",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5105150",
+    "municipio": "Juína",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5105176",
+    "municipio": "Juruena",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5105200",
+    "municipio": "Juscimeira",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5105234",
+    "municipio": "Lambari D'Oeste",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5105259",
+    "municipio": "Lucas do Rio Verde",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5105309",
+    "municipio": "Luciara",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5105507",
+    "municipio": "Vila Bela da Santíssima Trindade",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5105580",
+    "municipio": "Marcelândia",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5105606",
+    "municipio": "Matupá",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5105622",
+    "municipio": "Mirassol d'Oeste",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5105903",
+    "municipio": "Nobres",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106000",
+    "municipio": "Nortelândia",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106109",
+    "municipio": "Nossa Senhora do Livramento",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106158",
+    "municipio": "Nova Bandeirantes",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106174",
+    "municipio": "Nova Nazaré",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106182",
+    "municipio": "Nova Lacerda",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106190",
+    "municipio": "Nova Santa Helena",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106208",
+    "municipio": "Nova Brasilândia",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106216",
+    "municipio": "Nova Canaã do Norte",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106224",
+    "municipio": "Nova Mutum",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106232",
+    "municipio": "Nova Olímpia",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106240",
+    "municipio": "Nova Ubiratã",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106257",
+    "municipio": "Nova Xavantina",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106265",
+    "municipio": "Novo Mundo",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106273",
+    "municipio": "Novo Horizonte do Norte",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106281",
+    "municipio": "Novo São Joaquim",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106299",
+    "municipio": "Paranaíta",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106307",
+    "municipio": "Paranatinga",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106315",
+    "municipio": "Novo Santo Antônio",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106372",
+    "municipio": "Pedra Preta",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106422",
+    "municipio": "Peixoto de Azevedo",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106455",
+    "municipio": "Planalto da Serra",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106505",
+    "municipio": "Poconé",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106653",
+    "municipio": "Pontal do Araguaia",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106703",
+    "municipio": "Ponte Branca",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106752",
+    "municipio": "Pontes e Lacerda",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106778",
+    "municipio": "Porto Alegre do Norte",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106802",
+    "municipio": "Porto dos Gaúchos",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106828",
+    "municipio": "Porto Esperidião",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5106851",
+    "municipio": "Porto Estrela",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107008",
+    "municipio": "Poxoréu",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107040",
+    "municipio": "Primavera do Leste",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107065",
+    "municipio": "Querência",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107107",
+    "municipio": "São José dos Quatro Marcos",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107156",
+    "municipio": "Reserva do Cabaçal",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107180",
+    "municipio": "Ribeirão Cascalheira",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107198",
+    "municipio": "Ribeirãozinho",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107206",
+    "municipio": "Rio Branco",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107248",
+    "municipio": "Santa Carmem",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107263",
+    "municipio": "Santo Afonso",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107297",
+    "municipio": "São José do Povo",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107305",
+    "municipio": "São José do Rio Claro",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107354",
+    "municipio": "São José do Xingu",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107404",
+    "municipio": "São Pedro da Cipa",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107578",
+    "municipio": "Rondolândia",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107602",
+    "municipio": "Rondonópolis",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107701",
+    "municipio": "Rosário Oeste",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107743",
+    "municipio": "Santa Cruz do Xingu",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107750",
+    "municipio": "Salto do Céu",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107768",
+    "municipio": "Santa Rita do Trivelato",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107776",
+    "municipio": "Santa Terezinha",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107792",
+    "municipio": "Santo Antônio do Leste",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107800",
+    "municipio": "Santo Antônio de Leverger",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107859",
+    "municipio": "São Félix do Araguaia",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107875",
+    "municipio": "Sapezal",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107883",
+    "municipio": "Serra Nova Dourada",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107909",
+    "municipio": "Sinop",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107925",
+    "municipio": "Sorriso",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107941",
+    "municipio": "Tabaporã",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5107958",
+    "municipio": "Tangará da Serra",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5108006",
+    "municipio": "Tapurah",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5108055",
+    "municipio": "Terra Nova do Norte",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5108105",
+    "municipio": "Tesouro",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5108204",
+    "municipio": "Torixoréu",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5108303",
+    "municipio": "União do Sul",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5108352",
+    "municipio": "Vale de São Domingos",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5108402",
+    "municipio": "Várzea Grande",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5108501",
+    "municipio": "Vera",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5108600",
+    "municipio": "Vila Rica",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5108808",
+    "municipio": "Nova Guarita",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5108857",
+    "municipio": "Nova Marilândia",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5108907",
+    "municipio": "Nova Maringá",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5108956",
+    "municipio": "Nova Monte Verde",
+    "uf": "MT"
+  },
+  {
+    "codigo": "5200050",
+    "municipio": "Abadia de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5200100",
+    "municipio": "Abadiânia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5200134",
+    "municipio": "Acreúna",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5200159",
+    "municipio": "Adelândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5200175",
+    "municipio": "Água Fria de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5200209",
+    "municipio": "Água Limpa",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5200258",
+    "municipio": "Águas Lindas de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5200308",
+    "municipio": "Alexânia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5200506",
+    "municipio": "Aloândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5200555",
+    "municipio": "Alto Horizonte",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5200605",
+    "municipio": "Alto Paraíso de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5200803",
+    "municipio": "Alvorada do Norte",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5200829",
+    "municipio": "Amaralina",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5200852",
+    "municipio": "Americano do Brasil",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5200902",
+    "municipio": "Amorinópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5201108",
+    "municipio": "Anápolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5201207",
+    "municipio": "Anhanguera",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5201306",
+    "municipio": "Anicuns",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5201405",
+    "municipio": "Aparecida de Goiânia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5201454",
+    "municipio": "Aparecida do Rio Doce",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5201504",
+    "municipio": "Aporé",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5201603",
+    "municipio": "Araçu",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5201702",
+    "municipio": "Aragarças",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5201801",
+    "municipio": "Aragoiânia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5202155",
+    "municipio": "Araguapaz",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5202353",
+    "municipio": "Arenópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5202502",
+    "municipio": "Aruanã",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5202601",
+    "municipio": "Aurilândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5202809",
+    "municipio": "Avelinópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5203104",
+    "municipio": "Baliza",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5203203",
+    "municipio": "Barro Alto",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5203302",
+    "municipio": "Bela Vista de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5203401",
+    "municipio": "Bom Jardim de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5203500",
+    "municipio": "Bom Jesus de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5203559",
+    "municipio": "Bonfinópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5203575",
+    "municipio": "Bonópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5203609",
+    "municipio": "Brazabrantes",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5203807",
+    "municipio": "Britânia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5203906",
+    "municipio": "Buriti Alegre",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5203939",
+    "municipio": "Buriti de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5203962",
+    "municipio": "Buritinópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5204003",
+    "municipio": "Cabeceiras",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5204102",
+    "municipio": "Cachoeira Alta",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5204201",
+    "municipio": "Cachoeira de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5204250",
+    "municipio": "Cachoeira Dourada",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5204300",
+    "municipio": "Caçu",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5204409",
+    "municipio": "Caiapônia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5204508",
+    "municipio": "Caldas Novas",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5204557",
+    "municipio": "Caldazinha",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5204607",
+    "municipio": "Campestre de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5204656",
+    "municipio": "Campinaçu",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5204706",
+    "municipio": "Campinorte",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5204805",
+    "municipio": "Campo Alegre de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5204854",
+    "municipio": "Campo Limpo de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5204904",
+    "municipio": "Campos Belos",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5204953",
+    "municipio": "Campos Verdes",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5205000",
+    "municipio": "Carmo do Rio Verde",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5205059",
+    "municipio": "Castelândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5205109",
+    "municipio": "Catalão",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5205208",
+    "municipio": "Caturaí",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5205307",
+    "municipio": "Cavalcante",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5205406",
+    "municipio": "Ceres",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5205455",
+    "municipio": "Cezarina",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5205471",
+    "municipio": "Chapadão do Céu",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5205497",
+    "municipio": "Cidade Ocidental",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5205513",
+    "municipio": "Cocalzinho de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5205521",
+    "municipio": "Colinas do Sul",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5205703",
+    "municipio": "Córrego do Ouro",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5205802",
+    "municipio": "Corumbá de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5205901",
+    "municipio": "Corumbaíba",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5206206",
+    "municipio": "Cristalina",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5206305",
+    "municipio": "Cristianópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5206404",
+    "municipio": "Crixás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5206503",
+    "municipio": "Cromínia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5206602",
+    "municipio": "Cumari",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5206701",
+    "municipio": "Damianópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5206800",
+    "municipio": "Damolândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5206909",
+    "municipio": "Davinópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5207105",
+    "municipio": "Diorama",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5207253",
+    "municipio": "Doverlândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5207352",
+    "municipio": "Edealina",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5207402",
+    "municipio": "Edéia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5207501",
+    "municipio": "Estrela do Norte",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5207535",
+    "municipio": "Faina",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5207600",
+    "municipio": "Fazenda Nova",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5207808",
+    "municipio": "Firminópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5207907",
+    "municipio": "Flores de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5208004",
+    "municipio": "Formosa",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5208103",
+    "municipio": "Formoso",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5208152",
+    "municipio": "Gameleira de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5208301",
+    "municipio": "Divinópolis de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5208400",
+    "municipio": "Goianápolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5208509",
+    "municipio": "Goiandira",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5208608",
+    "municipio": "Goianésia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5208707",
+    "municipio": "Goiânia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5208806",
+    "municipio": "Goianira",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5208905",
+    "municipio": "Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5209101",
+    "municipio": "Goiatuba",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5209150",
+    "municipio": "Gouvelândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5209200",
+    "municipio": "Guapó",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5209291",
+    "municipio": "Guaraíta",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5209408",
+    "municipio": "Guarani de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5209457",
+    "municipio": "Guarinos",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5209606",
+    "municipio": "Heitoraí",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5209705",
+    "municipio": "Hidrolândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5209804",
+    "municipio": "Hidrolina",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5209903",
+    "municipio": "Iaciara",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5209937",
+    "municipio": "Inaciolândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5209952",
+    "municipio": "Indiara",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5210000",
+    "municipio": "Inhumas",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5210109",
+    "municipio": "Ipameri",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5210158",
+    "municipio": "Ipiranga de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5210208",
+    "municipio": "Iporá",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5210307",
+    "municipio": "Israelândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5210406",
+    "municipio": "Itaberaí",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5210562",
+    "municipio": "Itaguari",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5210604",
+    "municipio": "Itaguaru",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5210802",
+    "municipio": "Itajá",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5210901",
+    "municipio": "Itapaci",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5211008",
+    "municipio": "Itapirapuã",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5211206",
+    "municipio": "Itapuranga",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5211305",
+    "municipio": "Itarumã",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5211404",
+    "municipio": "Itauçu",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5211503",
+    "municipio": "Itumbiara",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5211602",
+    "municipio": "Ivolândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5211701",
+    "municipio": "Jandaia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5211800",
+    "municipio": "Jaraguá",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5211909",
+    "municipio": "Jataí",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5212006",
+    "municipio": "Jaupaci",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5212055",
+    "municipio": "Jesúpolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5212105",
+    "municipio": "Joviânia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5212204",
+    "municipio": "Jussara",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5212253",
+    "municipio": "Lagoa Santa",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5212303",
+    "municipio": "Leopoldo de Bulhões",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5212501",
+    "municipio": "Luziânia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5212600",
+    "municipio": "Mairipotaba",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5212709",
+    "municipio": "Mambaí",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5212808",
+    "municipio": "Mara Rosa",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5212907",
+    "municipio": "Marzagão",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5212956",
+    "municipio": "Matrinchã",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5213004",
+    "municipio": "Maurilândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5213053",
+    "municipio": "Mimoso de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5213087",
+    "municipio": "Minaçu",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5213103",
+    "municipio": "Mineiros",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5213400",
+    "municipio": "Moiporá",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5213509",
+    "municipio": "Monte Alegre de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5213707",
+    "municipio": "Montes Claros de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5213756",
+    "municipio": "Montividiu",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5213772",
+    "municipio": "Montividiu do Norte",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5213806",
+    "municipio": "Morrinhos",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5213855",
+    "municipio": "Morro Agudo de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5213905",
+    "municipio": "Mossâmedes",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5214002",
+    "municipio": "Mozarlândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5214051",
+    "municipio": "Mundo Novo",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5214101",
+    "municipio": "Mutunópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5214408",
+    "municipio": "Nazário",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5214507",
+    "municipio": "Nerópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5214606",
+    "municipio": "Niquelândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5214705",
+    "municipio": "Nova América",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5214804",
+    "municipio": "Nova Aurora",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5214838",
+    "municipio": "Nova Crixás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5214861",
+    "municipio": "Nova Glória",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5214879",
+    "municipio": "Nova Iguaçu de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5214903",
+    "municipio": "Nova Roma",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5215009",
+    "municipio": "Nova Veneza",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5215207",
+    "municipio": "Novo Brasil",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5215231",
+    "municipio": "Novo Gama",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5215256",
+    "municipio": "Novo Planalto",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5215306",
+    "municipio": "Orizona",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5215405",
+    "municipio": "Ouro Verde de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5215504",
+    "municipio": "Ouvidor",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5215603",
+    "municipio": "Padre Bernardo",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5215652",
+    "municipio": "Palestina de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5215702",
+    "municipio": "Palmeiras de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5215801",
+    "municipio": "Palmelo",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5215900",
+    "municipio": "Palminópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5216007",
+    "municipio": "Panamá",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5216304",
+    "municipio": "Paranaiguara",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5216403",
+    "municipio": "Paraúna",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5216452",
+    "municipio": "Perolândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5216809",
+    "municipio": "Petrolina de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5216908",
+    "municipio": "Pilar de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5217104",
+    "municipio": "Piracanjuba",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5217203",
+    "municipio": "Piranhas",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5217302",
+    "municipio": "Pirenópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5217401",
+    "municipio": "Pires do Rio",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5217609",
+    "municipio": "Planaltina",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5217708",
+    "municipio": "Pontalina",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5218003",
+    "municipio": "Porangatu",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5218052",
+    "municipio": "Porteirão",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5218102",
+    "municipio": "Portelândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5218300",
+    "municipio": "Posse",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5218391",
+    "municipio": "Professor Jamil",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5218508",
+    "municipio": "Quirinópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5218607",
+    "municipio": "Rialma",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5218706",
+    "municipio": "Rianápolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5218789",
+    "municipio": "Rio Quente",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5218805",
+    "municipio": "Rio Verde",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5218904",
+    "municipio": "Rubiataba",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5219001",
+    "municipio": "Sanclerlândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5219100",
+    "municipio": "Santa Bárbara de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5219209",
+    "municipio": "Santa Cruz de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5219258",
+    "municipio": "Santa Fé de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5219308",
+    "municipio": "Santa Helena de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5219357",
+    "municipio": "Santa Isabel",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5219407",
+    "municipio": "Santa Rita do Araguaia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5219456",
+    "municipio": "Santa Rita do Novo Destino",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5219506",
+    "municipio": "Santa Rosa de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5219605",
+    "municipio": "Santa Tereza de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5219704",
+    "municipio": "Santa Terezinha de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5219712",
+    "municipio": "Santo Antônio da Barra",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5219738",
+    "municipio": "Santo Antônio de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5219753",
+    "municipio": "Santo Antônio do Descoberto",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5219803",
+    "municipio": "São Domingos",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5219902",
+    "municipio": "São Francisco de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5220009",
+    "municipio": "São João d'Aliança",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5220058",
+    "municipio": "São João da Paraúna",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5220108",
+    "municipio": "São Luís de Montes Belos",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5220157",
+    "municipio": "São Luiz do Norte",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5220207",
+    "municipio": "São Miguel do Araguaia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5220264",
+    "municipio": "São Miguel do Passa Quatro",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5220280",
+    "municipio": "São Patrício",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5220405",
+    "municipio": "São Simão",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5220454",
+    "municipio": "Senador Canedo",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5220504",
+    "municipio": "Serranópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5220603",
+    "municipio": "Silvânia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5220686",
+    "municipio": "Simolândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5220702",
+    "municipio": "Sítio d'Abadia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5221007",
+    "municipio": "Taquaral de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5221080",
+    "municipio": "Teresina de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5221197",
+    "municipio": "Terezópolis de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5221304",
+    "municipio": "Três Ranchos",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5221403",
+    "municipio": "Trindade",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5221452",
+    "municipio": "Trombas",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5221502",
+    "municipio": "Turvânia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5221551",
+    "municipio": "Turvelândia",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5221577",
+    "municipio": "Uirapuru",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5221601",
+    "municipio": "Uruaçu",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5221700",
+    "municipio": "Uruana",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5221809",
+    "municipio": "Urutaí",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5221858",
+    "municipio": "Valparaíso de Goiás",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5221908",
+    "municipio": "Varjão",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5222005",
+    "municipio": "Vianópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5222054",
+    "municipio": "Vicentinópolis",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5222203",
+    "municipio": "Vila Boa",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5222302",
+    "municipio": "Vila Propício",
+    "uf": "GO"
+  },
+  {
+    "codigo": "5300108",
+    "municipio": "Brasília",
+    "uf": "DF"
+  }
+]

--- a/servidor/services/nfceEmitter.js
+++ b/servidor/services/nfceEmitter.js
@@ -1250,10 +1250,19 @@ const emitPdvSaleFiscal = async ({ sale, pdv, store, emissionDate, environment, 
         cliente?.cMun ??
         cliente?.codigoIbgeMunicipio
     );
-    const dXMun = sanitize(
-      (delivery?.xMun ?? delivery?.cidade ?? cliente?.xMun ?? cliente?.cidade || '').slice(0, 60)
+    const rawCity = firstNonEmptyString(
+      delivery?.xMun,
+      delivery?.cidade,
+      cliente?.xMun,
+      cliente?.cidade
     );
-    const rawUf = (delivery?.UF ?? delivery?.uf ?? cliente?.UF ?? cliente?.uf || '').trim();
+    const dXMun = sanitize((rawCity || '').slice(0, 60));
+    const rawUf = (firstNonEmptyString(
+      delivery?.UF,
+      delivery?.uf,
+      cliente?.UF,
+      cliente?.uf
+    ) || '').trim();
     const normalizedUf = rawUf.toUpperCase().replace(/[^A-Z]/g, '').slice(0, 2);
     const dCEP = onlyDigits(delivery?.CEP ?? delivery?.cep ?? cliente?.CEP ?? cliente?.cep);
 

--- a/servidor/services/nfceEmitter.js
+++ b/servidor/services/nfceEmitter.js
@@ -1216,22 +1216,27 @@ const emitPdvSaleFiscal = async ({ sale, pdv, store, emissionDate, environment, 
   const hasCNPJ = /^\d{14}$/.test(destCNPJ);
   const hasIdE = !!destIdE;
 
-  const xNome = sanitize(
-    firstNonEmptyString(
-      cliente?.nome,
-      cliente?.razaoSocial,
-      cliente?.fantasia,
-      sale?.customerName,
-      sale?.customer?.nome,
-      sale?.customer?.razaoSocial,
-      sale?.customer?.fantasia,
-      sale?.cliente?.nome,
-      sale?.cliente?.razaoSocial,
-      sale?.cliente?.fantasia,
-      delivery?.nome
-    )
+  const isHomologation = tpAmb === '2';
+
+  const rawDestName = firstNonEmptyString(
+    cliente?.nome,
+    cliente?.razaoSocial,
+    cliente?.fantasia,
+    sale?.customerName,
+    sale?.customer?.nome,
+    sale?.customer?.razaoSocial,
+    sale?.customer?.fantasia,
+    sale?.cliente?.nome,
+    sale?.cliente?.razaoSocial,
+    sale?.cliente?.fantasia,
+    delivery?.nome
   );
-  const xNome60 = (xNome || 'CONSUMIDOR').slice(0, 60);
+
+  const destName = sanitize(
+    isHomologation
+      ? HOMOLOGATION_FIRST_ITEM_DESCRIPTION
+      : (rawDestName || 'CONSUMIDOR').slice(0, 60)
+  );
 
   if (hasCPF || hasCNPJ || hasIdE) {
     const dLgr = sanitize(delivery?.logradouro || cliente?.logradouro);
@@ -1259,7 +1264,7 @@ const emitPdvSaleFiscal = async ({ sale, pdv, store, emissionDate, environment, 
     else if (hasCPF) infNfeLines.push(`      <CPF>${destCPF}</CPF>`);
     else infNfeLines.push(`      <idEstrangeiro>${destIdE}</idEstrangeiro>`);
 
-    if (xNome60) infNfeLines.push(`      <xNome>${xNome60}</xNome>`);
+    if (destName) infNfeLines.push(`      <xNome>${destName}</xNome>`);
 
     if (hasAddr) {
       infNfeLines.push('      <enderDest>');
@@ -1283,8 +1288,6 @@ const emitPdvSaleFiscal = async ({ sale, pdv, store, emissionDate, environment, 
 
   let totalPis = 0;
   let totalCofins = 0;
-
-  const isHomologation = tpAmb === '2';
 
   fiscalItems.forEach((item, index) => {
     const product = item.productId ? productsMap.get(String(item.productId)) : null;

--- a/servidor/services/nfceEmitter.js
+++ b/servidor/services/nfceEmitter.js
@@ -74,6 +74,8 @@ const firstNonEmptyString = (...values) => {
 const BRAZILIAN_CNPJ_OID = '2.16.76.1.3.3';
 const HOMOLOGATION_FIRST_ITEM_DESCRIPTION =
   'NOTA FISCAL EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL';
+const HOMOLOGATION_DEST_NAME =
+  'NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL';
 
 const describeCertificate = (pem) => {
   if (!pem) {
@@ -1232,11 +1234,10 @@ const emitPdvSaleFiscal = async ({ sale, pdv, store, emissionDate, environment, 
     delivery?.nome
   );
 
-  const destName = sanitize(
-    isHomologation
-      ? HOMOLOGATION_FIRST_ITEM_DESCRIPTION
-      : (rawDestName || 'CONSUMIDOR').slice(0, 60)
-  );
+  const destNameSource = isHomologation
+    ? HOMOLOGATION_DEST_NAME
+    : rawDestName || 'CONSUMIDOR';
+  const destName = sanitize((destNameSource || '').slice(0, 60));
 
   if (hasCPF || hasCNPJ || hasIdE) {
     const dLgr = sanitize(delivery?.logradouro || cliente?.logradouro);


### PR DESCRIPTION
## Summary
- adiciona utilitário para selecionar valores não vazios ao montar a NFC-e
- preenche os dados do destinatário com CPF e nome do cliente sempre que informados na venda ou entrega

## Testing
- npm test *(falha: Variável de ambiente obrigatória não definida: CERT_PFX_PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e91f352c832399bb369db370b4c5