### PR TITLE
Add staff client management screen with address and pet handling

### DIFF
--- a/pages/funcionarios/clientes.html
+++ b/pages/funcionarios/clientes.html
@@ -41,7 +41,7 @@
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
                 <label for="cliente-codigo" class="block text-sm font-medium text-gray-700">Código</label>
-                <input id="cliente-codigo" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="Gerado automaticamente" />
+                <input id="cliente-codigo" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm bg-gray-100 focus:border-indigo-500 focus:ring-indigo-500" placeholder="Gerado automaticamente" readonly />
               </div>
               <div>
                 <label for="cliente-tipo" class="block text-sm font-medium text-gray-700">Tipo</label>

--- a/pages/funcionarios/clientes.html
+++ b/pages/funcionarios/clientes.html
@@ -2,8 +2,8 @@
 <html lang="pt-BR">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Funcionários — Clientes</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Funcionários — Cadastro de Cliente</title>
 
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
   <link rel="stylesheet" href="../../src/output.css">
@@ -12,19 +12,359 @@
   <div id="admin-header-placeholder"></div>
 
   <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
-    <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
-
-      <aside class="md:col-span-4">
+    <div class="grid grid-cols-1 lg:grid-cols-12 gap-6">
+      <aside class="lg:col-span-3">
         <div id="admin-sidebar-placeholder"></div>
       </aside>
 
-      <section class="md:col-span-4">
+      <section class="lg:col-span-9 space-y-6">
         <div class="bg-white rounded-lg shadow p-6">
-          <div class="flex items-center gap-3 mb-4">
-            <i class="fas fa-users text-gray-400 text-2xl"></i>
-            <h1 class="text-2xl font-bold text-gray-800">Clientes</h1>
+          <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div class="flex items-center gap-3">
+              <span class="flex h-12 w-12 items-center justify-center rounded-full bg-indigo-50 text-indigo-600">
+                <i class="fas fa-user-plus text-xl"></i>
+              </span>
+              <div>
+                <h1 class="text-2xl font-bold text-gray-800">Cadastro de Cliente</h1>
+                <p class="text-gray-500">Gerencie os dados dos clientes da empresa.</p>
+              </div>
+            </div>
+            <div class="flex items-center gap-2">
+              <button id="btn-novo-cliente" type="button" class="px-4 py-2 rounded border border-gray-300 text-gray-700 hover:bg-gray-50 transition">Novo Cliente</button>
+              <button form="cliente-form" id="btn-salvar-cliente" type="submit" class="px-4 py-2 rounded bg-indigo-600 text-white font-medium hover:bg-indigo-700 transition">Salvar</button>
+            </div>
           </div>
