### PR TITLE
Add financial configuration tab to PDV settings

### DIFF
--- a/pages/admin/admin-empresa-configuracoes-pdv.html
+++ b/pages/admin/admin-empresa-configuracoes-pdv.html
@@ -58,6 +58,7 @@
                             <button type="button" class="tab-trigger px-3 py-2 text-sm font-semibold border-b-2 border-transparent text-gray-500 hover:text-primary" data-tab-target="venda">Venda</button>
                             <button type="button" class="tab-trigger px-3 py-2 text-sm font-semibold border-b-2 border-transparent text-gray-500 hover:text-primary" data-tab-target="administrativo">Administrativo</button>
                             <button type="button" class="tab-trigger px-3 py-2 text-sm font-semibold border-b-2 border-transparent text-gray-500 hover:text-primary" data-tab-target="fiscal">Fiscal</button>
+                            <button type="button" class="tab-trigger px-3 py-2 text-sm font-semibold border-b-2 border-transparent text-gray-500 hover:text-primary" data-tab-target="financeiro">Financeiro</button>
                             <button type="button" class="tab-trigger px-3 py-2 text-sm font-semibold border-b-2 border-transparent text-gray-500 hover:text-primary" data-tab-target="estoque">Estoque</button>
                         </nav>
 
@@ -174,6 +175,32 @@
                                         </div>
                                     </div>
                                     <p class="text-xs text-gray-500">A emissão padrão define qual layout o PDV utilizará ao iniciar uma venda fiscal.</p>
+                                </div>
+                            </div>
+
+                            <div data-tab-panel="financeiro" class="hidden">
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <div>
+                                        <label for="conta-corrente" class="block text-sm font-semibold text-gray-700 mb-1">Conta corrente</label>
+                                        <select id="conta-corrente" class="config-input w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" data-config-field>
+                                            <option value="">Selecione uma conta corrente</option>
+                                        </select>
+                                        <p class="mt-2 text-xs text-gray-500">Mostra apenas contas correntes vinculadas à empresa selecionada.</p>
+                                    </div>
+                                    <div>
+                                        <label for="conta-contabil-receber" class="block text-sm font-semibold text-gray-700 mb-1">Conta contábil (Receber)</label>
+                                        <select id="conta-contabil-receber" class="config-input w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" data-config-field>
+                                            <option value="">Selecione uma conta contábil de receber</option>
+                                        </select>
+                                        <p class="mt-2 text-xs text-gray-500">Listagem filtrada pelas contas contábeis de contas a receber da empresa.</p>
+                                    </div>
+                                    <div>
+                                        <label for="conta-contabil-pagar" class="block text-sm font-semibold text-gray-700 mb-1">Conta contábil (A pagar)</label>
+                                        <select id="conta-contabil-pagar" class="config-input w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-primary focus:ring-2 focus:ring-primary/20" data-config-field>
+                                            <option value="">Selecione uma conta contábil de pagar</option>
+                                        </select>
+                                        <p class="mt-2 text-xs text-gray-500">Mostra contas contábeis classificadas como contas a pagar da empresa.</p>
+                                    </div>
                                 </div>
                             </div>
 

--- a/servidor/models/Pdv.js
+++ b/servidor/models/Pdv.js
@@ -53,6 +53,15 @@ const estoqueSchema = new mongoose.Schema(
   { _id: false }
 );
 
+const financeiroSchema = new mongoose.Schema(
+  {
+    contaCorrente: { type: mongoose.Schema.Types.ObjectId, ref: 'BankAccount', default: null },
+    contaContabilReceber: { type: mongoose.Schema.Types.ObjectId, ref: 'AccountingAccount', default: null },
+    contaContabilPagar: { type: mongoose.Schema.Types.ObjectId, ref: 'AccountingAccount', default: null },
+  },
+  { _id: false }
+);
+
 const pdvSchema = new mongoose.Schema(
   {
     codigo: { type: String, required: true, trim: true, unique: true },
@@ -128,6 +137,7 @@ const pdvSchema = new mongoose.Schema(
     configuracoesVenda: { type: vendaSchema, default: () => ({}) },
     configuracoesFiscal: { type: fiscalSchema, default: () => ({}) },
     configuracoesEstoque: { type: estoqueSchema, default: () => ({}) },
+    configuracoesFinanceiro: { type: financeiroSchema, default: () => ({}) },
   },
   {
     timestamps: true,


### PR DESCRIPTION
## Summary
- add a Financeiro tab to the PDV configuration screen with account dropdowns
- load company bank and accounting accounts in the admin UI and include them when saving configurations
- persist the new finance configuration on PDV records with validation for company ownership and payment nature

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e524426d848323bbbfc20a12606e1d