-          <p class="text-gray-600">Em breve: listagem e ferramentas de clientes.</p>
+
+          <form id="cliente-form" class="mt-6 space-y-6">
+            <input type="hidden" id="cliente-id" />
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label for="cliente-codigo" class="block text-sm font-medium text-gray-700">Código</label>
+                <input id="cliente-codigo" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="Gerado automaticamente" />
+              </div>
+              <div>
+                <label for="cliente-tipo" class="block text-sm font-medium text-gray-700">Tipo</label>
+                <select id="cliente-tipo" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                  <option value="pessoa_fisica">Pessoa Física</option>
+                  <option value="pessoa_juridica">Pessoa Jurídica</option>
+                </select>
+              </div>
+              <div>
+                <label for="cliente-pais" class="block text-sm font-medium text-gray-700">País</label>
+                <input id="cliente-pais" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" value="Brasil" />
+              </div>
+              <div>
+                <label for="cliente-empresa" class="block text-sm font-medium text-gray-700">Empresa</label>
+                <select id="cliente-empresa" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                  <option value="">Selecione uma empresa</option>
+                </select>
+              </div>
+            </div>
+
+            <div id="pf-fields" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label for="cliente-nome" class="block text-sm font-medium text-gray-700">Nome completo</label>
+                <input id="cliente-nome" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+              </div>
+              <div>
+                <label for="cliente-apelido" class="block text-sm font-medium text-gray-700">Apelido</label>
+                <input id="cliente-apelido" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+              </div>
+              <div>
+                <label for="cliente-cpf" class="block text-sm font-medium text-gray-700">CPF</label>
+                <input id="cliente-cpf" type="text" inputmode="numeric" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="000.000.000-00" />
+              </div>
+              <div>
+                <label for="cliente-rg" class="block text-sm font-medium text-gray-700">RG</label>
+                <input id="cliente-rg" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+              </div>
+              <div>
+                <label for="cliente-nascimento" class="block text-sm font-medium text-gray-700">Nascimento</label>
+                <input id="cliente-nascimento" type="date" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+              </div>
+              <div>
+                <label for="cliente-sexo" class="block text-sm font-medium text-gray-700">Sexo</label>
+                <select id="cliente-sexo" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                  <option value="">Selecione</option>
+                  <option value="masculino">Masculino</option>
+                  <option value="feminino">Feminino</option>
+                  <option value="outro">Outro</option>
+                  <option value="nao_informado">Prefere não informar</option>
+                </select>
+              </div>
+            </div>
+
+            <div id="pj-fields" class="grid grid-cols-1 md:grid-cols-2 gap-4 hidden">
+              <div>
+                <label for="cliente-razao-social" class="block text-sm font-medium text-gray-700">Razão Social</label>
+                <input id="cliente-razao-social" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+              </div>
+              <div>
+                <label for="cliente-nome-fantasia" class="block text-sm font-medium text-gray-700">Nome Fantasia</label>
+                <input id="cliente-nome-fantasia" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+              </div>
+              <div>
+                <label for="cliente-nome-contato" class="block text-sm font-medium text-gray-700">Nome do contato</label>
+                <input id="cliente-nome-contato" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+              </div>
+              <div>
+                <label for="cliente-inscricao-estadual" class="block text-sm font-medium text-gray-700">Inscrição Estadual</label>
+                <input id="cliente-inscricao-estadual" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+              </div>
+              <div class="flex items-center gap-2 mt-2 md:mt-6">
+                <input id="cliente-isento-ie" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" />
+                <label for="cliente-isento-ie" class="text-sm text-gray-700">Isento de IE</label>
+              </div>
+              <div>
+                <label for="cliente-estado-ie" class="block text-sm font-medium text-gray-700">Estado da IE</label>
+                <select id="cliente-estado-ie" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                  <option value="">Selecione o estado</option>
+                  <option value="AC">Acre</option>
+                  <option value="AL">Alagoas</option>
+                  <option value="AM">Amazonas</option>
+                  <option value="AP">Amapá</option>
+                  <option value="BA">Bahia</option>
+                  <option value="CE">Ceará</option>
+                  <option value="DF">Distrito Federal</option>
+                  <option value="ES">Espírito Santo</option>
+                  <option value="GO">Goiás</option>
+                  <option value="MA">Maranhão</option>
+                  <option value="MG">Minas Gerais</option>
+                  <option value="MS">Mato Grosso do Sul</option>
+                  <option value="MT">Mato Grosso</option>
+                  <option value="PA">Pará</option>
+                  <option value="PB">Paraíba</option>
+                  <option value="PE">Pernambuco</option>
+                  <option value="PI">Piauí</option>
+                  <option value="PR">Paraná</option>
+                  <option value="RJ">Rio de Janeiro</option>
+                  <option value="RN">Rio Grande do Norte</option>
+                  <option value="RO">Rondônia</option>
+                  <option value="RR">Roraima</option>
+                  <option value="RS">Rio Grande do Sul</option>
+                  <option value="SC">Santa Catarina</option>
+                  <option value="SE">Sergipe</option>
+                  <option value="SP">São Paulo</option>
+                  <option value="TO">Tocantins</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="border-t pt-4">
+              <div class="flex flex-wrap items-center gap-2 border-b pb-3">
+                <button type="button" class="tab-button px-4 py-2 rounded-md text-sm font-medium bg-indigo-100 text-indigo-700" data-tab="endereco">Endereço</button>
+                <button type="button" class="tab-button px-4 py-2 rounded-md text-sm font-medium text-gray-600 hover:bg-gray-100" data-tab="contato">Contato</button>
+                <button type="button" class="tab-button px-4 py-2 rounded-md text-sm font-medium text-gray-600 hover:bg-gray-100" data-tab="pendencias">Pendências</button>
+                <button type="button" class="tab-button px-4 py-2 rounded-md text-sm font-medium text-gray-600 hover:bg-gray-100" data-tab="animais">Animais</button>
+              </div>
+
+              <div class="mt-4 space-y-6">
+                <div class="tab-panel" data-tab-panel="endereco">
+                  <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div>
+                      <label for="endereco-cep" class="block text-sm font-medium text-gray-700">CEP</label>
+                      <input id="endereco-cep" type="text" inputmode="numeric" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="00000-000" />
+                    </div>
+                    <div>
+                      <label for="endereco-logradouro" class="block text-sm font-medium text-gray-700">Logradouro</label>
+                      <input id="endereco-logradouro" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                    </div>
+                    <div>
+                      <label for="endereco-numero" class="block text-sm font-medium text-gray-700">Número</label>
+                      <input id="endereco-numero" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                    </div>
+                    <div>
+                      <label for="endereco-complemento" class="block text-sm font-medium text-gray-700">Complemento</label>
+                      <input id="endereco-complemento" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                    </div>
+                    <div>
+                      <label for="endereco-bairro" class="block text-sm font-medium text-gray-700">Bairro</label>
+                      <input id="endereco-bairro" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                    </div>
+                    <div>
+                      <label for="endereco-cidade" class="block text-sm font-medium text-gray-700">Cidade</label>
+                      <input id="endereco-cidade" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                    </div>
+                    <div>
+                      <label for="endereco-apelido" class="block text-sm font-medium text-gray-700">Apelido</label>
+                      <input id="endereco-apelido" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="Principal, Cobrança, etc." />
+                    </div>
+                    <div>
+                      <label for="endereco-cod-ibge" class="block text-sm font-medium text-gray-700">Cod. IBGE Município</label>
+                      <input id="endereco-cod-ibge" type="text" inputmode="numeric" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                    </div>
+                    <div>
+                      <label for="endereco-cod-uf" class="block text-sm font-medium text-gray-700">Cod. UF (IBGE/SEFAZ)</label>
+                      <input id="endereco-cod-uf" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                    </div>
+                    <div>
+                      <label for="endereco-pais" class="block text-sm font-medium text-gray-700">País</label>
+                      <input id="endereco-pais" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" value="Brasil" />
+                    </div>
+                  </div>
+
+                  <div class="mt-4 flex flex-wrap items-center gap-2">
+                    <button id="btn-endereco-salvar" type="button" class="px-4 py-2 rounded bg-emerald-600 text-white text-sm font-medium hover:bg-emerald-700 transition">Salvar endereço</button>
+                    <button id="btn-endereco-cancelar" type="button" class="px-4 py-2 rounded border border-gray-300 text-sm font-medium text-gray-600 hover:bg-gray-50 transition hidden">Cancelar</button>
+                  </div>
+
+                  <div class="mt-6">
+                    <h3 class="text-sm font-semibold text-gray-700 mb-3">Endereços cadastrados</h3>
+                    <div id="enderecos-lista" class="grid grid-cols-1 md:grid-cols-2 gap-4"></div>
+                    <p id="enderecos-vazio" class="text-sm text-gray-500 hidden">Nenhum endereço cadastrado.</p>
+                  </div>
+                </div>
+
+                <div class="tab-panel hidden" data-tab-panel="contato">
+                  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                      <label for="cliente-email" class="block text-sm font-medium text-gray-700">Email</label>
+                      <input id="cliente-email" type="email" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                    </div>
+                    <div>
+                      <label for="cliente-celular" class="block text-sm font-medium text-gray-700">Celular</label>
+                      <input id="cliente-celular" type="text" inputmode="tel" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="(00) 00000-0000" />
+                    </div>
+                    <div>
+                      <label for="cliente-telefone" class="block text-sm font-medium text-gray-700">Telefone</label>
+                      <input id="cliente-telefone" type="text" inputmode="tel" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="(00) 0000-0000" />
+                    </div>
+                    <div>
+                      <label for="cliente-celular2" class="block text-sm font-medium text-gray-700">Celular 2</label>
+                      <input id="cliente-celular2" type="text" inputmode="tel" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                    </div>
+                    <div>
+                      <label for="cliente-telefone2" class="block text-sm font-medium text-gray-700">Telefone 2</label>
+                      <input id="cliente-telefone2" type="text" inputmode="tel" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                    </div>
+                  </div>
+                </div>
+
+                <div class="tab-panel hidden" data-tab-panel="pendencias">
+                  <div class="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-6 text-center text-sm text-gray-500">
+                    Pendências em construção.
+                  </div>
+                </div>
+
+                <div class="tab-panel hidden" data-tab-panel="animais">
+                  <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div>
+                      <label for="pet-nome" class="block text-sm font-medium text-gray-700">Nome do Pet</label>
+                      <input id="pet-nome" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                    </div>
+                    <div>
+                      <label for="pet-tipo" class="block text-sm font-medium text-gray-700">Tipo do Pet</label>
+                      <select id="pet-tipo" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        <option value="">Selecione</option>
+                        <option value="cachorro">Cachorro</option>
+                        <option value="gato">Gato</option>
+                        <option value="ave">Ave</option>
+                        <option value="roedor">Roedor</option>
+                        <option value="peixe">Peixe</option>
+                        <option value="reptil">Réptil</option>
+                        <option value="outro">Outro</option>
+                      </select>
+                    </div>
+                    <div>
+                      <label for="pet-porte" class="block text-sm font-medium text-gray-700">Porte</label>
+                      <select id="pet-porte" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        <option value="">Selecione</option>
+                        <option value="pequeno">Pequeno</option>
+                        <option value="medio">Médio</option>
+                        <option value="grande">Grande</option>
+                      </select>
+                    </div>
+                    <div>
+                      <label for="pet-raca" class="block text-sm font-medium text-gray-700">Raça</label>
+                      <input id="pet-raca" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                    </div>
+                    <div>
+                      <label for="pet-pelagem" class="block text-sm font-medium text-gray-700">Pelagem/Cor</label>
+                      <input id="pet-pelagem" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                    </div>
+                    <div>
+                      <label for="pet-nascimento" class="block text-sm font-medium text-gray-700">Nascimento</label>
+                      <input id="pet-nascimento" type="date" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                    </div>
+                    <div>
+                      <label for="pet-peso" class="block text-sm font-medium text-gray-700">Peso</label>
+                      <input id="pet-peso" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="Ex.: 8.5 kg" />
+                    </div>
+                    <div>
+                      <label for="pet-sexo" class="block text-sm font-medium text-gray-700">Sexo</label>
+                      <select id="pet-sexo" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        <option value="">Selecione</option>
+                        <option value="macho">Macho</option>
+                        <option value="femea">Fêmea</option>
+                      </select>
+                    </div>
+                    <div>
+                      <label for="pet-rga" class="block text-sm font-medium text-gray-700">RGA</label>
+                      <input id="pet-rga" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                    </div>
+                    <div>
+                      <label for="pet-microchip" class="block text-sm font-medium text-gray-700">Microchip</label>
+                      <input id="pet-microchip" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                    </div>
+                  </div>
+
+                  <div class="mt-4 flex flex-wrap items-center gap-2">
+                    <button id="btn-pet-salvar" type="button" class="px-4 py-2 rounded bg-emerald-600 text-white text-sm font-medium hover:bg-emerald-700 transition">Adicionar pet</button>
+                    <button id="btn-pet-cancelar" type="button" class="px-4 py-2 rounded border border-gray-300 text-sm font-medium text-gray-600 hover:bg-gray-50 transition hidden">Cancelar edição</button>
+                  </div>
+
+                  <div class="mt-6">
+                    <h3 class="text-sm font-semibold text-gray-700 mb-3">Animais cadastrados</h3>
+                    <div id="pets-lista" class="grid grid-cols-1 md:grid-cols-2 gap-4"></div>
+                    <p id="pets-vazio" class="text-sm text-gray-500 hidden">Nenhum pet cadastrado.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+
+        <div class="bg-white rounded-lg shadow p-6">
+          <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-4">
+            <div>
+              <h2 class="text-xl font-semibold text-gray-800">Clientes cadastrados</h2>
+              <p class="text-sm text-gray-500">Somente clientes (usuários não marcados como funcionários).</p>
+            </div>
+            <div class="flex items-center gap-2">
+              <input id="cliente-busca" type="text" class="w-full md:w-64 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="Buscar por nome, documento ou email" />
+              <button id="btn-busca-cliente" type="button" class="px-3 py-2 rounded bg-gray-800 text-white hover:bg-gray-900 transition"><i class="fas fa-search"></i></button>
+            </div>
+          </div>
+
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 text-sm">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-4 py-3 text-left font-semibold text-gray-600 uppercase tracking-wide">Código</th>
+                  <th class="px-4 py-3 text-left font-semibold text-gray-600 uppercase tracking-wide">Nome</th>
+                  <th class="px-4 py-3 text-left font-semibold text-gray-600 uppercase tracking-wide">Tipo</th>
+                  <th class="px-4 py-3 text-left font-semibold text-gray-600 uppercase tracking-wide">Documento</th>
+                  <th class="px-4 py-3 text-left font-semibold text-gray-600 uppercase tracking-wide">Empresa</th>
+                  <th class="px-4 py-3 text-left font-semibold text-gray-600 uppercase tracking-wide">Contato</th>
+                  <th class="px-4 py-3"></th>
+                </tr>
+              </thead>
+              <tbody id="clientes-tbody" class="divide-y divide-gray-200">
+                <tr>
+                  <td colspan="7" class="px-4 py-6 text-center text-gray-500 text-sm">Carregando clientes...</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="mt-4 flex items-center justify-between text-sm text-gray-500">
+            <div id="clientes-info">&nbsp;</div>
+            <div class="flex items-center gap-2">
+              <button id="clientes-prev" type="button" class="px-3 py-1 rounded border border-gray-300 text-gray-600 hover:bg-gray-50 transition">Anterior</button>
+              <button id="clientes-next" type="button" class="px-3 py-1 rounded border border-gray-300 text-gray-600 hover:bg-gray-50 transition">Próximo</button>
+            </div>
+          </div>
         </div>
       </section>
     </div>
@@ -40,5 +380,6 @@
   <script src="../../scripts/core/main.js"></script>
   <script src="../../scripts/admin/admin.js"></script>
   <script src="/scripts/common/modal-bridge.js"></script>
+  <script src="../../scripts/funcionarios/clientes.js"></script>
 </body>
 </html>

--- a/pages/funcionarios/clientes.html
+++ b/pages/funcionarios/clientes.html
@@ -6,6 +6,7 @@
   <title>Funcionários — Cadastro de Cliente</title>
 
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/awesomplete/1.1.5/awesomplete.min.css" integrity="sha512-YQ2GZWlznImPi0tLxe3LjXLp8dkUBaRdOy+nK8BPVKx/aRV+7Y6AmTAPGY7d8IvFcl1l0I/+ZZOco2wnBbUdeg==" crossorigin="anonymous" referrerpolicy="no-referrer">
   <link rel="stylesheet" href="../../src/output.css">
 </head>
 <body class="bg-gray-100">
@@ -259,10 +260,11 @@
                         <option value="">Selecione</option>
                         <option value="cachorro">Cachorro</option>
                         <option value="gato">Gato</option>
-                        <option value="ave">Ave</option>
-                        <option value="roedor">Roedor</option>
+                        <option value="passaro">Pássaro</option>
                         <option value="peixe">Peixe</option>
-                        <option value="reptil">Réptil</option>
+                        <option value="roedor">Roedor</option>
+                        <option value="lagarto">Lagarto</option>
+                        <option value="tartaruga">Tartaruga</option>
                         <option value="outro">Outro</option>
                       </select>
                     </div>
@@ -270,14 +272,17 @@
                       <label for="pet-porte" class="block text-sm font-medium text-gray-700">Porte</label>
                       <select id="pet-porte" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
                         <option value="">Selecione</option>
-                        <option value="pequeno">Pequeno</option>
-                        <option value="medio">Médio</option>
-                        <option value="grande">Grande</option>
+                        <option value="Sem porte definido">Sem porte definido</option>
+                        <option value="Mini">Mini</option>
+                        <option value="Pequeno">Pequeno</option>
+                        <option value="Médio">Médio</option>
+                        <option value="Grande">Grande</option>
+                        <option value="Gigante">Gigante</option>
                       </select>
                     </div>
                     <div>
                       <label for="pet-raca" class="block text-sm font-medium text-gray-700">Raça</label>
-                      <input id="pet-raca" type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" />
+                      <input id="pet-raca" type="text" class="awesomplete mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="Comece a digitar a raça..." />
                     </div>
                     <div>
                       <label for="pet-pelagem" class="block text-sm font-medium text-gray-700">Pelagem/Cor</label>
@@ -380,6 +385,7 @@
   <script src="../../scripts/core/main.js"></script>
   <script src="../../scripts/admin/admin.js"></script>
   <script src="/scripts/common/modal-bridge.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/awesomplete/1.1.5/awesomplete.min.js" integrity="sha512-6Z6/Dr7guPmyAnbcW2CYwiVdc+GqOR/mdrIW6DCeU44yWiNysGEKMluSleqrs9jwELyhl725LLJoPLD114F8ZA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="../../scripts/funcionarios/clientes.js"></script>
 </body>
 </html>

--- a/pages/funcionarios/clientes.html
+++ b/pages/funcionarios/clientes.html
@@ -11,13 +11,13 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
-    <div class="grid grid-cols-1 lg:grid-cols-12 gap-6">
-      <aside class="lg:col-span-3">
+  <main class="w-full px-6 pt-1 pb-8 min-h-screen">
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-[280px_minmax(0,1fr)]">
+      <aside>
         <div id="admin-sidebar-placeholder"></div>
       </aside>
 
-      <section class="lg:col-span-9 space-y-6">
+      <section class="space-y-6">
         <div class="bg-white rounded-lg shadow p-6">
           <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
             <div class="flex items-center gap-3">

--- a/pages/funcionarios/clientes.html
+++ b/pages/funcionarios/clientes.html
@@ -11,13 +11,13 @@
 <body class="bg-gray-100">
   <div id="admin-header-placeholder"></div>
 
-  <main class="w-full px-6 pt-1 pb-8 min-h-screen">
-    <div class="grid grid-cols-1 gap-6 lg:grid-cols-[280px_minmax(0,1fr)]">
-      <aside>
+  <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
+      <aside class="md:col-span-1">
         <div id="admin-sidebar-placeholder"></div>
       </aside>
 
-      <section class="space-y-6">
+      <section class="md:col-span-3 space-y-6">
         <div class="bg-white rounded-lg shadow p-6">
           <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
             <div class="flex items-center gap-3">

--- a/pages/funcionarios/clientes.html
+++ b/pages/funcionarios/clientes.html
@@ -13,11 +13,11 @@
 
   <main class="container mx-auto px-4 pt-1 pb-8 min-h-screen">
     <div class="grid grid-cols-1 md:grid-cols-4 gap-8">
-      <aside class="md:col-span-1">
+      <aside class="md:col-span-4">
         <div id="admin-sidebar-placeholder"></div>
       </aside>
 
-      <section class="md:col-span-3 space-y-6">
+      <section class="md:col-span-4 space-y-6">
         <div class="bg-white rounded-lg shadow p-6">
           <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
             <div class="flex items-center gap-3">

--- a/scripts/funcionarios/clientes.js
+++ b/scripts/funcionarios/clientes.js
@@ -341,7 +341,7 @@
           const contato = [cliente.email, cliente.celular ? formatPhone(cliente.celular) : ''].filter(Boolean).join('<br>');
           return `
             <tr class="hover:bg-gray-50">
-              <td class="px-4 py-3 align-top text-sm text-gray-700">${cliente.codigoCliente || '—'}</td>
+              <td class="px-4 py-3 align-top text-sm text-gray-700">${cliente.codigo || cliente._id || '—'}</td>
               <td class="px-4 py-3 align-top text-sm text-gray-900 font-medium">${cliente.nome || '—'}</td>
               <td class="px-4 py-3 align-top text-sm text-gray-700">${tipo}</td>
               <td class="px-4 py-3 align-top text-sm text-gray-700">${formatDocumento(cliente.documento) || '—'}</td>
@@ -403,7 +403,7 @@
         const data = await apiFetch(`/func/clientes/${id}`);
         state.currentClienteId = data._id;
         elements.inputId.value = data._id;
-        elements.inputCodigo.value = data.codigoCliente || '';
+        elements.inputCodigo.value = data.codigo || data._id || '';
         elements.selectTipo.value = data.tipoConta || 'pessoa_fisica';
         switchTipo(elements.selectTipo.value);
         elements.inputPais.value = data.pais || 'Brasil';

--- a/scripts/funcionarios/clientes.js
+++ b/scripts/funcionarios/clientes.js
@@ -467,24 +467,28 @@
       breeds = breeds.map((item) => fixEncoding(item)).sort((a, b) => a.localeCompare(b));
 
       if (racaInput) {
-        racaInput.setAttribute('data-list', breeds.join(','));
         racaInput.setAttribute('autocomplete', 'off');
       }
 
-      if (typeof Awesomplete !== 'undefined' && Awesomplete) {
-        const existing = racaInput.awesomplete || petAutocomplete.instance;
-        if (existing && existing.input === racaInput) {
-          existing.list = breeds;
-          if (typeof existing.evaluate === 'function') {
-            existing.evaluate();
-          }
-          petAutocomplete.instance = existing;
-        } else if (typeof Awesomplete === 'function') {
+      if (typeof Awesomplete === 'function') {
+        if (!petAutocomplete.instance || petAutocomplete.instance.input !== racaInput) {
           petAutocomplete.instance = new Awesomplete(racaInput, {
             minChars: 1,
             list: breeds,
             autoFirst: true,
           });
+        } else {
+          petAutocomplete.instance.list = breeds;
+        }
+
+        if (petAutocomplete.instance) {
+          if (typeof petAutocomplete.instance.evaluate === 'function') {
+            petAutocomplete.instance.evaluate();
+          }
+          if (document.activeElement === racaInput
+            && typeof petAutocomplete.instance.open === 'function') {
+            petAutocomplete.instance.open();
+          }
         }
       }
     }
@@ -1008,13 +1012,18 @@
       elements.pets.raca.addEventListener('awesomplete-selectcomplete', () => setTimeout(setPorteFromBreedIfDog, 0));
       elements.pets.raca.addEventListener('focus', () => {
         updateBreedOptions();
-        if (petAutocomplete.instance && typeof petAutocomplete.instance.evaluate === 'function') {
-          petAutocomplete.instance.evaluate();
+        if (petAutocomplete.instance && typeof petAutocomplete.instance.open === 'function') {
+          petAutocomplete.instance.open();
         }
       });
       elements.pets.raca.addEventListener('input', () => {
-        if (petAutocomplete.instance && typeof petAutocomplete.instance.evaluate === 'function') {
-          petAutocomplete.instance.evaluate();
+        if (petAutocomplete.instance) {
+          if (typeof petAutocomplete.instance.evaluate === 'function') {
+            petAutocomplete.instance.evaluate();
+          }
+          if (typeof petAutocomplete.instance.open === 'function') {
+            petAutocomplete.instance.open();
+          }
         }
       });
     }

--- a/scripts/funcionarios/clientes.js
+++ b/scripts/funcionarios/clientes.js
@@ -466,9 +466,19 @@
       }
       breeds = breeds.map((item) => fixEncoding(item)).sort((a, b) => a.localeCompare(b));
 
+      if (racaInput) {
+        racaInput.setAttribute('data-list', breeds.join(','));
+        racaInput.setAttribute('autocomplete', 'off');
+      }
+
       if (typeof Awesomplete !== 'undefined' && Awesomplete) {
-        if (petAutocomplete.instance && petAutocomplete.instance.input === racaInput) {
-          petAutocomplete.instance.list = breeds;
+        const existing = racaInput.awesomplete || petAutocomplete.instance;
+        if (existing && existing.input === racaInput) {
+          existing.list = breeds;
+          if (typeof existing.evaluate === 'function') {
+            existing.evaluate();
+          }
+          petAutocomplete.instance = existing;
         } else if (typeof Awesomplete === 'function') {
           petAutocomplete.instance = new Awesomplete(racaInput, {
             minChars: 1,
@@ -996,6 +1006,17 @@
         elements.pets.raca.addEventListener(evt, () => setTimeout(setPorteFromBreedIfDog, 0));
       });
       elements.pets.raca.addEventListener('awesomplete-selectcomplete', () => setTimeout(setPorteFromBreedIfDog, 0));
+      elements.pets.raca.addEventListener('focus', () => {
+        updateBreedOptions();
+        if (petAutocomplete.instance && typeof petAutocomplete.instance.evaluate === 'function') {
+          petAutocomplete.instance.evaluate();
+        }
+      });
+      elements.pets.raca.addEventListener('input', () => {
+        if (petAutocomplete.instance && typeof petAutocomplete.instance.evaluate === 'function') {
+          petAutocomplete.instance.evaluate();
+        }
+      });
     }
 
     elements.enderecosLista.addEventListener('click', (event) => {

--- a/scripts/funcionarios/clientes.js
+++ b/scripts/funcionarios/clientes.js
@@ -1,0 +1,764 @@
+(function () {
+  const API_BASE = API_CONFIG?.BASE_URL || 'http://localhost:3000/api';
+
+  const UF_CODE_MAP = {
+    AC: '12', AL: '27', AM: '13', AP: '16', BA: '29', CE: '23', DF: '53', ES: '32', GO: '52',
+    MA: '21', MG: '31', MS: '50', MT: '51', PA: '15', PB: '25', PE: '26', PI: '22', PR: '41',
+    RJ: '33', RN: '24', RO: '11', RR: '14', RS: '43', SC: '42', SE: '28', SP: '35', TO: '17',
+  };
+
+  function onlyDigits(value = '') {
+    return String(value || '').replace(/\D/g, '');
+  }
+
+  function formatCpf(value = '') {
+    const digits = onlyDigits(value).slice(0, 11);
+    if (!digits) return '';
+    return digits.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
+  }
+
+  function formatCnpj(value = '') {
+    const digits = onlyDigits(value).slice(0, 14);
+    if (!digits) return '';
+    return digits.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, '$1.$2.$3/$4-$5');
+  }
+
+  function formatPhone(value = '') {
+    const digits = onlyDigits(value).slice(0, 11);
+    if (!digits) return '';
+    if (digits.length <= 10) {
+      return digits.replace(/(\d{2})(\d{4})(\d{4})/, '($1) $2-$3');
+    }
+    return digits.replace(/(\d{2})(\d{5})(\d{4})/, '($1) $2-$3');
+  }
+
+  function formatCep(value = '') {
+    const digits = onlyDigits(value).slice(0, 8);
+    if (digits.length <= 5) return digits;
+    return `${digits.slice(0, 5)}-${digits.slice(5)}`;
+  }
+
+  function formatDocumento(value = '') {
+    const digits = onlyDigits(value);
+    if (digits.length === 11) return formatCpf(digits);
+    if (digits.length === 14) return formatCnpj(digits);
+    return value || '';
+  }
+
+  function toISODateInput(value) {
+    if (!value) return '';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '';
+    return date.toISOString().slice(0, 10);
+  }
+
+  function notify(message, type = 'info') {
+    if (typeof window.showToast === 'function') {
+      window.showToast(message, type, 4000);
+    } else {
+      const prefix = type === 'error' ? '[Erro]' : type === 'success' ? '[Sucesso]' : '[Info]';
+      console.log(prefix, message);
+    }
+  }
+
+  function getAuthToken() {
+    try {
+      const raw = localStorage.getItem('loggedInUser');
+      if (!raw) return '';
+      const parsed = JSON.parse(raw);
+      return parsed?.token || '';
+    } catch (err) {
+      console.error('Erro ao obter token', err);
+      return '';
+    }
+  }
+
+  async function apiFetch(path, options = {}) {
+    const token = getAuthToken();
+    const headers = Object.assign({ 'Content-Type': 'application/json' }, options.headers || {});
+    if (token) headers.Authorization = `Bearer ${token}`;
+    const config = Object.assign({}, options, { headers });
+    const resp = await fetch(`${API_BASE}${path}`, config);
+    if (!resp.ok) {
+      let message = 'Erro inesperado.';
+      try {
+        const data = await resp.json();
+        if (data?.message) message = data.message;
+      } catch (_) {
+        message = `${message} (status ${resp.status})`;
+      }
+      const error = new Error(message);
+      error.status = resp.status;
+      throw error;
+    }
+    if (resp.status === 204) return null;
+    const contentType = resp.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+      return resp.json();
+    }
+    return resp.text();
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const state = {
+      currentClienteId: null,
+      enderecos: [],
+      enderecoEditandoId: null,
+      pets: [],
+      petEditandoId: null,
+      tabAtual: 'endereco',
+      pagination: { page: 1, totalPages: 1, total: 0, limit: 10 },
+      busca: '',
+      empresas: [],
+      cepAbort: null,
+    };
+
+    const elements = {
+      form: document.getElementById('cliente-form'),
+      btnNovo: document.getElementById('btn-novo-cliente'),
+      btnSalvar: document.getElementById('btn-salvar-cliente'),
+      inputId: document.getElementById('cliente-id'),
+      inputCodigo: document.getElementById('cliente-codigo'),
+      selectTipo: document.getElementById('cliente-tipo'),
+      inputPais: document.getElementById('cliente-pais'),
+      selectEmpresa: document.getElementById('cliente-empresa'),
+      pfFields: document.getElementById('pf-fields'),
+      pjFields: document.getElementById('pj-fields'),
+      inputNome: document.getElementById('cliente-nome'),
+      inputApelido: document.getElementById('cliente-apelido'),
+      inputCpf: document.getElementById('cliente-cpf'),
+      inputRg: document.getElementById('cliente-rg'),
+      inputNascimento: document.getElementById('cliente-nascimento'),
+      selectSexo: document.getElementById('cliente-sexo'),
+      inputRazao: document.getElementById('cliente-razao-social'),
+      inputFantasia: document.getElementById('cliente-nome-fantasia'),
+      inputContato: document.getElementById('cliente-nome-contato'),
+      inputIE: document.getElementById('cliente-inscricao-estadual'),
+      checkboxIsentoIE: document.getElementById('cliente-isento-ie'),
+      selectEstadoIE: document.getElementById('cliente-estado-ie'),
+      tabButtons: Array.from(document.querySelectorAll('.tab-button')),
+      tabPanels: Array.from(document.querySelectorAll('.tab-panel')),
+      endereco: {
+        cep: document.getElementById('endereco-cep'),
+        logradouro: document.getElementById('endereco-logradouro'),
+        numero: document.getElementById('endereco-numero'),
+        complemento: document.getElementById('endereco-complemento'),
+        bairro: document.getElementById('endereco-bairro'),
+        cidade: document.getElementById('endereco-cidade'),
+        apelido: document.getElementById('endereco-apelido'),
+        codIbge: document.getElementById('endereco-cod-ibge'),
+        codUf: document.getElementById('endereco-cod-uf'),
+        pais: document.getElementById('endereco-pais'),
+      },
+      btnEnderecoSalvar: document.getElementById('btn-endereco-salvar'),
+      btnEnderecoCancelar: document.getElementById('btn-endereco-cancelar'),
+      enderecosLista: document.getElementById('enderecos-lista'),
+      enderecosVazio: document.getElementById('enderecos-vazio'),
+      contato: {
+        email: document.getElementById('cliente-email'),
+        celular: document.getElementById('cliente-celular'),
+        telefone: document.getElementById('cliente-telefone'),
+        celular2: document.getElementById('cliente-celular2'),
+        telefone2: document.getElementById('cliente-telefone2'),
+      },
+      pets: {
+        nome: document.getElementById('pet-nome'),
+        tipo: document.getElementById('pet-tipo'),
+        porte: document.getElementById('pet-porte'),
+        raca: document.getElementById('pet-raca'),
+        pelagem: document.getElementById('pet-pelagem'),
+        nascimento: document.getElementById('pet-nascimento'),
+        peso: document.getElementById('pet-peso'),
+        sexo: document.getElementById('pet-sexo'),
+        rga: document.getElementById('pet-rga'),
+        microchip: document.getElementById('pet-microchip'),
+      },
+      btnPetSalvar: document.getElementById('btn-pet-salvar'),
+      btnPetCancelar: document.getElementById('btn-pet-cancelar'),
+      petsLista: document.getElementById('pets-lista'),
+      petsVazio: document.getElementById('pets-vazio'),
+      busca: document.getElementById('cliente-busca'),
+      btnBusca: document.getElementById('btn-busca-cliente'),
+      tabelaBody: document.getElementById('clientes-tbody'),
+      info: document.getElementById('clientes-info'),
+      btnPrev: document.getElementById('clientes-prev'),
+      btnNext: document.getElementById('clientes-next'),
+    };
+
+    function switchTipo(tipo) {
+      const isPJ = tipo === 'pessoa_juridica';
+      elements.selectTipo.value = tipo;
+      elements.pfFields.classList.toggle('hidden', isPJ);
+      elements.pjFields.classList.toggle('hidden', !isPJ);
+    }
+
+    function switchTab(tab) {
+      state.tabAtual = tab;
+      elements.tabButtons.forEach((btn) => {
+        const isActive = btn.dataset.tab === tab;
+        btn.classList.toggle('bg-indigo-100', isActive);
+        btn.classList.toggle('text-indigo-700', isActive);
+        btn.classList.toggle('text-gray-600', !isActive);
+      });
+      elements.tabPanels.forEach((panel) => {
+        panel.classList.toggle('hidden', panel.dataset.tabPanel !== tab);
+      });
+    }
+
+    function clearEnderecoForm() {
+      state.enderecoEditandoId = null;
+      Object.values(elements.endereco).forEach((input) => {
+        if (input) input.value = input.id === 'endereco-pais' ? 'Brasil' : '';
+      });
+      elements.btnEnderecoCancelar.classList.add('hidden');
+      elements.btnEnderecoSalvar.textContent = 'Salvar endereço';
+    }
+
+    function clearPetForm() {
+      state.petEditandoId = null;
+      Object.values(elements.pets).forEach((input) => {
+        if (input) input.value = '';
+      });
+      elements.btnPetCancelar.classList.add('hidden');
+      elements.btnPetSalvar.textContent = 'Adicionar pet';
+    }
+
+    function clearForm() {
+      state.currentClienteId = null;
+      elements.inputId.value = '';
+      elements.inputCodigo.value = '';
+      elements.inputPais.value = 'Brasil';
+      elements.selectEmpresa.value = '';
+      elements.inputNome.value = '';
+      elements.inputApelido.value = '';
+      elements.inputCpf.value = '';
+      elements.inputRg.value = '';
+      elements.inputNascimento.value = '';
+      elements.selectSexo.value = '';
+      elements.inputRazao.value = '';
+      elements.inputFantasia.value = '';
+      elements.inputContato.value = '';
+      elements.inputIE.value = '';
+      elements.checkboxIsentoIE.checked = false;
+      elements.inputIE.removeAttribute('disabled');
+      elements.selectEstadoIE.value = '';
+      switchTipo('pessoa_fisica');
+      Object.values(elements.contato).forEach((input) => { if (input) input.value = ''; });
+      state.enderecos = [];
+      renderEnderecos();
+      state.pets = [];
+      renderPets();
+      clearEnderecoForm();
+      clearPetForm();
+    }
+
+    async function loadEmpresas() {
+      try {
+        const lojas = await fetch(`${API_BASE}/stores`).then((r) => r.json());
+        state.empresas = Array.isArray(lojas) ? lojas : [];
+        elements.selectEmpresa.innerHTML = '<option value="">Selecione uma empresa</option>' +
+          state.empresas.map((loja) => `<option value="${loja._id}">${loja.nomeFantasia || loja.nome || loja.razaoSocial || 'Empresa sem nome'}</option>`).join('');
+      } catch (err) {
+        console.error('Erro ao carregar empresas', err);
+      }
+    }
+
+    function renderEnderecos() {
+      const lista = elements.enderecosLista;
+      lista.innerHTML = '';
+      if (!state.enderecos.length) {
+        elements.enderecosVazio.classList.remove('hidden');
+        return;
+      }
+      elements.enderecosVazio.classList.add('hidden');
+      state.enderecos.forEach((item) => {
+        const card = document.createElement('div');
+        card.className = 'rounded-lg border border-gray-200 p-4 shadow-sm bg-gray-50';
+        const linhas = [
+          `${item.apelido || 'Endereço'}${item.isDefault ? ' <span class="ml-1 inline-flex items-center rounded bg-emerald-100 px-2 py-0.5 text-xs font-semibold text-emerald-700">Principal</span>' : ''}`,
+          `${item.logradouro || ''} ${item.numero || ''}`.trim(),
+          `${item.bairro || ''} - ${item.cidade || ''}/${item.uf || ''}`,
+          `${item.cep ? formatCep(item.cep) : ''}`,
+          item.codIbgeMunicipio ? `IBGE: ${item.codIbgeMunicipio}` : '',
+          item.codUf ? `Cod. UF: ${item.codUf}` : '',
+        ].filter(Boolean);
+        card.innerHTML = `
+          <div class="flex flex-col gap-2 text-sm text-gray-700">
+            ${linhas.map((linha, index) => index === 0 ? `<div class="font-semibold text-gray-800">${linha}</div>` : `<div>${linha}</div>`).join('')}
+          </div>
+          <div class="mt-3 flex items-center gap-2">
+            <button data-id="${item._id}" data-action="editar" class="px-3 py-1.5 rounded border border-indigo-200 text-indigo-600 text-xs font-medium hover:bg-indigo-50">Editar</button>
+            <button data-id="${item._id}" data-action="remover" class="px-3 py-1.5 rounded border border-red-200 text-red-600 text-xs font-medium hover:bg-red-50">Remover</button>
+          </div>
+        `;
+        lista.appendChild(card);
+      });
+    }
+
+    function renderPets() {
+      const lista = elements.petsLista;
+      lista.innerHTML = '';
+      if (!state.pets.length) {
+        elements.petsVazio.classList.remove('hidden');
+        return;
+      }
+      elements.petsVazio.classList.add('hidden');
+      state.pets.forEach((pet) => {
+        const card = document.createElement('div');
+        card.className = 'rounded-lg border border-gray-200 p-4 shadow-sm bg-white';
+        const nascimento = pet.dataNascimento ? toISODateInput(pet.dataNascimento) : '';
+        const detalhes = [
+          pet.tipo ? `Tipo: ${pet.tipo}` : '',
+          pet.raca ? `Raça: ${pet.raca}` : '',
+          pet.porte ? `Porte: ${pet.porte}` : '',
+          pet.pelagemCor ? `Pelagem: ${pet.pelagemCor}` : '',
+          nascimento ? `Nascimento: ${nascimento.split('-').reverse().join('/')}` : '',
+          pet.peso ? `Peso: ${pet.peso}` : '',
+          pet.sexo ? `Sexo: ${pet.sexo}` : '',
+          pet.rga ? `RGA: ${pet.rga}` : '',
+          pet.microchip ? `Microchip: ${pet.microchip}` : '',
+        ].filter(Boolean);
+        card.innerHTML = `
+          <div class="flex flex-col gap-1 text-sm text-gray-700">
+            <div class="text-base font-semibold text-gray-800">${pet.nome}</div>
+            ${detalhes.map((linha) => `<div>${linha}</div>`).join('')}
+          </div>
+          <div class="mt-3 flex items-center gap-2">
+            <button data-id="${pet._id}" data-action="editar-pet" class="px-3 py-1.5 rounded border border-indigo-200 text-indigo-600 text-xs font-medium hover:bg-indigo-50">Editar</button>
+            <button data-id="${pet._id}" data-action="remover-pet" class="px-3 py-1.5 rounded border border-red-200 text-red-600 text-xs font-medium hover:bg-red-50">Remover</button>
+          </div>
+        `;
+        lista.appendChild(card);
+      });
+    }
+
+    function renderClientes(items = [], pagination) {
+      if (!Array.isArray(items) || !items.length) {
+        elements.tabelaBody.innerHTML = '<tr><td colspan="7" class="px-4 py-6 text-center text-gray-500 text-sm">Nenhum cliente encontrado.</td></tr>';
+      } else {
+        elements.tabelaBody.innerHTML = items.map((cliente) => {
+          const tipo = cliente.tipoConta === 'pessoa_juridica' ? 'Jurídica' : 'Física';
+          const contato = [cliente.email, cliente.celular ? formatPhone(cliente.celular) : ''].filter(Boolean).join('<br>');
+          return `
+            <tr class="hover:bg-gray-50">
+              <td class="px-4 py-3 align-top text-sm text-gray-700">${cliente.codigoCliente || '—'}</td>
+              <td class="px-4 py-3 align-top text-sm text-gray-900 font-medium">${cliente.nome || '—'}</td>
+              <td class="px-4 py-3 align-top text-sm text-gray-700">${tipo}</td>
+              <td class="px-4 py-3 align-top text-sm text-gray-700">${formatDocumento(cliente.documento) || '—'}</td>
+              <td class="px-4 py-3 align-top text-sm text-gray-700">${cliente.empresa || '—'}</td>
+              <td class="px-4 py-3 align-top text-sm text-gray-700">${contato || '—'}</td>
+              <td class="px-4 py-3 align-top text-right text-sm">
+                <button data-id="${cliente._id}" class="btn-editar-cliente px-3 py-1.5 rounded bg-indigo-600 text-white text-xs font-medium hover:bg-indigo-700">Editar</button>
+              </td>
+            </tr>
+          `;
+        }).join('');
+      }
+      if (pagination) {
+        state.pagination = pagination;
+        const { page, totalPages, total } = pagination;
+        elements.info.textContent = `Página ${page} de ${totalPages} — ${total} cliente(s)`;
+        elements.btnPrev.disabled = page <= 1;
+        elements.btnNext.disabled = page >= totalPages;
+        elements.btnPrev.classList.toggle('opacity-50', elements.btnPrev.disabled);
+        elements.btnNext.classList.toggle('opacity-50', elements.btnNext.disabled);
+      }
+    }
+
+    async function loadClientes(page = 1) {
+      try {
+        const params = new URLSearchParams({ page: String(page), limit: String(state.pagination.limit), search: state.busca || '' });
+        const data = await apiFetch(`/func/clientes?${params.toString()}`);
+        renderClientes(data.items || [], data.pagination || state.pagination);
+      } catch (err) {
+        console.error('Erro ao listar clientes', err);
+        notify(err.message || 'Erro ao listar clientes', 'error');
+      }
+    }
+
+    async function loadEnderecos() {
+      if (!state.currentClienteId) return;
+      try {
+        const data = await apiFetch(`/func/clientes/${state.currentClienteId}/enderecos`);
+        state.enderecos = Array.isArray(data) ? data : [];
+        renderEnderecos();
+      } catch (err) {
+        console.error('Erro ao carregar endereços', err);
+      }
+    }
+
+    async function loadPets() {
+      if (!state.currentClienteId) return;
+      try {
+        const data = await apiFetch(`/func/clientes/${state.currentClienteId}/pets`);
+        state.pets = Array.isArray(data) ? data : [];
+        renderPets();
+      } catch (err) {
+        console.error('Erro ao carregar pets', err);
+      }
+    }
+
+    async function loadCliente(id) {
+      try {
+        const data = await apiFetch(`/func/clientes/${id}`);
+        state.currentClienteId = data._id;
+        elements.inputId.value = data._id;
+        elements.inputCodigo.value = data.codigoCliente || '';
+        elements.selectTipo.value = data.tipoConta || 'pessoa_fisica';
+        switchTipo(elements.selectTipo.value);
+        elements.inputPais.value = data.pais || 'Brasil';
+        if (data.empresaPrincipal?._id) {
+          elements.selectEmpresa.value = data.empresaPrincipal._id;
+        } else {
+          elements.selectEmpresa.value = '';
+        }
+        elements.inputNome.value = data.nome || data.nomeCompleto || '';
+        elements.inputApelido.value = data.apelido || '';
+        elements.inputCpf.value = formatCpf(data.cpf || '');
+        elements.inputRg.value = data.rgNumero || '';
+        elements.inputNascimento.value = data.dataNascimento || '';
+        elements.selectSexo.value = data.genero || '';
+        elements.inputRazao.value = data.razaoSocial || '';
+        elements.inputFantasia.value = data.nomeFantasia || '';
+        elements.inputContato.value = data.nomeContato || '';
+        elements.inputIE.value = data.inscricaoEstadual || '';
+        elements.checkboxIsentoIE.checked = !!data.isentoIE;
+        if (elements.checkboxIsentoIE.checked) {
+          elements.inputIE.value = 'ISENTO';
+          elements.inputIE.setAttribute('disabled', 'disabled');
+        } else {
+          elements.inputIE.removeAttribute('disabled');
+        }
+        elements.selectEstadoIE.value = data.estadoIE || '';
+        elements.contato.email.value = data.email || '';
+        elements.contato.celular.value = formatPhone(data.celular || '');
+        elements.contato.telefone.value = formatPhone(data.telefone || '');
+        elements.contato.celular2.value = formatPhone(data.celularSecundario || '');
+        elements.contato.telefone2.value = formatPhone(data.telefoneSecundario || '');
+        state.enderecos = Array.isArray(data.enderecos) ? data.enderecos : [];
+        renderEnderecos();
+        await loadPets();
+        notify('Cliente carregado.', 'success');
+      } catch (err) {
+        console.error('Erro ao carregar cliente', err);
+        notify(err.message || 'Erro ao carregar cliente.', 'error');
+      }
+    }
+
+    async function salvarCliente(event) {
+      event.preventDefault();
+      const tipoConta = elements.selectTipo.value === 'pessoa_juridica' ? 'pessoa_juridica' : 'pessoa_fisica';
+      const payload = {
+        tipoConta,
+        codigoCliente: elements.inputCodigo.value.trim(),
+        pais: elements.inputPais.value.trim() || 'Brasil',
+        empresaId: elements.selectEmpresa.value || '',
+        email: elements.contato.email.value.trim(),
+        celular: onlyDigits(elements.contato.celular.value),
+        telefone: onlyDigits(elements.contato.telefone.value),
+        celular2: onlyDigits(elements.contato.celular2.value),
+        telefone2: onlyDigits(elements.contato.telefone2.value),
+      };
+
+      if (tipoConta === 'pessoa_fisica') {
+        payload.nome = elements.inputNome.value.trim();
+        payload.apelido = elements.inputApelido.value.trim();
+        payload.cpf = onlyDigits(elements.inputCpf.value);
+        payload.rg = elements.inputRg.value.trim();
+        payload.nascimento = elements.inputNascimento.value;
+        payload.sexo = elements.selectSexo.value;
+      } else {
+        payload.razaoSocial = elements.inputRazao.value.trim();
+        payload.nomeFantasia = elements.inputFantasia.value.trim();
+        payload.nomeContato = elements.inputContato.value.trim();
+        payload.inscricaoEstadual = elements.inputIE.value.trim();
+        payload.estadoIE = elements.selectEstadoIE.value;
+        payload.isentoIE = elements.checkboxIsentoIE.checked;
+      }
+
+      const method = state.currentClienteId ? 'PUT' : 'POST';
+      const path = state.currentClienteId ? `/func/clientes/${state.currentClienteId}` : '/func/clientes';
+
+      try {
+        const data = await apiFetch(path, {
+          method,
+          body: JSON.stringify(payload),
+        });
+        notify(method === 'POST' ? 'Cliente cadastrado com sucesso.' : 'Cliente atualizado com sucesso.', 'success');
+        await loadClientes(method === 'POST' ? 1 : state.pagination.page);
+        if (method === 'POST' && data?.id) {
+          await loadCliente(data.id);
+        } else if (state.currentClienteId) {
+          await loadCliente(state.currentClienteId);
+        }
+      } catch (err) {
+        console.error('Erro ao salvar cliente', err);
+        notify(err.message || 'Erro ao salvar cliente.', 'error');
+      }
+    }
+
+    async function salvarEndereco() {
+      if (!state.currentClienteId) {
+        notify('Salve o cliente antes de adicionar endereços.', 'warning');
+        return;
+      }
+      const cep = elements.endereco.cep.value;
+      const payload = {
+        cep,
+        logradouro: elements.endereco.logradouro.value,
+        numero: elements.endereco.numero.value,
+        complemento: elements.endereco.complemento.value,
+        bairro: elements.endereco.bairro.value,
+        cidade: elements.endereco.cidade.value,
+        apelido: elements.endereco.apelido.value,
+        codIbgeMunicipio: elements.endereco.codIbge.value,
+        codUf: elements.endereco.codUf.value,
+        pais: elements.endereco.pais.value,
+      };
+      const isEdicao = !!state.enderecoEditandoId;
+      const path = isEdicao
+        ? `/func/clientes/${state.currentClienteId}/enderecos/${state.enderecoEditandoId}`
+        : `/func/clientes/${state.currentClienteId}/enderecos`;
+      try {
+        await apiFetch(path, {
+          method: isEdicao ? 'PUT' : 'POST',
+          body: JSON.stringify(payload),
+        });
+        notify(isEdicao ? 'Endereço atualizado.' : 'Endereço adicionado.', 'success');
+        clearEnderecoForm();
+        await loadEnderecos();
+      } catch (err) {
+        console.error('Erro ao salvar endereço', err);
+        notify(err.message || 'Erro ao salvar endereço.', 'error');
+      }
+    }
+
+    async function removerEndereco(id) {
+      if (!state.currentClienteId) return;
+      const confirmar = window.confirm('Deseja remover este endereço?');
+      if (!confirmar) return;
+      try {
+        await apiFetch(`/func/clientes/${state.currentClienteId}/enderecos/${id}`, { method: 'DELETE' });
+        notify('Endereço removido.', 'success');
+        if (state.enderecoEditandoId === id) {
+          clearEnderecoForm();
+        }
+        await loadEnderecos();
+      } catch (err) {
+        console.error('Erro ao remover endereço', err);
+        notify(err.message || 'Erro ao remover endereço.', 'error');
+      }
+    }
+
+    async function salvarPet() {
+      if (!state.currentClienteId) {
+        notify('Salve o cliente antes de adicionar animais.', 'warning');
+        return;
+      }
+      const payload = {
+        nome: elements.pets.nome.value.trim(),
+        tipo: elements.pets.tipo.value,
+        porte: elements.pets.porte.value,
+        raca: elements.pets.raca.value.trim(),
+        pelagem: elements.pets.pelagem.value.trim(),
+        nascimento: elements.pets.nascimento.value,
+        peso: elements.pets.peso.value.trim(),
+        sexo: elements.pets.sexo.value,
+        rga: elements.pets.rga.value.trim(),
+        microchip: elements.pets.microchip.value.trim(),
+      };
+      const isEdicao = !!state.petEditandoId;
+      const path = isEdicao
+        ? `/func/clientes/${state.currentClienteId}/pets/${state.petEditandoId}`
+        : `/func/clientes/${state.currentClienteId}/pets`;
+      try {
+        await apiFetch(path, {
+          method: isEdicao ? 'PUT' : 'POST',
+          body: JSON.stringify(payload),
+        });
+        notify(isEdicao ? 'Pet atualizado.' : 'Pet cadastrado.', 'success');
+        clearPetForm();
+        await loadPets();
+      } catch (err) {
+        console.error('Erro ao salvar pet', err);
+        notify(err.message || 'Erro ao salvar pet.', 'error');
+      }
+    }
+
+    async function removerPet(id) {
+      if (!state.currentClienteId) return;
+      const confirmar = window.confirm('Deseja remover este pet?');
+      if (!confirmar) return;
+      try {
+        await apiFetch(`/func/clientes/${state.currentClienteId}/pets/${id}`, { method: 'DELETE' });
+        notify('Pet removido.', 'success');
+        if (state.petEditandoId === id) {
+          clearPetForm();
+        }
+        await loadPets();
+      } catch (err) {
+        console.error('Erro ao remover pet', err);
+        notify(err.message || 'Erro ao remover pet.', 'error');
+      }
+    }
+
+    async function consultarCep(value) {
+      const digits = onlyDigits(value);
+      if (digits.length !== 8) return;
+      if (state.cepAbort) {
+        state.cepAbort.abort();
+      }
+      state.cepAbort = new AbortController();
+      try {
+        const resp = await fetch(`https://viacep.com.br/ws/${digits}/json/`, { signal: state.cepAbort.signal });
+        if (!resp.ok) throw new Error('CEP não encontrado.');
+        const data = await resp.json();
+        if (data.erro) throw new Error('CEP não encontrado.');
+        elements.endereco.logradouro.value = data.logradouro || '';
+        elements.endereco.bairro.value = data.bairro || '';
+        elements.endereco.cidade.value = data.localidade || '';
+        if (!elements.endereco.apelido.value) {
+          elements.endereco.apelido.value = 'Principal';
+        }
+        elements.endereco.cep.value = formatCep(digits);
+        elements.endereco.codIbge.value = data.ibge || '';
+        const uf = (data.uf || '').toUpperCase();
+        if (uf) {
+          elements.endereco.codUf.value = UF_CODE_MAP[uf] || '';
+        }
+      } catch (err) {
+        if (err.name === 'AbortError') return;
+        console.warn('Erro ao consultar CEP', err);
+      }
+    }
+
+    elements.selectTipo.addEventListener('change', () => {
+      switchTipo(elements.selectTipo.value);
+    });
+
+    elements.checkboxIsentoIE.addEventListener('change', () => {
+      if (elements.checkboxIsentoIE.checked) {
+        elements.inputIE.value = 'ISENTO';
+        elements.inputIE.setAttribute('disabled', 'disabled');
+      } else {
+        elements.inputIE.removeAttribute('disabled');
+        elements.inputIE.value = '';
+      }
+    });
+
+    elements.tabButtons.forEach((btn) => {
+      btn.addEventListener('click', () => switchTab(btn.dataset.tab));
+    });
+
+    switchTab('endereco');
+
+    elements.form.addEventListener('submit', salvarCliente);
+    elements.btnNovo.addEventListener('click', () => {
+      clearForm();
+      notify('Formulário limpo.', 'info');
+    });
+
+    elements.btnEnderecoSalvar.addEventListener('click', salvarEndereco);
+    elements.btnEnderecoCancelar.addEventListener('click', () => {
+      clearEnderecoForm();
+    });
+
+    elements.btnPetSalvar.addEventListener('click', salvarPet);
+    elements.btnPetCancelar.addEventListener('click', () => {
+      clearPetForm();
+    });
+
+    elements.enderecosLista.addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-action]');
+      if (!button) return;
+      const id = button.dataset.id;
+      const action = button.dataset.action;
+      const endereco = state.enderecos.find((item) => item._id === id);
+      if (action === 'editar' && endereco) {
+        state.enderecoEditandoId = id;
+        elements.endereco.cep.value = formatCep(endereco.cep || '');
+        elements.endereco.logradouro.value = endereco.logradouro || '';
+        elements.endereco.numero.value = endereco.numero || '';
+        elements.endereco.complemento.value = endereco.complemento || '';
+        elements.endereco.bairro.value = endereco.bairro || '';
+        elements.endereco.cidade.value = endereco.cidade || '';
+        elements.endereco.apelido.value = endereco.apelido || '';
+        elements.endereco.codIbge.value = endereco.codIbgeMunicipio || '';
+        elements.endereco.codUf.value = endereco.codUf || '';
+        elements.endereco.pais.value = endereco.pais || 'Brasil';
+        elements.btnEnderecoCancelar.classList.remove('hidden');
+        elements.btnEnderecoSalvar.textContent = 'Atualizar endereço';
+        switchTab('endereco');
+      } else if (action === 'remover') {
+        removerEndereco(id);
+      }
+    });
+
+    elements.petsLista.addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-action]');
+      if (!button) return;
+      const id = button.dataset.id;
+      const action = button.dataset.action;
+      const pet = state.pets.find((item) => item._id === id);
+      if (action === 'editar-pet' && pet) {
+        state.petEditandoId = id;
+        elements.pets.nome.value = pet.nome || '';
+        elements.pets.tipo.value = pet.tipo || '';
+        elements.pets.porte.value = pet.porte || '';
+        elements.pets.raca.value = pet.raca || '';
+        elements.pets.pelagem.value = pet.pelagemCor || '';
+        elements.pets.nascimento.value = toISODateInput(pet.dataNascimento);
+        elements.pets.peso.value = pet.peso || '';
+        elements.pets.sexo.value = pet.sexo || '';
+        elements.pets.rga.value = pet.rga || '';
+        elements.pets.microchip.value = pet.microchip || '';
+        elements.btnPetCancelar.classList.remove('hidden');
+        elements.btnPetSalvar.textContent = 'Atualizar pet';
+        switchTab('animais');
+      } else if (action === 'remover-pet') {
+        removerPet(id);
+      }
+    });
+
+    elements.tabelaBody.addEventListener('click', (event) => {
+      const button = event.target.closest('.btn-editar-cliente');
+      if (!button) return;
+      const id = button.dataset.id;
+      if (!id) return;
+      loadCliente(id);
+    });
+
+    elements.btnPrev.addEventListener('click', () => {
+      if (state.pagination.page > 1) {
+        loadClientes(state.pagination.page - 1);
+      }
+    });
+
+    elements.btnNext.addEventListener('click', () => {
+      if (state.pagination.page < state.pagination.totalPages) {
+        loadClientes(state.pagination.page + 1);
+      }
+    });
+
+    elements.btnBusca.addEventListener('click', () => {
+      state.busca = elements.busca.value.trim();
+      loadClientes(1);
+    });
+
+    elements.busca.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        state.busca = elements.busca.value.trim();
+        loadClientes(1);
+      }
+    });
+
+    elements.endereco.cep.addEventListener('blur', () => {
+      consultarCep(elements.endereco.cep.value);
+    });
+
+    clearForm();
+    loadEmpresas();
+    loadClientes();
+  });
+})();

--- a/scripts/funcionarios/clientes.js
+++ b/scripts/funcionarios/clientes.js
@@ -450,7 +450,6 @@
       const tipoConta = elements.selectTipo.value === 'pessoa_juridica' ? 'pessoa_juridica' : 'pessoa_fisica';
       const payload = {
         tipoConta,
-        codigoCliente: elements.inputCodigo.value.trim(),
         pais: elements.inputPais.value.trim() || 'Brasil',
         empresaId: elements.selectEmpresa.value || '',
         email: elements.contato.email.value.trim(),

--- a/servidor/models/User.js
+++ b/servidor/models/User.js
@@ -32,6 +32,14 @@ const userSchema = new Schema({
     type: String // Opcional
   },
 
+  // Dados adicionais comuns a todos os clientes
+  codigoCliente: { type: String, trim: true },
+  apelido: { type: String, trim: true },
+  pais: { type: String, trim: true, default: 'Brasil' },
+  celularSecundario: { type: String, trim: true },
+  telefoneSecundario: { type: String, trim: true },
+  empresaPrincipal: { type: Schema.Types.ObjectId, ref: 'Store' },
+
   // --- Campos Específicos de Pessoa Física ---
   nomeCompleto: { type: String },
   cpf: { type: String, unique: true, sparse: true },
@@ -159,6 +167,7 @@ const userSchema = new Schema({
   razaoSocial: { type: String },
   cnpj: { type: String, unique: true, sparse: true },
   nomeContato: { type: String },
+  nomeFantasia: { type: String },
   inscricaoEstadual: { type: String },
   estadoIE: { type: String },
   isentoIE: { type: Boolean, default: false },

--- a/servidor/models/UserAddress.js
+++ b/servidor/models/UserAddress.js
@@ -15,6 +15,9 @@ const userAddressSchema = new mongoose.Schema({
   cidade:     { type: String, default: '' },
   uf:         { type: String, default: '' },
   ibge:       { type: String, default: '' },
+  codIbgeMunicipio: { type: String, default: '' },
+  codUf:      { type: String, default: '' },
+  pais:       { type: String, default: 'Brasil' },
 
   // Marcação de endereço principal
   isDefault: { type: Boolean, default: true }


### PR DESCRIPTION
## Summary
- replace the RH clientes page with a full customer registration workflow including tabs for addresses, contact data, pendências placeholder and animal records
- implement a dedicated staff client management script that handles CEP autofill, address cards, pet CRUD and paginated customer listings
- extend the user and user address models plus the /api/func endpoints to persist new customer fields and expose CRUD routes for clients, addresses and pets

## Testing
- npm test *(fails: requires CERT_PFX_PATH and other NFC-e environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68e40c063ac883239851e98ca088595f